### PR TITLE
Remove formal param warnings

### DIFF
--- a/six/modules/c++/samples/test_parse_xml.cpp
+++ b/six/modules/c++/samples/test_parse_xml.cpp
@@ -277,15 +277,15 @@ xml::lite::Element* createPath(const six::LatLonCorners& coords,
     }
 
     xml::lite::Element* coordsXML = new xml::lite::Element("coordinates",
-                                                           KML_URI, oss.str());
+                                                           envelopeURI, oss.str());
     xml::lite::Element* envelopeXML = new xml::lite::Element(envelopeType,
-                                                             KML_URI);
+                                                             envelopeURI);
     envelopeXML->addChild(coordsXML);
 
     xml::lite::Element* placemarkXML = new xml::lite::Element("Placemark",
-                                                              KML_URI);
-    placemarkXML->addChild(new xml::lite::Element("name", KML_URI, name));
-    placemarkXML->addChild(new xml::lite::Element("styleUrl", KML_URI,
+                                                              envelopeURI);
+    placemarkXML->addChild(new xml::lite::Element("name", envelopeURI, name));
+    placemarkXML->addChild(new xml::lite::Element("styleUrl", envelopeURI,
                                                   std::string("#") + name));
     placemarkXML->addChild(envelopeXML);
 
@@ -324,15 +324,15 @@ xml::lite::Element* createPath(const std::vector<six::LatLonAlt>& coords,
     }
 
     xml::lite::Element* coordsXML = new xml::lite::Element("coordinates",
-                                                           KML_URI, oss.str());
+                                                           envelopeURI, oss.str());
     xml::lite::Element* envelopeXML = new xml::lite::Element(envelopeType,
-                                                             KML_URI);
+                                                             envelopeURI);
     envelopeXML->addChild(coordsXML);
 
     xml::lite::Element* placemarkXML = new xml::lite::Element("Placemark",
-                                                              KML_URI);
-    placemarkXML->addChild(new xml::lite::Element("name", KML_URI, name));
-    placemarkXML->addChild(new xml::lite::Element("styleUrl", KML_URI,
+                                                              envelopeURI);
+    placemarkXML->addChild(new xml::lite::Element("name", envelopeURI, name));
+    placemarkXML->addChild(new xml::lite::Element("styleUrl", envelopeURI,
                                                   std::string("#") + name));
     placemarkXML->addChild(envelopeXML);
 

--- a/six/modules/c++/scene/source/EllipsoidModel.cpp
+++ b/six/modules/c++/scene/source/EllipsoidModel.cpp
@@ -192,13 +192,13 @@ void WGS84EllipsoidModel::initRadiusValues()
     }
 }
 
-void WGS84EllipsoidModel::setEquatorialRadius(double val)
+void WGS84EllipsoidModel::setEquatorialRadius(double)
 {
     //can't change the value - do some error
     throw except::Exception(Ctxt("Tried to change the equatorial radius - not supported"));
 }
 
-void WGS84EllipsoidModel::setPolarRadius(double val)
+void WGS84EllipsoidModel::setPolarRadius(double)
 {
     throw except::Exception(Ctxt("Tried to change the polar radius - not supported"));
 

--- a/six/modules/c++/six.sicd/source/ComplexXMLParser04x.cpp
+++ b/six/modules/c++/six.sicd/source/ComplexXMLParser04x.cpp
@@ -330,14 +330,14 @@ XMLElem ComplexXMLParser04x::convertHPBWToXML(
 }
 
 XMLElem ComplexXMLParser04x::convertAntennaParamArrayToXML(
-    const std::string& name,
+    const std::string& /*name*/,
     const GainAndPhasePolys* array,
     XMLElem apXML) const
 {
     //! optional field in 0.4
     if (array)
     {
-        XMLElem arrXML = newElement(name, apXML);
+        XMLElem arrXML = newElement("Array", apXML);
         common().createPoly2D("GainPoly", array->gainPoly, arrXML);
         common().createPoly2D("PhasePoly", array->phasePoly, arrXML);
         return arrXML;

--- a/six/modules/c++/six.sicd/source/ComplexXMLParser04x.cpp
+++ b/six/modules/c++/six.sicd/source/ComplexXMLParser04x.cpp
@@ -337,7 +337,7 @@ XMLElem ComplexXMLParser04x::convertAntennaParamArrayToXML(
     //! optional field in 0.4
     if (array)
     {
-        XMLElem arrXML = newElement("Array", apXML);
+        XMLElem arrXML = newElement(name, apXML);
         common().createPoly2D("GainPoly", array->gainPoly, arrXML);
         common().createPoly2D("PhasePoly", array->phasePoly, arrXML);
         return arrXML;
@@ -451,8 +451,8 @@ void ComplexXMLParser04x::parseRMATFromXML(const XMLElem rmatElem,
     parseDouble(getFirstAndOnly(rmatElem, "Ky2"), rmat->ky2);
 }
 
-void ComplexXMLParser04x::parseRMCRFromXML(const XMLElem rmcrElem, 
-                                           RMCR* rmcr) const
+void ComplexXMLParser04x::parseRMCRFromXML(const XMLElem, 
+                                           RMCR*) const
 {
     // did not exist in 0.4
     throw except::Exception(Ctxt("RMA=>RMCR is not available in 0.4"));

--- a/six/modules/c++/six.sicd/source/ComplexXMLParser10x.cpp
+++ b/six/modules/c++/six.sicd/source/ComplexXMLParser10x.cpp
@@ -319,8 +319,8 @@ XMLElem ComplexXMLParser10x::convertRMATToXML(
 }
 
 XMLElem ComplexXMLParser10x::convertHPBWToXML(
-    const HalfPowerBeamwidths* halfPowerBeamwidths, 
-    XMLElem parent) const
+    const HalfPowerBeamwidths*, 
+    XMLElem) const
 {
     //! this field was deprecated in 1.0.0
     return NULL;

--- a/six/modules/c++/six.sicd/unittests/test_sicd_schemata.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_sicd_schemata.cpp
@@ -280,7 +280,7 @@ std::string  initGeoInfoXML(unsigned int version, size_t numInfos = 4, size_t nu
 }
 
 
-std::string  initGeoDataXML(unsigned int version, size_t numInfos = 4, size_t numPoints = 4)
+std::string  initGeoDataXML(unsigned int version, size_t numInfos = 4)
 {
     std::string xmlText("");
 

--- a/six/modules/c++/six.sidd/source/DerivedXMLParser.cpp
+++ b/six/modules/c++/six.sidd/source/DerivedXMLParser.cpp
@@ -46,7 +46,7 @@ const char DerivedXMLParser::ISM_URI[] = "urn:us:gov:ic:ism";
 DerivedXMLParser::DerivedXMLParser(const std::string& version,
                                    logging::Logger* log,
                                    bool ownLog) :
-    XMLParser(versionToURI(version), false, log),
+    XMLParser(versionToURI(version), false, log, ownLog),
     mCommon(new six::SICommonXMLParser01x(
                 versionToURI(version), false, 
                 SI_COMMON_URI, log))

--- a/six/modules/c++/six.sidd/unittests/test_geometric_chip.cpp
+++ b/six/modules/c++/six.sidd/unittests/test_geometric_chip.cpp
@@ -38,7 +38,7 @@ TEST_CASE(testGeometricChip)
 }
 }
 
-int main(int argc, char** argv)
+int main(int, char**)
 {
     TEST_CHECK(testGeometricChip);
     return 0;

--- a/six/modules/c++/six.sidd/unittests/test_read_sidd_legend.cpp
+++ b/six/modules/c++/six.sidd/unittests/test_read_sidd_legend.cpp
@@ -299,7 +299,7 @@ TEST_CASE(testRead)
 }
 }
 
-int main(int argc, char** argv)
+int main(int, char**)
 {
     try
     {

--- a/six/modules/c++/six/include/six/Classification.h
+++ b/six/modules/c++/six/include/six/Classification.h
@@ -62,9 +62,9 @@ public:
         return (!level.empty() && ::toupper(level[0]) == 'U');
     }
 
-    virtual void setSecurity(const std::string& prefix,
-                             logging::Logger& log,
-                             nitf::FileSecurity security) const
+    virtual void setSecurity(const std::string& /*prefix*/,
+                             logging::Logger& /*log*/,
+                             nitf::FileSecurity /*security*/) const
     {
     }
 

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -350,7 +350,7 @@ protected:
     //  to be cleaned up elsewhere. There is no access
     //  to deallocation in NITFWriteControl directly
     virtual void createCompressionOptions(
-            std::map<std::string, void*>& options)
+            std::map<std::string, void*>& /*options*/)
     {
     }
 

--- a/six/projects/csm/source/SIXSensorModel.cpp
+++ b/six/projects/csm/source/SIXSensorModel.cpp
@@ -91,7 +91,7 @@ inverse(const math::linear::MatrixMxN<3, 3>& mat)
     {
         invMat = math::linear::inverse(mat);
     }
-    catch (const except::Exception& ex)
+    catch (const except::Exception&)
     {
         invMat = pseudoInverse(mat);
     }


### PR DESCRIPTION
This will take care of all the frivolous one, except from external places. Will try to deal with a common one from Nitro shortly.