### PR TITLE
Regenerated python bindings

### DIFF
--- a/modules/python/scene/source/generated/scene.py
+++ b/modules/python/scene/source/generated/scene.py
@@ -1004,6 +1004,11 @@ class SceneGeometry(_object):
         return _scene.SceneGeometry_getMultiPathAngle(self)
 
 
+    def getGroundTrackAngle(self):
+        """getGroundTrackAngle(SceneGeometry self) -> double"""
+        return _scene.SceneGeometry_getGroundTrackAngle(self)
+
+
     def getOPAngle(self, vec):
         """getOPAngle(SceneGeometry self, Vector3 vec) -> double"""
         return _scene.SceneGeometry_getOPAngle(self, vec)

--- a/modules/python/scene/source/generated/scene_wrap.cxx
+++ b/modules/python/scene/source/generated/scene_wrap.cxx
@@ -13872,6 +13872,58 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SceneGeometry_getGroundTrackAngle(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  scene::SceneGeometry *arg1 = (scene::SceneGeometry *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  double result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:SceneGeometry_getGroundTrackAngle",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_scene__SceneGeometry, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SceneGeometry_getGroundTrackAngle" "', argument " "1"" of type '" "scene::SceneGeometry const *""'"); 
+  }
+  arg1 = reinterpret_cast< scene::SceneGeometry * >(argp1);
+  {
+    try
+    {
+      result = (double)((scene::SceneGeometry const *)arg1)->getGroundTrackAngle();
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_From_double(static_cast< double >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SceneGeometry_getOPAngle(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   scene::SceneGeometry *arg1 = (scene::SceneGeometry *) 0 ;
@@ -25380,6 +25432,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SceneGeometry_getRotationAngle", _wrap_SceneGeometry_getRotationAngle, METH_VARARGS, (char *)"SceneGeometry_getRotationAngle(SceneGeometry self) -> double"},
 	 { (char *)"SceneGeometry_getMultiPathVector", _wrap_SceneGeometry_getMultiPathVector, METH_VARARGS, (char *)"SceneGeometry_getMultiPathVector(SceneGeometry self) -> Vector3"},
 	 { (char *)"SceneGeometry_getMultiPathAngle", _wrap_SceneGeometry_getMultiPathAngle, METH_VARARGS, (char *)"SceneGeometry_getMultiPathAngle(SceneGeometry self) -> double"},
+	 { (char *)"SceneGeometry_getGroundTrackAngle", _wrap_SceneGeometry_getGroundTrackAngle, METH_VARARGS, (char *)"SceneGeometry_getGroundTrackAngle(SceneGeometry self) -> double"},
 	 { (char *)"SceneGeometry_getOPAngle", _wrap_SceneGeometry_getOPAngle, METH_VARARGS, (char *)"SceneGeometry_getOPAngle(SceneGeometry self, Vector3 vec) -> double"},
 	 { (char *)"SceneGeometry_getOPNorthAngle", _wrap_SceneGeometry_getOPNorthAngle, METH_VARARGS, (char *)"SceneGeometry_getOPNorthAngle(SceneGeometry self) -> double"},
 	 { (char *)"SceneGeometry_getOPLayoverAngle", _wrap_SceneGeometry_getOPLayoverAngle, METH_VARARGS, (char *)"SceneGeometry_getOPLayoverAngle(SceneGeometry self) -> double"},

--- a/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/modules/python/six.sicd/source/generated/six_sicd.py
@@ -959,8 +959,6 @@ class AreaDirectionParameters(_object):
         """clone(AreaDirectionParameters self) -> AreaDirectionParameters"""
         return _six_sicd.AreaDirectionParameters_clone(self)
 
-    __swig_destroy__ = _six_sicd.delete_AreaDirectionParameters
-    __del__ = lambda self: None
     __swig_setmethods__["unitVector"] = _six_sicd.AreaDirectionParameters_unitVector_set
     __swig_getmethods__["unitVector"] = _six_sicd.AreaDirectionParameters_unitVector_get
     if _newclass:
@@ -978,6 +976,11 @@ class AreaDirectionParameters(_object):
     if _newclass:
         first = _swig_property(_six_sicd.AreaDirectionParameters_first_get, _six_sicd.AreaDirectionParameters_first_set)
 
+    def getExtentInMeters(self):
+        """getExtentInMeters(AreaDirectionParameters self) -> double"""
+        return _six_sicd.AreaDirectionParameters_getExtentInMeters(self)
+
+
     def __eq__(self, other):
         """__eq__(AreaDirectionParameters self, AreaDirectionParameters other) -> bool"""
         return _six_sicd.AreaDirectionParameters___eq__(self, other)
@@ -987,6 +990,8 @@ class AreaDirectionParameters(_object):
         """__ne__(AreaDirectionParameters self, AreaDirectionParameters other) -> bool"""
         return _six_sicd.AreaDirectionParameters___ne__(self, other)
 
+    __swig_destroy__ = _six_sicd.delete_AreaDirectionParameters
+    __del__ = lambda self: None
 AreaDirectionParameters_swigregister = _six_sicd.AreaDirectionParameters_swigregister
 AreaDirectionParameters_swigregister(AreaDirectionParameters)
 
@@ -5085,6 +5090,11 @@ class ScopedCloneableAreaDirectionParameters(_object):
     __swig_getmethods__["first"] = _six_sicd.ScopedCloneableAreaDirectionParameters_first_get
     if _newclass:
         first = _swig_property(_six_sicd.ScopedCloneableAreaDirectionParameters_first_get, _six_sicd.ScopedCloneableAreaDirectionParameters_first_set)
+
+    def getExtentInMeters(self):
+        """getExtentInMeters(ScopedCloneableAreaDirectionParameters self) -> double"""
+        return _six_sicd.ScopedCloneableAreaDirectionParameters_getExtentInMeters(self)
+
 
     def __eq__(self, other):
         """__eq__(ScopedCloneableAreaDirectionParameters self, AreaDirectionParameters other) -> bool"""

--- a/modules/python/six/source/generated/six_base.py
+++ b/modules/python/six/source/generated/six_base.py
@@ -1539,12 +1539,13 @@ class MagnificationMethod(_object):
     __repr__ = _swig_repr
     NEAREST_NEIGHBOR = _six_base.MagnificationMethod_NEAREST_NEIGHBOR
     BILINEAR = _six_base.MagnificationMethod_BILINEAR
+    LAGRANGE = _six_base.MagnificationMethod_LAGRANGE
     NOT_SET = _six_base.MagnificationMethod_NOT_SET
 
     def __init__(self, *args):
         """
         __init__(six::MagnificationMethod self) -> MagnificationMethod
-        __init__(six::MagnificationMethod self, std::string s) -> MagnificationMethod
+        __init__(six::MagnificationMethod self, std::string const & s) -> MagnificationMethod
         __init__(six::MagnificationMethod self, int i) -> MagnificationMethod
         """
         this = _six_base.new_MagnificationMethod(*args)

--- a/modules/python/six/source/generated/six_base_wrap.cxx
+++ b/modules/python/six/source/generated/six_base_wrap.cxx
@@ -24906,24 +24906,27 @@ fail:
 
 SWIGINTERN PyObject *_wrap_new_MagnificationMethod__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::string arg1 ;
+  std::string *arg1 = 0 ;
+  int res1 = SWIG_OLDOBJ ;
   PyObject * obj0 = 0 ;
   six::MagnificationMethod *result = 0 ;
   
   if (!PyArg_ParseTuple(args,(char *)"O:new_MagnificationMethod",&obj0)) SWIG_fail;
   {
     std::string *ptr = (std::string *)0;
-    int res = SWIG_AsPtr_std_string(obj0, &ptr);
-    if (!SWIG_IsOK(res) || !ptr) {
-      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "new_MagnificationMethod" "', argument " "1"" of type '" "std::string""'"); 
+    res1 = SWIG_AsPtr_std_string(obj0, &ptr);
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_MagnificationMethod" "', argument " "1"" of type '" "std::string const &""'"); 
     }
-    arg1 = *ptr;
-    if (SWIG_IsNewObj(res)) delete ptr;
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_MagnificationMethod" "', argument " "1"" of type '" "std::string const &""'"); 
+    }
+    arg1 = ptr;
   }
   {
     try
     {
-      result = (six::MagnificationMethod *)new six::MagnificationMethod(arg1);
+      result = (six::MagnificationMethod *)new six::MagnificationMethod((std::string const &)*arg1);
     } 
     catch (const std::exception& e)
     {
@@ -24952,8 +24955,10 @@ SWIGINTERN PyObject *_wrap_new_MagnificationMethod__SWIG_1(PyObject *SWIGUNUSEDP
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_six__MagnificationMethod, SWIG_POINTER_NEW |  0 );
+  if (SWIG_IsNewObj(res1)) delete arg1;
   return resultobj;
 fail:
+  if (SWIG_IsNewObj(res1)) delete arg1;
   return NULL;
 }
 
@@ -25046,7 +25051,7 @@ fail:
   SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_MagnificationMethod'.\n"
     "  Possible C/C++ prototypes are:\n"
     "    six::MagnificationMethod::MagnificationMethod()\n"
-    "    six::MagnificationMethod::MagnificationMethod(std::string)\n"
+    "    six::MagnificationMethod::MagnificationMethod(std::string const &)\n"
     "    six::MagnificationMethod::MagnificationMethod(int)\n");
   return 0;
 }
@@ -72101,7 +72106,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"ImageFormationType_swigregister", ImageFormationType_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_MagnificationMethod", _wrap_new_MagnificationMethod, METH_VARARGS, (char *)"\n"
 		"MagnificationMethod()\n"
-		"MagnificationMethod(std::string s)\n"
+		"MagnificationMethod(std::string const & s)\n"
 		"new_MagnificationMethod(int i) -> MagnificationMethod\n"
 		""},
 	 { (char *)"delete_MagnificationMethod", _wrap_delete_MagnificationMethod, METH_VARARGS, (char *)"delete_MagnificationMethod(MagnificationMethod self)"},
@@ -74503,6 +74508,7 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "ImageFormationType_NOT_SET",SWIG_From_int(static_cast< int >(six::ImageFormationType::NOT_SET)));
   SWIG_Python_SetConstant(d, "MagnificationMethod_NEAREST_NEIGHBOR",SWIG_From_int(static_cast< int >(six::MagnificationMethod::NEAREST_NEIGHBOR)));
   SWIG_Python_SetConstant(d, "MagnificationMethod_BILINEAR",SWIG_From_int(static_cast< int >(six::MagnificationMethod::BILINEAR)));
+  SWIG_Python_SetConstant(d, "MagnificationMethod_LAGRANGE",SWIG_From_int(static_cast< int >(six::MagnificationMethod::LAGRANGE)));
   SWIG_Python_SetConstant(d, "MagnificationMethod_NOT_SET",SWIG_From_int(static_cast< int >(six::MagnificationMethod::NOT_SET)));
   SWIG_Python_SetConstant(d, "OrientationType_UP",SWIG_From_int(static_cast< int >(six::OrientationType::UP)));
   SWIG_Python_SetConstant(d, "OrientationType_DOWN",SWIG_From_int(static_cast< int >(six::OrientationType::DOWN)));


### PR DESCRIPTION
six.sicd-python will get touched while refactoring some utility functions, might as well regenerate the whole library's bindings on their own.