### PR TITLE
Improve error when no uri

### DIFF
--- a/modules/c++/samples/check_valid_six.cpp
+++ b/modules/c++/samples/check_valid_six.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv)
             }
             catch (const six::DESValidationException& ex)
             {
-            	log->error(ex);
+                log->error(ex);
                 log->error(Ctxt("Unsuccessful: Please contact your product "
                                "vendor with these details!"));
                 retCode = 1;

--- a/modules/c++/samples/check_valid_six.cpp
+++ b/modules/c++/samples/check_valid_six.cpp
@@ -208,6 +208,7 @@ int main(int argc, char** argv)
             }
             catch (const six::DESValidationException& ex)
             {
+            	log->error(ex);
                 log->error(Ctxt("Unsuccessful: Please contact your product "
                                "vendor with these details!"));
                 retCode = 1;

--- a/modules/c++/six/source/XMLControl.cpp
+++ b/modules/c++/six/source/XMLControl.cpp
@@ -57,6 +57,14 @@ void validate(const xml::lite::Document* doc,
         xml::lite::Validator validator(paths, log, true);
 
         std::vector<xml::lite::ValidationInfo> errors;
+
+        if (doc->getRootElement()->getUri().empty())
+        {
+        	throw six::DESValidationException(Ctxt(
+				"INVALID XML: URI is empty so document version cannot be "
+				"determined to use for validation"));
+        }
+
         validator.validate(doc->getRootElement(), 
                            doc->getRootElement()->getUri(), 
                            errors);

--- a/modules/c++/six/source/XMLControl.cpp
+++ b/modules/c++/six/source/XMLControl.cpp
@@ -60,9 +60,9 @@ void validate(const xml::lite::Document* doc,
 
         if (doc->getRootElement()->getUri().empty())
         {
-        	throw six::DESValidationException(Ctxt(
-				"INVALID XML: URI is empty so document version cannot be "
-				"determined to use for validation"));
+            throw six::DESValidationException(Ctxt(
+                "INVALID XML: URI is empty so document version cannot be "
+                "determined to use for validation"));
         }
 
         validator.validate(doc->getRootElement(), 


### PR DESCRIPTION
Previously when you didn't specify the URI (such as xmlns="urn:SICD:1.1.0"), you got a validation error but it wasn't clear that it was because the URI was missing (the validator just said it didn't know what any of these elements were).