### PR TITLE
Fixed byte swap issue in cphd

### DIFF
--- a/six/modules/c++/cphd/source/Wideband.cpp
+++ b/six/modules/c++/cphd/source/Wideband.cpp
@@ -442,7 +442,7 @@ void Wideband::read(size_t channel,
         // Element size is half mElementSize because it's complex
         if (!sys::isBigEndianSystem() && mElementSize > 2)
         {
-            byteSwap(data.data, mElementSize / 2, numPixels / 2, numThreads);
+            byteSwap(data.data, mElementSize / 2, numPixels * 2, numThreads);
         }
     }
 }


### PR DESCRIPTION
numPixels should be * 2 because we need double the number of pixels since we halved their size