### PR TITLE
Add SIDD legend support

### DIFF
--- a/modules/c++/samples/test_create_sidd_from_mem.cpp
+++ b/modules/c++/samples/test_create_sidd_from_mem.cpp
@@ -1739,11 +1739,11 @@ std::auto_ptr<six::WriteControl> getWriteControl(std::string outputName)
 
 /*!
  *  Read a SICD XML into a data structure.  If this was in a NITF
- *  you wouldnt bother with this step, since the ReadControl would
+ *  you wouldn't bother with this step, since the ReadControl would
  *  do this for you.
  *
  */
-six::sicd::ComplexData* getComplexData(std::string sicdXMLName)
+six::sicd::ComplexData* getComplexData(const std::string& sicdXMLName)
 {
     // Create a file input stream
     io::FileInputStream sicdXMLFile(sicdXMLName);
@@ -1758,12 +1758,11 @@ six::sicd::ComplexData* getComplexData(std::string sicdXMLName)
     xml::lite::Document *doc = xmlParser.getDocument();
 
     std::auto_ptr<logging::Logger> log (new logging::NullLogger());
-    six::XMLControl* xmlControl =
+    std::auto_ptr<six::XMLControl> xmlControl(
             six::XMLControlFactory::getInstance().newXMLControl(
-                    DataType::COMPLEX, log.get());
+                    DataType::COMPLEX, log.get()));
 
     six::Data* data = xmlControl->fromXML(doc, std::vector<std::string>());
-    delete xmlControl;
     return (six::sicd::ComplexData*) data;
 }
 

--- a/modules/c++/samples/test_create_sidd_legend.cpp
+++ b/modules/c++/samples/test_create_sidd_legend.cpp
@@ -145,30 +145,21 @@ int main(int argc, char** argv)
         container.addData(data1);
         buffers.push_back(buffer1.get());
 
-        // Now a single segment with a legend
+        // Now a single segment with a mono legend
         types::RowCol<size_t> dims2(40, numCols);
         std::auto_ptr<six::Data> data2(mockupDerivedData(dims2));
 
         const types::RowCol<size_t> legendDims(50, 50);
-        std::auto_ptr<six::Legend> legend1(new six::Legend());
-        legend1->mType = six::PixelType::RGB8LU;
-        legend1->mLocation.row = 10;
-        legend1->mLocation.col = 10;
-        legend1->setDims(legendDims);
-        legend1->mLUT.reset(new six::LUT(256, 3));
-        for (size_t ii = 0, idx = 0;
-             ii < legend1->mLUT->numEntries;
-             ++ii, idx += 3)
-        {
-            legend1->mLUT->table[idx] = ii;
-            legend1->mLUT->table[idx + 1] = ii;
-            legend1->mLUT->table[idx + 2] = ii;
-        }
+        std::auto_ptr<six::Legend> monoLegend(new six::Legend());
+        monoLegend->mType = six::PixelType::MONO8I;
+        monoLegend->mLocation.row = 10;
+        monoLegend->mLocation.col = 10;
+        monoLegend->setDims(legendDims);
 
         const mem::ScopedArray<sys::ubyte> buffer2(new sys::ubyte[dims2.normL1()]);
         std::fill_n(buffer2.get(), dims2.normL1(), 100);
 
-        container.addData(data2, legend1);
+        container.addData(data2, monoLegend);
         buffers.push_back(buffer2.get());
 
         // Now a multi-segment without a legend
@@ -181,29 +172,29 @@ int main(int argc, char** argv)
         container.addData(data3);
         buffers.push_back(buffer3.get());
 
-        // Now a multi-segment with a legend
+        // Now a multi-segment with an RGB legend
         types::RowCol<size_t> dims4(155, numCols);
         std::auto_ptr<six::Data> data4(mockupDerivedData(dims4));
 
-        std::auto_ptr<six::Legend> legend2(new six::Legend());
-        legend2->mType = six::PixelType::RGB8LU;
-        legend2->mLocation.row = 10;
-        legend2->mLocation.col = 10;
-        legend2->setDims(legendDims);
-        legend2->mLUT.reset(new six::LUT(256, 3));
+        std::auto_ptr<six::Legend> rgbLegend(new six::Legend());
+        rgbLegend->mType = six::PixelType::RGB8LU;
+        rgbLegend->mLocation.row = 10;
+        rgbLegend->mLocation.col = 10;
+        rgbLegend->setDims(legendDims);
+        rgbLegend->mLUT.reset(new six::LUT(256, 3));
         for (size_t ii = 0, idx = 0;
-             ii < legend2->mLUT->numEntries;
+             ii < rgbLegend->mLUT->numEntries;
              ++ii, idx += 3)
         {
-            legend2->mLUT->table[idx] = ii;
-            legend2->mLUT->table[idx + 1] = ii;
-            legend2->mLUT->table[idx + 2] = ii;
+            rgbLegend->mLUT->table[idx] = ii;
+            rgbLegend->mLUT->table[idx + 1] = ii;
+            rgbLegend->mLUT->table[idx + 2] = ii;
         }
 
         const mem::ScopedArray<sys::ubyte> buffer4(new sys::ubyte[dims4.normL1()]);
         std::fill_n(buffer4.get(), dims4.normL1(), 200);
 
-        container.addData(data4, legend2);
+        container.addData(data4, rgbLegend);
         buffers.push_back(buffer4.get());
 
         // Write it out

--- a/modules/c++/samples/test_create_sidd_legend.cpp
+++ b/modules/c++/samples/test_create_sidd_legend.cpp
@@ -1,0 +1,196 @@
+/* =========================================================================
+ * This file is part of six-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * six-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ *  This test serves as an example to show how one can construct and write
+ *  a SIDD NITF from scratch, using only a memory buffer.
+ *
+ *  The caller may optionally pass in a SICD XML file (XML only please),
+ *  in which case that data will be read into ComplexData, and placed
+ *  at the end of the Container.
+ *
+ *  NITF and GeoTIFF support are builtin.  If the suffix is .nitf or .ntf,
+ *  the test will write a NITF.  Otherwise, if tiff support is enabled, it
+ *  will attempt to write a GeoTIFF.  If tiff support is disabled in the
+ *  library an exception will be thrown.  NITF is always written
+ *  in big-endian.  Tiff output will always be in native endian.
+ *
+ *  The usage is extremely simple:
+ *
+ *  $ test_create_sidd_from_mem <output>.<nitf|tiff> (sicd-xml)
+ *
+ *
+ *
+ */
+
+#include <stdexcept>
+#include <iostream>
+#include <memory>
+
+#include <except/Exception.h>
+#include <mem/ScopedArray.h>
+#include <sys/Path.h>
+#include <six/sidd/DerivedXMLControl.h>
+#include <six/sidd/DerivedData.h>
+#include <six/sidd/DerivedDataBuilder.h>
+#include "utils.h"
+
+namespace
+{
+std::auto_ptr<six::Data>
+mockupDerivedData(const types::RowCol<size_t>& dims)
+{
+    six::PixelType pixelType = six::PixelType::MONO8I;
+
+    six::sidd::DerivedDataBuilder siddBuilder;
+    siddBuilder.addDisplay(pixelType);
+    siddBuilder.addGeographicAndTarget(six::RegionType::GEOGRAPHIC_INFO);
+    siddBuilder.addMeasurement(six::ProjectionType::PLANE).
+            addExploitationFeatures(1);
+
+    std::auto_ptr<six::sidd::DerivedData> siddData(siddBuilder.steal());
+
+    siddData->setNumRows(dims.row);
+    siddData->setNumCols(dims.col);
+    siddData->setImageCorners(makeUpCornersFromDMS());
+
+    siddData->productCreation->productName = "ProductName";
+    siddData->productCreation->productClass = "Classy";
+    siddData->productCreation->classification.classification = "U";
+
+    siddData->productCreation->processorInformation->application = "ProcessorName";
+    siddData->productCreation->processorInformation->profile = "Profile";
+    siddData->productCreation->processorInformation->site = "Ypsilanti, MI";
+
+    siddData->display->decimationMethod = six::DecimationMethod::BRIGHTEST_PIXEL;
+    siddData->display->magnificationMethod =
+            six::MagnificationMethod::NEAREST_NEIGHBOR;
+
+    // We know this is PGD so this is safe
+    six::sidd::PlaneProjection* const planeProjection =
+        reinterpret_cast<six::sidd::PlaneProjection*>(
+                siddData->measurement->projection.get());
+
+    planeProjection->timeCOAPoly = six::Poly2D(0, 0);
+    planeProjection->timeCOAPoly[0][0] = 1;
+    siddData->measurement->arpPoly = six::PolyXYZ(0);
+    siddData->measurement->arpPoly[0] = six::Vector3(0.0);
+    planeProjection->productPlane.rowUnitVector = six::Vector3(0.0);
+    planeProjection->productPlane.colUnitVector = six::Vector3(0.0);
+
+    six::sidd::Collection* const parent =
+            siddData->exploitationFeatures->collections[0].get();
+    parent->information->resolution.rg = 0;
+    parent->information->resolution.az = 0;
+    parent->information->collectionDuration = 0;
+
+    parent->information->collectionDateTime = six::DateTime();
+    parent->information->radarMode = six::RadarModeType::SPOTLIGHT;
+    parent->information->sensorName.clear();
+    siddData->exploitationFeatures->product.resolution.row = 0;
+    siddData->exploitationFeatures->product.resolution.col = 0;
+
+    return siddData;
+}
+}
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        // Parse the command line
+        if (argc != 2)
+        {
+            std::cerr << "Usage: " << sys::Path::basename(argv[0])
+                      << " <output NITF pathname>\n\n";
+            return 1;
+        }
+        const std::string outPathname(argv[1]);
+        verifySchemaEnvVariableIsSet();
+
+        // In order to make it easier to test segmenting, let's artifically set
+        // the segment size really small
+        const types::RowCol<size_t> dims(100, 200);
+        const size_t numPixels(dims.row * dims.col);
+        const size_t maxSize = dims.col * 50;
+
+        six::XMLControlRegistry xmlRegistry;
+        xmlRegistry.addCreator(
+                six::DataType::DERIVED,
+                new six::XMLControlCreatorT<
+                        six::sidd::DerivedXMLControl>());
+
+
+
+        six::Container container(six::DataType::DERIVED);
+        std::auto_ptr<six::Data> data(mockupDerivedData(dims));
+
+        const types::RowCol<size_t> legendDims(50, 50);
+        std::auto_ptr<six::Legend> legend(new six::Legend());
+        legend->mType = six::PixelType::RGB8LU;
+        legend->mLocation.row = 10;
+        legend->mLocation.col = 10;
+        legend->setDims(legendDims);
+        legend->mLUT.reset(new six::LUT(256, 3));
+        for (size_t ii = 0, idx = 0;
+             ii < legend->mLUT->numEntries;
+             ++ii, idx += 3)
+        {
+            legend->mLUT->table[idx] = ii;
+            legend->mLUT->table[idx + 1] = ii;
+            legend->mLUT->table[idx + 2] = ii;
+        }
+
+        container.addData(data, legend);
+
+        six::NITFWriteControl writer;
+
+        writer.getOptions().setParameter(
+                six::NITFWriteControl::OPT_MAX_PRODUCT_SIZE,
+                str::toString(maxSize));
+
+        writer.setXMLControlRegistry(&xmlRegistry);
+        writer.initialize(&container);
+
+        const mem::ScopedArray<sys::ubyte> buffer(new sys::ubyte[numPixels]);
+        std::fill_n(buffer.get(), numPixels, 0);
+
+        writer.save(buffer.get(), outPathname);
+
+        return 0;
+    }
+    catch (const except::Exception& e)
+    {
+        std::cerr << "Caught exception: " << e.getMessage() << std::endl;
+        return 1;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Caught exception: " << e.what() << std::endl;
+        return 1;
+    }
+    catch (...)
+    {
+        std::cerr << "Unknown exception\n";
+        return 1;
+    }
+}

--- a/modules/c++/samples/test_create_sidd_legend.cpp
+++ b/modules/c++/samples/test_create_sidd_legend.cpp
@@ -22,23 +22,14 @@
 
 /**
  *  This test serves as an example to show how one can construct and write
- *  a SIDD NITF from scratch, using only a memory buffer.
+ *  a SIDD NITF with legends from scratch, using only a memory buffer.
  *
- *  The caller may optionally pass in a SICD XML file (XML only please),
- *  in which case that data will be read into ComplexData, and placed
- *  at the end of the Container.
- *
- *  NITF and GeoTIFF support are builtin.  If the suffix is .nitf or .ntf,
- *  the test will write a NITF.  Otherwise, if tiff support is enabled, it
- *  will attempt to write a GeoTIFF.  If tiff support is disabled in the
- *  library an exception will be thrown.  NITF is always written
- *  in big-endian.  Tiff output will always be in native endian.
+ *  It creates NITFs with and without blocking and adds derived products of
+ *  varying numbers of image segments with and without legends.
  *
  *  The usage is extremely simple:
  *
- *  $ test_create_sidd_from_mem <output>.<nitf|tiff> (sicd-xml)
- *
- *
+ *  $ test_create_sidd_legend <output NITF prefix>
  *
  */
 

--- a/modules/c++/samples/utils.h
+++ b/modules/c++/samples/utils.h
@@ -45,6 +45,36 @@ six::LatLonCorners makeUpCornersFromDMS()
     return corners;
 }
 
+inline
+void verifySchemaEnvVariableIsSet(const std::string& commandLineArg = "")
+{
+    sys::OS os;
+    std::string schemaPath;
+    try
+    {
+        schemaPath = os.getEnv(six::SCHEMA_PATH);
+    }
+    catch(const except::Exception& )
+    {
+        std::string errorMsg =
+                "Must specify SICD/SIDD schema path via ";
+        if (!commandLineArg.empty())
+        {
+            errorMsg += commandLineArg + " or ";
+        }
+
+        errorMsg += std::string(six::SCHEMA_PATH) + " environment variable";
+
+        throw except::Exception(Ctxt(errorMsg));
+    }
+
+    if (schemaPath.empty())
+    {
+        throw except::Exception(Ctxt(std::string(six::SCHEMA_PATH) +
+                " environment variable is set but is empty"));
+    }
+}
+
 // Throws if both schemaArg isn't present and six::SCHEMA_PATH isn't set
 inline
 void getSchemaPaths(const cli::Results& options,
@@ -58,25 +88,7 @@ void getSchemaPaths(const cli::Results& options,
     }
     else
     {
-        sys::OS os;
-        std::string schemaPath;
-        try
-        {
-            schemaPath = os.getEnv(six::SCHEMA_PATH);
-        }
-        catch(const except::Exception& )
-        {
-            throw except::Exception(Ctxt(
-                    "Must specify SICD/SIDD schema path via " +
-                    commandLineArg + " or " + six::SCHEMA_PATH +
-                    " environment variable"));
-        }
-
-        if (schemaPath.empty())
-        {
-            throw except::Exception(Ctxt(std::string(six::SCHEMA_PATH) +
-                    " environment variable is set but is empty"));
-        }
+        verifySchemaEnvVariableIsSet(commandLineArg);
     }
 }
 

--- a/modules/c++/samples/wscript
+++ b/modules/c++/samples/wscript
@@ -11,6 +11,7 @@ def build(bld):
                'round_trip_six'            : 'cli six.sicd six.sidd',
                'test_create_sicd'          : 'cli six.sicd sio.lite',
                'test_create_sidd_from_mem' : 'cli six.sicd six.sidd',
+               'test_create_sidd_legend'   : 'cli six.sidd',
                'test_create_sidd'          : 'cli six.sicd six.sidd sio.lite',
                'test_dump_images'          : 'cli six.sicd six.sidd sio.lite',
                'test_extract_xml'          : 'cli nitf xml.lite',

--- a/modules/c++/six/include/six/Container.h
+++ b/modules/c++/six/include/six/Container.h
@@ -23,11 +23,12 @@
 #define __SIX_CONTAINER_H__
 
 #include <memory>
-#include "six/Data.h"
-#include "six/Utilities.h"
+#include <vector>
+#include <utility>
 
 #include <mem/ScopedCloneablePtr.h>
-
+#include <six/Legend.h>
+#include <six/Data.h>
 
 namespace six
 {
@@ -83,6 +84,12 @@ public:
     void addData(std::auto_ptr<Data> data);
 
     /*!
+     * Same as above but also supports passing in a legend.  Only valid for
+     * derived data.
+     */
+    void addData(std::auto_ptr<Data> data, std::auto_ptr<Legend> legend);
+
+    /*!
      *  Set the data item at location i.  If there is an item in the
      *  slot already, we delete it.
      *
@@ -97,7 +104,7 @@ public:
      */
     Data* getData(size_t i)
     {
-        return mData[i].get();
+        return mData[i].first.get();
     }
 
     /*!
@@ -106,7 +113,7 @@ public:
      */
     const Data* getData(size_t i) const
     {
-        return mData[i].get();
+        return mData[i].first.get();
     }
 
     /*!
@@ -123,10 +130,23 @@ public:
     void removeData(const Data* data);
 
 protected:
-    typedef std::vector<mem::ScopedCloneablePtr<Data> > DataVec;
+    typedef std::pair<mem::ScopedCloneablePtr<Data>,
+    		          mem::ScopedCopyablePtr<Legend> > DataPair;
 
-    DataVec mData;
+    typedef std::vector<DataPair> DataVec;
+
     DataType mDataType;
+    DataVec mData;
+
+private:
+    static
+    mem::ScopedCopyablePtr<Legend> nullLegend()
+    {
+    	return mem::ScopedCopyablePtr<Legend>(NULL);
+    }
+
+    void addData(std::auto_ptr<Data> data,
+    	         mem::ScopedCopyablePtr<Legend> legend);
 };
 }
 

--- a/modules/c++/six/include/six/Container.h
+++ b/modules/c++/six/include/six/Container.h
@@ -117,6 +117,15 @@ public:
     }
 
     /*!
+     *  Get the legend, if present, living in the ith slot.
+     *  \return The legend
+     */
+    const Legend* getLegend(size_t i) const
+    {
+    	return mData[i].second.get();
+    }
+
+    /*!
      *  Get the item from the ImageSubheader field IID1.
      *  \return The data
      */

--- a/modules/c++/six/include/six/Legend.h
+++ b/modules/c++/six/include/six/Legend.h
@@ -1,0 +1,59 @@
+/* =========================================================================
+ * This file is part of six-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * six-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __SIX_LEGEND_H__
+#define __SIX_LEGEND_H__
+
+#include <vector>
+
+#include <sys/Conf.h>
+#include <types/RowCol.h>
+
+namespace six
+{
+/*
+ * This is a legend associated with a SIDD product
+ * See section 2.4.3 of SIDD Volume 2
+ *
+ * Caller puts it in the Container but then I think we'll need to add this into
+ * NITFImageInfo to give NITFWriteControl the chance to write it out
+ */
+struct Legend
+{
+public:
+	// TODO: Or this could be PixelType and we throw if you give us an invalid
+	//       one
+	enum Type
+	{
+        RGB8LU = 0,
+        RGB24I
+	};
+
+	Type mType;
+	types::RowCol<size_t> mLocation;
+
+	types::RowCol<size_t> mDims;
+	std::vector<sys::ubyte> mImage;
+};
+}
+
+#endif

--- a/modules/c++/six/include/six/Legend.h
+++ b/modules/c++/six/include/six/Legend.h
@@ -27,6 +27,8 @@
 
 #include <sys/Conf.h>
 #include <types/RowCol.h>
+#include <mem/ScopedCloneablePtr.h>
+#include <six/Types.h>
 
 namespace six
 {
@@ -39,19 +41,21 @@ namespace six
 struct Legend
 {
 public:
-	// TODO: Or this could be PixelType and we throw if you give us an invalid
-	//       one
-	enum Type
-	{
-        RGB8LU = 0,
-        RGB24I
-	};
+    Legend() :
+        mType(PixelType::NOT_SET),
+        mLocation(0, 0),
+        mDims(0, 0)
+    {
+    }
 
-	Type mType;
+    // TODO: For now, only RGB8LU is supported
+	PixelType mType;
+
 	types::RowCol<size_t> mLocation;
 
 	types::RowCol<size_t> mDims;
 	std::vector<sys::ubyte> mImage;
+	mem::ScopedCloneablePtr<LUT> mLUT;
 };
 }
 

--- a/modules/c++/six/include/six/Legend.h
+++ b/modules/c++/six/include/six/Legend.h
@@ -34,8 +34,7 @@ namespace six
  * This is a legend associated with a SIDD product
  * See section 2.4.3 of SIDD Volume 2
  *
- * Caller puts it in the Container but then I think we'll need to add this into
- * NITFImageInfo to give NITFWriteControl the chance to write it out
+ * TODO: Have started adding this in NITFWriteControl.cpp - see legend section
  */
 struct Legend
 {

--- a/modules/c++/six/include/six/Legend.h
+++ b/modules/c++/six/include/six/Legend.h
@@ -48,6 +48,13 @@ public:
     {
     }
 
+    // Resizes 'mImage' to match
+    void setDims(const types::RowCol<size_t>& dims)
+    {
+        mDims = dims;
+        mImage.resize(dims.row * dims.col);
+    }
+
     // TODO: For now, only RGB8LU is supported
 	PixelType mType;
 

--- a/modules/c++/six/include/six/Legend.h
+++ b/modules/c++/six/include/six/Legend.h
@@ -32,15 +32,17 @@
 
 namespace six
 {
-/*
- * This is a legend associated with a SIDD product
+/*!
+ * \struct Legend
+ * \brief A legend associated with a SIDD product
+ *
  * See section 2.4.3 of SIDD Volume 2
  *
- * TODO: Have started adding this in NITFWriteControl.cpp - see legend section
  */
 struct Legend
 {
 public:
+    //! Construct, initializing to invalid values
     Legend() :
         mType(PixelType::NOT_SET),
         mLocation(0, 0),
@@ -48,20 +50,30 @@ public:
     {
     }
 
-    // Resizes 'mImage' to match
+    //! Convenience method to resize the image to match the dimensions
     void setDims(const types::RowCol<size_t>& dims)
     {
         mDims = dims;
         mImage.resize(dims.row * dims.col);
     }
 
-    // TODO: For now, only RGB8LU is supported
+    //! Pixel type of legend image data.
+    //  TODO: For now, only MONO8I and RGB8LU are supported
 	PixelType mType;
 
+	//! Location of the legend with respect to the upper-left corner of the
+	//  image segment it's attached to
 	types::RowCol<size_t> mLocation;
 
+	//! Dimensions of the legend image pixels
 	types::RowCol<size_t> mDims;
+
+	//! Image legend pixels.  These are either pixel values or LUT indices
+	//  depending on of the pixel type is MONO8I or RGB8LU, respectively.
 	std::vector<sys::ubyte> mImage;
+
+	//! LUT associated with image pixels.  Must be present if pixel type is
+	//  RGB8LU.
 	mem::ScopedCloneablePtr<LUT> mLUT;
 };
 }

--- a/modules/c++/six/include/six/NITFImageInfo.h
+++ b/modules/c++/six/include/six/NITFImageInfo.h
@@ -175,8 +175,8 @@ public:
     template <typename GetDisplayLutT>
     static
     std::vector<nitf::BandInfo>
-    NITFImageInfo::getBandInfoImpl(PixelType pixelType,
-                                   const GetDisplayLutT& getDisplayLUT);
+    getBandInfoImpl(PixelType pixelType,
+                    const GetDisplayLutT& getDisplayLUT);
 
     //!  File security classification system
     static const char CLSY[];

--- a/modules/c++/six/include/six/NITFImageInfo.h
+++ b/modules/c++/six/include/six/NITFImageInfo.h
@@ -63,66 +63,66 @@ public:
         return data->getNumBytesPerPixel() / data->getNumChannels() * 8;
     }
 
-    std::string getPixelValueType() const
+    static
+    std::string getPixelValueType(PixelType pixelType)
     {
-        std::string type;
-        switch (data->getPixelType())
+        switch (pixelType)
         {
         case PixelType::RE32F_IM32F:
-            type = "R";
-            break;
-
+            return "R";
         case PixelType::RE16I_IM16I:
-            type = "SI";
-            break;
-
+            return "SI";
         default:
-            type = "INT";
-
+            return "INT";
         }
-        return type;
+    }
+
+    std::string getPixelValueType() const
+    {
+        return getPixelValueType(data->getPixelType());
+    }
+
+    static
+    std::string getRepresentation(PixelType pixelType)
+    {
+        switch (pixelType)
+        {
+        case PixelType::MONO8LU:
+        case PixelType::MONO8I:
+        case PixelType::MONO16I:
+            return "MONO";
+        case PixelType::RGB8LU:
+            return "RGB/LUT";
+        case PixelType::RGB24I:
+            return "RGB";
+        default:
+            return "NODISPLY";
+        }
     }
 
     std::string getRepresentation() const
     {
+        return getRepresentation(data->getPixelType());
+    }
 
-        std::string irep;
-        switch (data->getPixelType())
+    static
+    std::string getMode(PixelType pixelType)
+    {
+        switch (pixelType)
         {
+        case PixelType::RGB8LU:
         case PixelType::MONO8LU:
         case PixelType::MONO8I:
         case PixelType::MONO16I:
-            irep = "MONO";
-            break;
-        case PixelType::RGB8LU:
-            irep = "RGB/LUT";
-            break;
-        case PixelType::RGB24I:
-            irep = "RGB";
-            break;
-
+            return "B";
         default:
-            irep = "NODISPLY";
+            return "P";
         }
-        return irep;
-
     }
 
     std::string getMode() const
     {
-        std::string imode;
-        switch (data->getPixelType())
-        {
-        case PixelType::RGB8LU:
-        case PixelType::MONO8LU:
-        case PixelType::MONO8I:
-        case PixelType::MONO16I:
-            imode = "B";
-            break;
-        default:
-            imode = "P";
-        }
-        return imode;
+        return getMode(data->getPixelType());
     }
 
     Data* getData() const
@@ -167,8 +167,16 @@ public:
         return maxProductSize;
     }
 
-    // Currently punts on LU
     std::vector<nitf::BandInfo> getBandInfo() const;
+
+    // We have to do this a little strangely with a functor rather than just
+    // always sending in the display LUT because that method will throw for
+    // ComplexData
+    template <typename GetDisplayLutT>
+    static
+    std::vector<nitf::BandInfo>
+    NITFImageInfo::getBandInfoImpl(PixelType pixelType,
+                                   const GetDisplayLutT& getDisplayLUT);
 
     //!  File security classification system
     static const char CLSY[];
@@ -205,28 +213,7 @@ public:
     static std::string generateFieldKey(const std::string& field,
             const std::string& prefix = "", int index = -1);
 
-protected:
-    Data* data;
-
-    size_t startIndex;
-
-    //! Number of bytes in the product
-    sys::Uint64_T productSize;
-
-    //! This is the total number of rows we can have in a NITF segment
-    size_t numRowsLimit;
-
-    //! This is the total size that each product seg can be
-    sys::Uint64_T maxProductSize;
-
-    /*!
-     *  This is a vector of segment information that is used to get
-     *  the per-segment info for populating/reading from a NITF
-     *
-     *  Note that the number of segments has a hard limit of 999
-     */
-    std::vector<NITFSegmentInfo> imageSegments;
-
+private:
     void computeImageInfo();
 
     /*!
@@ -287,8 +274,174 @@ protected:
     /*          numRowsLimit = maxRows; */
     /*      } */
 
+private:
+    Data* data;
+
+    size_t startIndex;
+
+    //! Number of bytes in the product
+    sys::Uint64_T productSize;
+
+    //! This is the total number of rows we can have in a NITF segment
+    size_t numRowsLimit;
+
+    //! This is the total size that each product seg can be
+    sys::Uint64_T maxProductSize;
+
+    /*!
+     *  This is a vector of segment information that is used to get
+     *  the per-segment info for populating/reading from a NITF
+     *
+     *  Note that the number of segments has a hard limit of 999
+     */
+    std::vector<NITFSegmentInfo> imageSegments;
 };
 
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// WHAT FOLLOWS IS IMPLEMENTATION DETAIL
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+
+template <typename GetDisplayLutT>
+std::vector<nitf::BandInfo>
+NITFImageInfo::getBandInfoImpl(PixelType pixelType,
+                               const GetDisplayLutT& getDisplayLUT)
+{
+    std::vector<nitf::BandInfo> bands;
+
+    switch (pixelType)
+    {
+    case PixelType::RE32F_IM32F:
+    case PixelType::RE16I_IM16I:
+    {
+        nitf::BandInfo band1;
+        band1.getSubcategory().set("I");
+        nitf::BandInfo band2;
+        band2.getSubcategory().set("Q");
+
+        bands.push_back(band1);
+        bands.push_back(band2);
+    }
+        break;
+    case PixelType::RGB24I:
+    {
+        nitf::BandInfo band1;
+        band1.getRepresentation().set("R");
+
+        nitf::BandInfo band2;
+        band2.getRepresentation().set("G");
+
+        nitf::BandInfo band3;
+        band3.getRepresentation().set("B");
+
+        bands.push_back(band1);
+        bands.push_back(band2);
+        bands.push_back(band3);
+    }
+        break;
+
+    case PixelType::MONO8I:
+    case PixelType::MONO16I:
+    {
+        nitf::BandInfo band1;
+        band1.getRepresentation().set("M");
+        bands.push_back(band1);
+    }
+        break;
+
+    case PixelType::MONO8LU:
+    {
+        nitf::BandInfo band1;
+
+        // TODO: Why do we need to byte swap here?  If it is required, could
+        //       we avoid the clone and byte swap and instead index into
+        //       the LUT in the opposite order?
+        std::auto_ptr<LUT> lut(getDisplayLUT()->clone());
+        sys::byteSwap(reinterpret_cast<sys::byte*>(lut->table.get()),
+                      static_cast<unsigned short>(lut->elementSize),
+                      lut->numEntries);
+
+        if (lut->elementSize != sizeof(short))
+        {
+            throw except::Exception(Ctxt(
+                "Unexpected element size: " +
+                str::toString(lut->elementSize)));
+        }
+
+        nitf::LookupTable lookupTable(lut->elementSize, lut->numEntries);
+        unsigned char* const table(lookupTable.getTable());
+
+        for (size_t i = 0; i < lut->numEntries; ++i)
+        {
+            // Need two LUTS in the nitf, with high order
+            // bits in the first and low order in the second
+            const unsigned char* const entry = (*lut)[i];
+            table[i] = entry[0];
+            table[lut->numEntries + i] = entry[1];
+        }
+
+        //         //I would like to set it this way but it does not seem to work.
+        //         //Using the init function instead.
+        //         //band1.getRepresentation().set("LU");
+        //         //band1.getLookupTable().setTable(table, 2, lut->numEntries);
+
+        band1.init("LU", "", "", "",
+                   static_cast<nitf::Uint32>(lut->elementSize),
+                   static_cast<nitf::Uint32>(lut->numEntries),
+                   lookupTable);
+        bands.push_back(band1);
+    }
+        break;
+
+    case PixelType::RGB8LU:
+    {
+        nitf::BandInfo band1;
+
+        const LUT* const lut = getDisplayLUT();
+
+        if (lut->elementSize != 3)
+        {
+            throw except::Exception(Ctxt(
+                "Unexpected element size: " +
+                str::toString(lut->elementSize)));
+        }
+
+        nitf::LookupTable lookupTable(lut->elementSize, lut->numEntries);
+        unsigned char* const table(lookupTable.getTable());
+
+        for (size_t i = 0, k = 0; i < lut->numEntries; ++i)
+        {
+            for (size_t j = 0; j < lut->elementSize; ++j, ++k)
+            {
+                // Need to transpose the lookup table entries
+                table[j * lut->numEntries + i] = lut->table[k];
+            }
+        }
+
+        //I would like to set it this way but it does not seem to work.
+        //Using the init function instead.
+        //band1.getRepresentation().set("LU");
+        //band1.getLookupTable().setTable(table, 3, lut->numEntries);
+
+        band1.init("LU", "", "", "",
+                   static_cast<nitf::Uint32>(lut->elementSize),
+                   static_cast<nitf::Uint32>(lut->numEntries),
+                   lookupTable);
+        bands.push_back(band1);
+    }
+        break;
+
+    default:
+        throw except::Exception(Ctxt("Unknown pixel type"));
+    }
+
+    for (size_t i = 0; i < bands.size(); ++i)
+    {
+        bands[i].getImageFilterCondition().set("N");
+    }
+    return bands;
+}
 }
 
 #endif

--- a/modules/c++/six/include/six/NITFImageInfo.h
+++ b/modules/c++/six/include/six/NITFImageInfo.h
@@ -202,7 +202,7 @@ public:
 
     //! Utility that generates a key for the given field, with optional prefix and index
     static std::string generateFieldKey(const std::string& field,
-            std::string prefix = "", int index = -1);
+            const std::string& prefix = "", int index = -1);
 
 protected:
     Data* data;

--- a/modules/c++/six/include/six/NITFImageInfo.h
+++ b/modules/c++/six/include/six/NITFImageInfo.h
@@ -22,9 +22,9 @@
 #ifndef __SIX_NITF_IMAGE_INFO_H__
 #define __SIX_NITF_IMAGE_INFO_H__
 
-#include "six/Data.h"
-#include "six/Utilities.h"
-#include "six/NITFSegmentInfo.h"
+#include <six/Data.h>
+#include <six/Utilities.h>
+#include <six/NITFSegmentInfo.h>
 
 namespace six
 {
@@ -45,9 +45,10 @@ class NITFImageInfo
 {
 public:
 
-    NITFImageInfo(Data* d, size_t maxRows = Constants::ILOC_MAX,
-            sys::Uint64_T maxSize = Constants::IS_SIZE_MAX,
-            bool computeSegments = false) :
+    NITFImageInfo(Data* d,
+    		      size_t maxRows = Constants::ILOC_MAX,
+                  sys::Uint64_T maxSize = Constants::IS_SIZE_MAX,
+                  bool computeSegments = false) :
         data(d), startIndex(0), numRowsLimit(maxRows), maxProductSize(maxSize)
     {
         productSize = (sys::Uint64_T) data->getNumBytesPerPixel()
@@ -167,7 +168,7 @@ public:
     }
 
     // Currently punts on LU
-    std::vector<nitf::BandInfo> getBandInfo();
+    std::vector<nitf::BandInfo> getBandInfo() const;
 
     //!  File security classification system
     static const char CLSY[];

--- a/modules/c++/six/include/six/NITFReadControl.h
+++ b/modules/c++/six/include/six/NITFReadControl.h
@@ -149,7 +149,7 @@ protected:
     //  to be cleaned up elsewhere. There is no access
     //  to deallocation in NITFReadControl directly
     virtual void createCompressionOptions(
-            std::map<std::string, void*>& options)
+            std::map<std::string, void*>& )
     {
     }
 };

--- a/modules/c++/six/include/six/NITFWriteControl.h
+++ b/modules/c++/six/include/six/NITFWriteControl.h
@@ -23,6 +23,8 @@
 #define __SIX_NITF_WRITE_CONTROL_H__
 
 #include <map>
+
+#include <mem/SharedPtr.h>
 #include "six/Types.h"
 #include "six/Container.h"
 #include "six/WriteControl.h"
@@ -50,8 +52,6 @@ public:
     NITFWriteControl()
     {
     }
-    //!  Destructor
-    ~NITFWriteControl();
 
     //!  We are a 'NITF'
     std::string getFileType() const
@@ -185,7 +185,7 @@ public:
 protected:
     nitf::Writer mWriter;
     nitf::Record mRecord;
-    std::vector<NITFImageInfo*> mInfos;
+    std::vector<mem::SharedPtr<NITFImageInfo> > mInfos;
     std::map<std::string, void*> mCompressionOptions;
 
     void writeNITF(nitf::IOInterface& os);
@@ -345,6 +345,18 @@ private:
 
     void addUserDefinedSubheader(const six::Data& data,
                                  nitf::DESubheader& subheader) const;
+
+    static
+    std::string getComplexIID(size_t segmentNum, size_t numImageSegments);
+
+    static
+    std::string getDerivedIID(size_t segmentNum, size_t productNum);
+
+    static
+	std::string getIID(DataType dataType,
+			           size_t segmentNum,
+			           size_t numImageSegments,
+			           size_t productNum);
 
     std::string mOrganizationId;
     std::string mLocationId;

--- a/modules/c++/six/include/six/Types.h
+++ b/modules/c++/six/include/six/Types.h
@@ -319,7 +319,7 @@ struct LUT
     }
 
     //!  Clone the LUT table
-    virtual LUT* clone()
+    virtual LUT* clone() const
     {
         return new LUT(table.get(), numEntries, elementSize);
     }

--- a/modules/c++/six/source/NITFImageInfo.cpp
+++ b/modules/c++/six/source/NITFImageInfo.cpp
@@ -323,7 +323,7 @@ std::vector<nitf::BandInfo> NITFImageInfo::getBandInfo()
 }
 
 std::string NITFImageInfo::generateFieldKey(const std::string& field,
-        std::string prefix, int index)
+        const std::string& prefix, int index)
 {
     std::ostringstream s;
     s << prefix << field;

--- a/modules/c++/six/source/NITFImageInfo.cpp
+++ b/modules/c++/six/source/NITFImageInfo.cpp
@@ -190,7 +190,7 @@ void NITFImageInfo::compute()
 }
 
 // Currently punts on LU
-std::vector<nitf::BandInfo> NITFImageInfo::getBandInfo()
+std::vector<nitf::BandInfo> NITFImageInfo::getBandInfo() const
 {
     std::vector < nitf::BandInfo > bands;
 

--- a/modules/c++/six/source/NITFImageInfo.cpp
+++ b/modules/c++/six/source/NITFImageInfo.cpp
@@ -29,8 +29,28 @@
 #include <six/NITFImageInfo.h>
 #include <scene/Utilities.h>
 
-using namespace six;
+namespace
+{
+class GetDisplayLutFromData
+{
+public:
+    GetDisplayLutFromData(six::Data& data) :
+        mData(data)
+    {
+    }
 
+    const six::LUT* operator()() const
+    {
+        return mData.getDisplayLUT();
+    }
+
+private:
+    six::Data& mData;
+};
+}
+
+namespace six
+{
 //!  File security classification system
 const char NITFImageInfo::CLSY[] = "CLSY";
 //!  File security codewords
@@ -189,137 +209,11 @@ void NITFImageInfo::compute()
     computeSegmentInfo();
 }
 
-// Currently punts on LU
+
 std::vector<nitf::BandInfo> NITFImageInfo::getBandInfo() const
 {
-    std::vector < nitf::BandInfo > bands;
-
-    switch (data->getPixelType())
-    {
-    case PixelType::RE32F_IM32F:
-    case PixelType::RE16I_IM16I:
-    {
-        nitf::BandInfo band1;
-        band1.getSubcategory().set("I");
-        nitf::BandInfo band2;
-        band2.getSubcategory().set("Q");
-
-        bands.push_back(band1);
-        bands.push_back(band2);
-    }
-        break;
-    case PixelType::RGB24I:
-    {
-        nitf::BandInfo band1;
-        band1.getRepresentation().set("R");
-
-        nitf::BandInfo band2;
-        band2.getRepresentation().set("G");
-
-        nitf::BandInfo band3;
-        band3.getRepresentation().set("B");
-
-        bands.push_back(band1);
-        bands.push_back(band2);
-        bands.push_back(band3);
-    }
-        break;
-
-    case PixelType::MONO8I:
-    case PixelType::MONO16I:
-    {
-        nitf::BandInfo band1;
-        band1.getRepresentation().set("M");
-        bands.push_back(band1);
-    }
-        break;
-
-    case PixelType::MONO8LU:
-    {
-        nitf::BandInfo band1;
-
-        // TODO: Why do we need to byte swap here?  If it is required, could
-        //       we avoid the clone and byte swap and instead index into
-        //       the LUT in the opposite order?
-        std::auto_ptr<LUT> lut(data->getDisplayLUT()->clone());
-        sys::byteSwap((sys::byte*) lut->table.get(), lut->elementSize,
-                      lut->numEntries);
-
-        if (lut->elementSize != sizeof(short))
-        {
-            throw except::Exception(Ctxt(
-                "Unexpected element size: " +
-                str::toString(lut->elementSize)));
-        }
-
-        nitf::LookupTable lookupTable(lut->elementSize, lut->numEntries);
-        unsigned char* const table(lookupTable.getTable());
-
-        for (unsigned int i = 0; i < lut->numEntries; ++i)
-        {
-            // Need two LUTS in the nitf, with high order
-            // bits in the first and low order in the second
-            const unsigned char* const entry = (*lut)[i];
-            table[i] = entry[0];
-            table[lut->numEntries + i] = entry[1];
-        }
-
-        //         //I would like to set it this way but it does not seem to work.
-        //         //Using the init function instead.
-        //         //band1.getRepresentation().set("LU");
-        //         //band1.getLookupTable().setTable(table, 2, lut->numEntries);
-
-        band1.init("LU", "", "", "", lut->elementSize, lut->numEntries,
-                   lookupTable);
-        bands.push_back(band1);
-    }
-        break;
-
-    case PixelType::RGB8LU:
-    {
-        nitf::BandInfo band1;
-
-        LUT* lut = data->getDisplayLUT();
-
-        if (lut->elementSize != 3)
-        {
-            throw except::Exception(Ctxt(
-                "Unexpected element size: " +
-                str::toString(lut->elementSize)));
-        }
-
-        nitf::LookupTable lookupTable(lut->elementSize, lut->numEntries);
-        unsigned char* const table(lookupTable.getTable());
-
-        for (unsigned int i = 0, k = 0; i < lut->numEntries; ++i)
-        {
-            for (unsigned int j = 0; j < lut->elementSize; ++j, ++k) //elementSize=3
-            {
-                // Need to transpose the lookup table entries
-                table[j * lut->numEntries + i] = lut->table[k];
-            }
-        }
-
-        //I would like to set it this way but it does not seem to work.
-        //Using the init function instead.
-        //band1.getRepresentation().set("LU");
-        //band1.getLookupTable().setTable(table, 3, lut->numEntries);
-
-        band1.init("LU", "", "", "", lut->elementSize, lut->numEntries,
-                   lookupTable);
-        bands.push_back(band1);
-    }
-        break;
-
-    default:
-        throw except::Exception(Ctxt("Unknown pixel type"));
-    }
-
-    for (size_t i = 0; i < bands.size(); ++i)
-    {
-        bands[i].getImageFilterCondition().set("N");
-    }
-    return bands;
+    const GetDisplayLutFromData getLUT(*data);
+    return getBandInfoImpl<GetDisplayLutFromData>(data->getPixelType(), getLUT);
 }
 
 std::string NITFImageInfo::generateFieldKey(const std::string& field,
@@ -330,4 +224,5 @@ std::string NITFImageInfo::generateFieldKey(const std::string& field,
     if (index >= 0)
         s << "[" << str::toString(index) << "]";
     return s.str();
+}
 }

--- a/modules/c++/six/source/NITFWriteControl.cpp
+++ b/modules/c++/six/source/NITFWriteControl.cpp
@@ -284,7 +284,7 @@ void NITFWriteControl::initialize(Container* container)
             const DateTime collectionDT =
                     info.getData()->getCollectionStartDateTime();
             subheader.getImageDateAndTime().set(collectionDT);
-            subheader.getImageId().set(getDerivedIID(numIS + 1, ii));
+            subheader.getImageId().set(getDerivedIID(numIS, ii));
 
             subheader.getImageLocation().set(generateILOC(legend->mLocation));
 

--- a/modules/c++/six/source/NITFWriteControl.cpp
+++ b/modules/c++/six/source/NITFWriteControl.cpp
@@ -199,6 +199,7 @@ void NITFWriteControl::initialize(Container* container)
         startIndex += numIS;
 
         // Images
+        const std::string imageSource = info.getData()->getSource();
         for (size_t jj = 0; jj < numIS; ++jj)
         {
             NITFSegmentInfo segmentInfo = imageSegments[jj];
@@ -211,9 +212,7 @@ void NITFWriteControl::initialize(Container* container)
                     info.getData()->getCollectionStartDateTime();
             subheader.getImageDateAndTime().set(collectionDT);
             subheader.getImageId().set(getIID(dataType, jj, numIS, ii));
-
-            std::string isorce = info.getData()->getSource();
-            subheader.getImageSource().set(isorce);
+            subheader.getImageSource().set(imageSource);
 
             // Fill out ILOC with the row offset, making sure it's in range
             if (segmentInfo.rowOffset > maxRows)
@@ -285,6 +284,7 @@ void NITFWriteControl::initialize(Container* container)
                     info.getData()->getCollectionStartDateTime();
             subheader.getImageDateAndTime().set(collectionDT);
             subheader.getImageId().set(getDerivedIID(numIS, ii));
+            subheader.getImageSource().set(imageSource);
 
             subheader.getImageLocation().set(generateILOC(legend->mLocation));
 
@@ -321,6 +321,8 @@ void NITFWriteControl::initialize(Container* container)
             // conveniently at info.getStartIndex()... but IDLVL is 1-based).
             subheader.getImageAttachmentLevel().set(static_cast<nitf::Uint16>(
             		info.getStartIndex() + 1));
+
+            setImageSecurity(info.getData()->getClassification(), subheader);
 
             ++startIndex;
         }

--- a/modules/c++/six/source/NITFWriteControl.cpp
+++ b/modules/c++/six/source/NITFWriteControl.cpp
@@ -135,8 +135,7 @@ void NITFWriteControl::initialize(Container* container)
 
     DataType dataType = mContainer->getDataType();
     std::string name = mInfos[0]->getData()->getName();
-    std::string fileTitle = FmtX("%s: %s", six::toString(dataType).c_str(),
-                                 name.c_str());
+    std::string fileTitle = six::toString(dataType) + ": " + name;
     fileTitle = fileTitle.substr(0, NITF_FTITLE_SZ); //truncate past 80
     mRecord.getHeader().getFileTitle().set(fileTitle);
 
@@ -162,7 +161,7 @@ void NITFWriteControl::initialize(Container* container)
         // NITRO wants to see this, not our corners object
         double corners[4][2];
 
-        std::string targetId = "";
+        std::string targetId;
 
         // TODO: Subclass to get this?
         // if (info->getData()->getDataType() == DataType::DERIVED)


### PR DESCRIPTION
Adding support for saving off legends with a SIDD per section 2.4.3 of SIDD Volume 2.  Currently only mono 8 bit and indexed RGB LUTs are supported as these are the common cases.  SIX auto-populates as much of the image subheader, including IDLVL and IALVL, for you that it can.  It makes some simplifying assumptions which mainly amount to...
a. For a given product, you always want exactly 0 or 1 legends
b. For a product that is split into multiple NITF image segments (presumably due to file format limitations), you always want the legend to attach to the first of these image segments

It does support adding a legend with each product, so you can have a SIDD with as many legends as you have SIDD XML DESs.

Added test_create_sidd_legend to test all this.

@mbojrab @chvink 