### PR TITLE
Fix Windows Python test

### DIFF
--- a/modules/python/six.sicd/tests/test_create_sicd_xml.py
+++ b/modules/python/six.sicd/tests/test_create_sicd_xml.py
@@ -685,6 +685,7 @@ fos = FileOutputStream(origPathname)
 out_doc = xml_ctrl.toXML(cmplx, vs)
 root = out_doc.getRootElement()
 root.prettyPrint(fos)
+fos.close()
 
 # If we made it to here, all the Python bindings must be present and what we
 # wrote out must have passed schema validation


### PR DESCRIPTION
If we don't close the FileOutputStream prior to re-opening it with a FileInputStream, we get a permissions error on Windows