### PR TITLE
Fixed a bug where OPT_BYTE_SWAP was ignored for the BufferList save() overloading

### DIFF
--- a/modules/c++/six/include/six/NITFWriteControl.h
+++ b/modules/c++/six/include/six/NITFWriteControl.h
@@ -337,6 +337,8 @@ protected:
     }
 
 private:
+    bool shouldByteSwap() const;
+
     static
     std::string getDesTypeID(const six::Data& data);
 

--- a/modules/c++/six/source/NITFWriteControl.cpp
+++ b/modules/c++/six/source/NITFWriteControl.cpp
@@ -704,22 +704,17 @@ void NITFWriteControl::save(SourceList& imageData,
     bufferedIO.close();
 }
 
-void NITFWriteControl::save(
-        SourceList& imageData,
-        nitf::IOInterface& outputFile,
-        const std::vector<std::string>& schemaPaths)
+bool NITFWriteControl::shouldByteSwap() const
 {
-
-    mWriter.prepareIO(outputFile, mRecord);
     bool doByteSwap;
 
-    int byteSwapping =
+    const int byteSwapping =
         (int) mOptions.getParameter(OPT_BYTE_SWAP,
                                     Parameter((int) ByteSwapping::SWAP_AUTO));
 
     if (byteSwapping == ByteSwapping::SWAP_AUTO)
     {
-        // Have to if its not a BE machine
+        // Have to if it's not a BE machine
         doByteSwap = !sys::isBigEndianSystem();
     }
     else
@@ -728,6 +723,18 @@ void NITFWriteControl::save(
         // unless you know what you're doing anyway!
         doByteSwap = byteSwapping ? true : false;
     }
+
+    return doByteSwap;
+}
+
+void NITFWriteControl::save(
+        SourceList& imageData,
+        nitf::IOInterface& outputFile,
+        const std::vector<std::string>& schemaPaths)
+{
+
+    mWriter.prepareIO(outputFile, mRecord);
+    const bool doByteSwap = shouldByteSwap();
 
     if (mInfos.size() != imageData.size())
     {
@@ -788,11 +795,8 @@ void NITFWriteControl::save(
         nitf::IOInterface& outputFile,
         const std::vector<std::string>& schemaPaths)
 {
-
     mWriter.prepareIO(outputFile, mRecord);
-
-    // Have to if its not a BE machine
-    bool doByteSwap = !sys::isBigEndianSystem();
+    const bool doByteSwap = shouldByteSwap();
 
     if (mInfos.size() != imageData.size())
         throw except::Exception(Ctxt(FmtX("Require %d images, received %s",


### PR DESCRIPTION
Added a convenience method and using the same one for both the IO interface and the BufferList overloading

@chvink 