### PR TITLE
Fix object slicing issue with Annotations, clean up some warnings

### DIFF
--- a/six/modules/c++/samples/test_create_sidd.cpp
+++ b/six/modules/c++/samples/test_create_sidd.cpp
@@ -340,7 +340,7 @@ int main(int argc, char** argv)
             six::sidd::Annotation *ann = (*data->annotations.rbegin()).get();
             std::cout << "Hey: " << ann->spatialReferenceSystem.get() << std::endl;
             ann->identifier = "1st Annotation";
-            ann->objects.push_back(mem::ScopedCopyablePtr<
+            ann->objects.push_back(mem::ScopedCloneablePtr<
                     six::sidd::SFAGeometry>(new six::sidd::SFAPoint));
 
             sources.push_back(sioReader);

--- a/six/modules/c++/six.sidd/include/six/sidd/Annotations.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/Annotations.h
@@ -34,20 +34,7 @@ struct Annotation
 {
     std::string identifier;
     mem::ScopedCopyablePtr<SFAReferenceSystem> spatialReferenceSystem;
-    std::vector<mem::ScopedCopyablePtr<SFAGeometry> > objects;
-
-    Annotation() {}
-
-    Annotation(const Annotation& other)
-    {
-        identifier = other.identifier;
-        spatialReferenceSystem = other.spatialReferenceSystem;
-        objects.resize(other.objects.size());
-        for (size_t ii = 0; ii < other.objects.size(); ++ii)
-        {
-            objects[ii].reset(other.objects[ii]->clone());
-        }
-    }
+    std::vector<mem::ScopedCloneablePtr<SFAGeometry> > objects;
 };
 
 typedef std::vector<mem::ScopedCopyablePtr<Annotation> > Annotations;

--- a/six/modules/c++/six.sidd/include/six/sidd/Annotations.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/Annotations.h
@@ -36,9 +36,17 @@ struct Annotation
     mem::ScopedCopyablePtr<SFAReferenceSystem> spatialReferenceSystem;
     std::vector<mem::ScopedCopyablePtr<SFAGeometry> > objects;
 
-    Annotation() :
-        identifier(""), spatialReferenceSystem(NULL)
+    Annotation() {}
+
+    Annotation(const Annotation& other)
     {
+        identifier = other.identifier;
+        spatialReferenceSystem = other.spatialReferenceSystem;
+        objects.resize(other.objects.size());
+        for (size_t ii = 0; ii < other.objects.size(); ++ii)
+        {
+            objects[ii].reset(other.objects[ii]->clone());
+        }
     }
 };
 

--- a/six/modules/c++/six.sidd/include/six/sidd/DerivedDataBuilder.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/DerivedDataBuilder.h
@@ -100,7 +100,7 @@ public:
      *  to one)
      *  \return Refrence to self
      */
-    virtual DerivedDataBuilder& addExploitationFeatures(unsigned int num = 1);
+    virtual DerivedDataBuilder& addExploitationFeatures(size_t num = 1);
 
     /*!
      *  Add the Optional ProductProcessing block to the SIDD Data object.

--- a/six/modules/c++/six.sidd/include/six/sidd/ExploitationFeatures.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/ExploitationFeatures.h
@@ -344,7 +344,7 @@ struct ExploitationFeatures
 {
 
     //!  Creates a collection object numCollections times
-    ExploitationFeatures(unsigned int numCollections = 0);
+    ExploitationFeatures(size_t numCollections = 0);
 
     /*!
      *  Deep copy of the block, including copies of each Collection

--- a/six/modules/c++/six.sidd/include/six/sidd/SFA.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/SFA.h
@@ -282,7 +282,7 @@ public:
         return new SFAMultiLineString(*this);
     }
 
-    std::vector<mem::ScopedCopyablePtr<SFALineString> > elements;
+    std::vector<mem::ScopedCloneablePtr<SFALineString> > elements;
     static const char TYPE_NAME[];
 };
 

--- a/six/modules/c++/six.sidd/include/six/sidd/SFA.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/SFA.h
@@ -43,7 +43,7 @@ public:
 
 protected:
     std::string mType;
-    SFATyped(std::string typeName) :
+    SFATyped(const std::string& typeName) :
         mType(typeName)
     {
     }
@@ -51,13 +51,13 @@ protected:
 
 struct SFAGeometry : public SFATyped
 {
-public:
-    virtual ~SFAGeometry()
+    virtual SFAGeometry* clone() const
     {
+        return new SFAGeometry(*this);
     }
 
 protected:
-    SFAGeometry(std::string typeName) :
+    SFAGeometry(const std::string& typeName) :
         SFATyped(typeName)
     {
     }
@@ -88,8 +88,9 @@ struct SFAPoint : public SFAGeometry
     {
     }
 
-    virtual ~SFAPoint()
+    virtual SFAPoint* clone() const
     {
+        return new SFAPoint(*this);
     }
 
     static const char TYPE_NAME[];
@@ -98,12 +99,8 @@ struct SFAPoint : public SFAGeometry
 //! Abstract type
 struct SFACurve : public SFAGeometry
 {
-public:
-    virtual ~SFACurve()
-    {
-    }
 protected:
-    SFACurve(std::string typeName) :
+    SFACurve(const std::string& typeName) :
         SFAGeometry(typeName)
     {
     }
@@ -116,10 +113,10 @@ public:
         SFACurve(TYPE_NAME)
     {
     }
-    virtual ~SFALineString()
+    virtual SFALineString* clone() const
     {
+        return new SFALineString(*this);
     }
-
     std::vector<mem::ScopedCopyablePtr<SFAPoint> > vertices;
     static const char TYPE_NAME[];
 };
@@ -132,10 +129,10 @@ public:
     {
         mType = TYPE_NAME;
     }
-    virtual ~SFALine()
+    virtual SFALine* clone() const
     {
+        return new SFALine(*this);
     }
-
     static const char TYPE_NAME[];
 };
 
@@ -147,22 +144,18 @@ public:
     {
         mType = TYPE_NAME;
     }
-    virtual ~SFALinearRing()
+    virtual SFALinearRing* clone() const
     {
+        return new SFALinearRing(*this);
     }
-
     static const char TYPE_NAME[];
 };
 
 //! Abstract type
 struct SFASurface : public SFAGeometry
 {
-public:
-    virtual ~SFASurface()
-    {
-    }
 protected:
-    SFASurface(std::string typeName) :
+    SFASurface(const std::string& typeName) :
         SFAGeometry(typeName)
     {
     }
@@ -175,8 +168,9 @@ public:
         SFASurface(TYPE_NAME)
     {
     }
-    virtual ~SFAPolygon()
+    virtual SFAPolygon* clone() const
     {
+        return new SFAPolygon(*this);
     }
 
     std::vector<mem::ScopedCopyablePtr<SFALinearRing> > rings;
@@ -191,8 +185,10 @@ public:
     {
         mType = TYPE_NAME;
     }
-    virtual ~SFATriangle()
+
+    virtual SFATriangle* clone() const
     {
+        return new SFATriangle(*this);
     }
 
     static const char TYPE_NAME[];
@@ -205,8 +201,10 @@ public:
         SFASurface(TYPE_NAME)
     {
     }
-    virtual ~SFAPolyhedralSurface()
+
+    virtual SFAPolyhedralSurface* clone() const
     {
+        return new SFAPolyhedralSurface(*this);
     }
 
     std::vector<mem::ScopedCopyablePtr<SFAPolygon> > patches;
@@ -222,8 +220,10 @@ public:
         SFASurface(TYPE_NAME)
     {
     }
-    virtual ~SFATriangulatedIrregularNetwork()
+
+    virtual SFATriangulatedIrregularNetwork* clone() const
     {
+        return new SFATriangulatedIrregularNetwork(*this);
     }
 
     std::vector<mem::ScopedCopyablePtr<SFAPolygon> > patches;
@@ -233,13 +233,8 @@ public:
 //! Abstract type
 struct SFAGeometryCollection : public SFAGeometry
 {
-public:
-    virtual ~SFAGeometryCollection() 
-    {
-    }
-
 protected:
-    SFAGeometryCollection(std::string typeName) :
+    SFAGeometryCollection(const std::string& typeName) :
         SFAGeometry(typeName)
     {
     }
@@ -252,10 +247,10 @@ public:
         SFAGeometryCollection(TYPE_NAME)
     {
     }
-    virtual ~SFAMultiPoint()
+    virtual SFAMultiPoint* clone() const
     {
+        return new SFAMultiPoint(*this);
     }
-
     std::vector<mem::ScopedCopyablePtr<SFAPoint> > vertices;
     static const char TYPE_NAME[];
 };
@@ -263,13 +258,8 @@ public:
 //! Abstract type
 struct SFAMultiCurve : public SFAGeometryCollection
 {
-public:
-    virtual ~SFAMultiCurve()
-    {
-    }
-
 protected:
-    SFAMultiCurve(std::string typeName) :
+    SFAMultiCurve(const std::string& typeName) :
         SFAGeometryCollection(typeName)
     {
     }
@@ -282,8 +272,10 @@ public:
         SFAMultiCurve(TYPE_NAME)
     {
     }
-    virtual ~SFAMultiLineString()
+
+    virtual SFAMultiLineString* clone() const
     {
+        return new SFAMultiLineString(*this);
     }
 
     std::vector<mem::ScopedCopyablePtr<SFALineString> > elements;
@@ -293,12 +285,8 @@ public:
 //! Abstract type
 struct SFAMultiSurface : public SFAGeometryCollection
 {
-public:
-    virtual ~SFAMultiSurface()
-    {
-    }
 protected:
-    SFAMultiSurface(std::string typeName) :
+    SFAMultiSurface(const std::string& typeName) :
         SFAGeometryCollection(typeName)
     {
     }
@@ -311,8 +299,10 @@ public:
         SFAMultiSurface(TYPE_NAME)
     {
     }
-    virtual ~SFAMultiPolygon()
+
+    virtual SFAMultiPolygon* clone() const
     {
+        return new SFAMultiPolygon(*this);
     }
 
     std::vector<mem::ScopedCopyablePtr<SFAPolygon> > elements;
@@ -322,12 +312,13 @@ public:
 struct SFACoordinateSystem : public SFATyped
 {
 public:
-    virtual ~SFACoordinateSystem()
+    virtual SFACoordinateSystem* clone() const
     {
+        return new SFACoordinateSystem(*this);
     }
 
 protected:
-    SFACoordinateSystem(std::string typeName) :
+    SFACoordinateSystem(const std::string& typeName) :
         SFATyped(typeName)
     {
     }
@@ -374,6 +365,11 @@ struct SFAGeocentricCoordinateSystem : public SFACoordinateSystem
     {
     }
 
+    virtual SFAGeocentricCoordinateSystem* clone() const
+    {
+        return new SFAGeocentricCoordinateSystem(*this); 
+    }
+
     static const char TYPE_NAME[];
 };
 
@@ -388,6 +384,11 @@ struct SFAGeographicCoordinateSystem : public SFACoordinateSystem
     SFAGeographicCoordinateSystem() :
         SFACoordinateSystem(TYPE_NAME)
     {
+    }
+
+    virtual SFAGeographicCoordinateSystem* clone() const
+    {
+        return new SFAGeographicCoordinateSystem(*this);
     }
 
     static const char TYPE_NAME[];
@@ -406,6 +407,11 @@ struct SFAProjectedCoordinateSystem : public SFACoordinateSystem
     {
     }
 
+    virtual SFAProjectedCoordinateSystem* clone() const
+    {
+        return new SFAProjectedCoordinateSystem(*this);
+    }
+
     static const char TYPE_NAME[];
 };
 
@@ -414,9 +420,14 @@ struct SFAReferenceSystem
     mem::ScopedCopyablePtr<SFACoordinateSystem> coordinateSystem;
     std::vector<std::string> axisNames;
 
-    SFAReferenceSystem()
+    SFAReferenceSystem(const SFAReferenceSystem& other)
     {
+        coordinateSystem.reset(other.coordinateSystem->clone());
+        axisNames = other.axisNames;
     }
+
+    SFAReferenceSystem() {}
+
 };
 
 }

--- a/six/modules/c++/six.sidd/include/six/sidd/SFA.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/SFA.h
@@ -70,25 +70,29 @@ struct SFAPoint : public SFAGeometry
     double x, y, z, m;
 
     SFAPoint() :
-        SFAGeometry(TYPE_NAME), x(0), y(0),
+        SFAGeometry(TYPE_NAME), 
+        x(0), 
+        y(0),
         z(::six::Init::undefined<double>()),
         m(::six::Init::undefined<double>())
     {
-        z = ::six::Init::undefined<double>();
-        m = ::six::Init::undefined<double>();
     }
     
     SFAPoint(double _x, double _y) :
-        SFAGeometry(TYPE_NAME), x(_x), y(_y),
+        SFAGeometry(TYPE_NAME), 
+        x(_x), 
+        y(_y),
         z(::six::Init::undefined<double>()),
         m(::six::Init::undefined<double>())
     {
-        z = ::six::Init::undefined<double>();
-        m = ::six::Init::undefined<double>();
     }
     
     SFAPoint(double _x, double _y, double _z, double _m) :
-        SFAGeometry(TYPE_NAME), x(_x), y(_y), z(_z), m(_m)
+        SFAGeometry(TYPE_NAME), 
+        x(_x), 
+        y(_y), 
+        z(_z), 
+        m(_m)
     {
     }
 
@@ -428,4 +432,3 @@ struct SFAReferenceSystem
 }
 }
 #endif
-

--- a/six/modules/c++/six.sidd/include/six/sidd/SFA.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/SFA.h
@@ -417,17 +417,8 @@ struct SFAProjectedCoordinateSystem : public SFACoordinateSystem
 
 struct SFAReferenceSystem
 {
-    mem::ScopedCopyablePtr<SFACoordinateSystem> coordinateSystem;
+    mem::ScopedCloneablePtr<SFACoordinateSystem> coordinateSystem;
     std::vector<std::string> axisNames;
-
-    SFAReferenceSystem(const SFAReferenceSystem& other)
-    {
-        coordinateSystem.reset(other.coordinateSystem->clone());
-        axisNames = other.axisNames;
-    }
-
-    SFAReferenceSystem() {}
-
 };
 
 }

--- a/six/modules/c++/six.sidd/include/six/sidd/SFA.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/SFA.h
@@ -36,6 +36,8 @@ public:
     {
     }
 
+    virtual SFATyped* clone() const = 0;
+
     inline std::string getType() const
     {
         return mType;
@@ -68,16 +70,18 @@ struct SFAPoint : public SFAGeometry
     double x, y, z, m;
 
     SFAPoint() :
-        SFAGeometry(TYPE_NAME)
+        SFAGeometry(TYPE_NAME), x(0), y(0),
+        z(::six::Init::undefined<double>()),
+        m(::six::Init::undefined<double>())
     {
-        x = 0;
-        y = 0;
         z = ::six::Init::undefined<double>();
         m = ::six::Init::undefined<double>();
     }
     
     SFAPoint(double _x, double _y) :
-        SFAGeometry(TYPE_NAME), x(_x), y(_y)
+        SFAGeometry(TYPE_NAME), x(_x), y(_y),
+        z(::six::Init::undefined<double>()),
+        m(::six::Init::undefined<double>())
     {
         z = ::six::Init::undefined<double>();
         m = ::six::Init::undefined<double>();
@@ -207,7 +211,7 @@ public:
         return new SFAPolyhedralSurface(*this);
     }
 
-    std::vector<mem::ScopedCopyablePtr<SFAPolygon> > patches;
+    std::vector<mem::ScopedCloneablePtr<SFAPolygon> > patches;
     static const char TYPE_NAME[];
 };
 
@@ -226,7 +230,7 @@ public:
         return new SFATriangulatedIrregularNetwork(*this);
     }
 
-    std::vector<mem::ScopedCopyablePtr<SFAPolygon> > patches;
+    std::vector<mem::ScopedCloneablePtr<SFAPolygon> > patches;
     static const char TYPE_NAME[];
 };
 
@@ -305,7 +309,7 @@ public:
         return new SFAMultiPolygon(*this);
     }
 
-    std::vector<mem::ScopedCopyablePtr<SFAPolygon> > elements;
+    std::vector<mem::ScopedCloneablePtr<SFAPolygon> > elements;
     static const char TYPE_NAME[];
 };
 

--- a/six/modules/c++/six.sidd/source/DerivedDataBuilder.cpp
+++ b/six/modules/c++/six.sidd/source/DerivedDataBuilder.cpp
@@ -64,7 +64,7 @@ DerivedDataBuilder& DerivedDataBuilder::addMeasurement(
 }
 
 DerivedDataBuilder& DerivedDataBuilder::addExploitationFeatures(
-                                                                unsigned int num)
+                                                                size_t num)
 {
     mData->exploitationFeatures.reset(new ExploitationFeatures(num));
 

--- a/six/modules/c++/six.sidd/source/DerivedXMLParser.cpp
+++ b/six/modules/c++/six.sidd/source/DerivedXMLParser.cpp
@@ -142,7 +142,7 @@ DerivedData* DerivedXMLParser::fromXML(
         std::vector<XMLElem> annChildren;
         annotationsXML->getElementsByTagName("Annotation", annChildren);
         data->annotations.resize(annChildren.size());
-        for (unsigned int i = 0, size = annChildren.size(); i < size; ++i)
+        for (size_t i = 0, size = annChildren.size(); i < size; ++i)
         {
             data->annotations[i].reset(new Annotation());
             parseAnnotationFromXML(annChildren[i], data->annotations[i].get());
@@ -893,11 +893,11 @@ void DerivedXMLParser::parseExploitationFeaturesFromXML(
         std::vector<XMLElem> polarization;
         informationXML->getElementsByTagName("Polarization", polarization);
         info->polarization.resize(polarization.size());
-        for (size_t i = 0, nElems = polarization.size(); i < nElems; ++i)
+        for (size_t jj = 0, nElems = polarization.size(); jj < nElems; ++jj)
         {
-            XMLElem polXML = polarization[i];
-            info->polarization[i].reset(new TxRcvPolarization());
-            TxRcvPolarization* p = info->polarization[i].get();
+            XMLElem polXML = polarization[jj];
+            info->polarization[jj].reset(new TxRcvPolarization());
+            TxRcvPolarization* p = info->polarization[jj].get();
 
             p->txPolarization = six::toType<PolarizationType>(
                     getFirstAndOnly(polXML, "TxPolarization")->
@@ -1889,7 +1889,7 @@ void DerivedXMLParser::parseProcessingModuleFromXML(
     std::vector<XMLElem> procModuleXML;
     procXML->getElementsByTagName("ProcessingModule", procModuleXML);
     procMod->processingModules.resize(procModuleXML.size());
-    for (unsigned int i = 0, size = procModuleXML.size(); i < size; ++i)
+    for (size_t i = 0, size = procModuleXML.size(); i < size; ++i)
     {
         procMod->processingModules[i].reset(new ProcessingModule());
         parseProcessingModuleFromXML(
@@ -1904,7 +1904,7 @@ void DerivedXMLParser::parseProductProcessingFromXML(
     std::vector<XMLElem> procModuleXML;
     elem->getElementsByTagName("ProcessingModule", procModuleXML);
     productProcessing->processingModules.resize(procModuleXML.size());
-    for (unsigned int i = 0, size = procModuleXML.size(); i < size; ++i)
+    for (size_t i = 0, size = procModuleXML.size(); i < size; ++i)
     {
         productProcessing->processingModules[i].reset(new ProcessingModule());
         parseProcessingModuleFromXML(
@@ -1942,7 +1942,7 @@ void DerivedXMLParser::parseDownstreamReprocessingFromXML(
     std::vector<XMLElem> procEventXML;
     elem->getElementsByTagName("ProcessingEvent", procEventXML);
     downstreamReproc->processingEvents.resize(procEventXML.size());
-    for (unsigned int i = 0, size = procEventXML.size(); i < size; ++i)
+    for (size_t i = 0, size = procEventXML.size(); i < size; ++i)
     {
         downstreamReproc->processingEvents[i].reset(new ProcessingEvent());
         ProcessingEvent* procEvent
@@ -2293,7 +2293,7 @@ void DerivedXMLParser::parseSFAGeometryFromXML(const XMLElem elem, SFAGeometry *
         std::vector<XMLElem> vXML;
         elem->getElementsByTagName("Vertex", vXML);
         p->vertices.resize(vXML.size());
-        for (unsigned int i = 0, size = vXML.size(); i < size; ++i)
+        for (size_t i = 0, size = vXML.size(); i < size; ++i)
         {
             p->vertices[i].reset(new SFAPoint());
             parseSFAGeometryFromXML(vXML[i], p->vertices[i].get());
@@ -2305,7 +2305,7 @@ void DerivedXMLParser::parseSFAGeometryFromXML(const XMLElem elem, SFAGeometry *
         std::vector<XMLElem> ringXML;
         elem->getElementsByTagName("Ring", ringXML);
         p->rings.resize(ringXML.size());
-        for (unsigned int i = 0, size = ringXML.size(); i < size; ++i)
+        for (size_t i = 0, size = ringXML.size(); i < size; ++i)
         {
             p->rings[i].reset(new SFALinearRing());
             parseSFAGeometryFromXML(ringXML[i], p->rings[i].get());
@@ -2317,7 +2317,7 @@ void DerivedXMLParser::parseSFAGeometryFromXML(const XMLElem elem, SFAGeometry *
         std::vector<XMLElem> polyXML;
         elem->getElementsByTagName("Patch", polyXML);
         p->patches.resize(polyXML.size());
-        for (unsigned int i = 0, size = polyXML.size(); i < size; ++i)
+        for (size_t i = 0, size = polyXML.size(); i < size; ++i)
         {
             p->patches[i].reset(new SFAPolygon());
             parseSFAGeometryFromXML(polyXML[i], p->patches[i].get());
@@ -2329,7 +2329,7 @@ void DerivedXMLParser::parseSFAGeometryFromXML(const XMLElem elem, SFAGeometry *
         std::vector<XMLElem> polyXML;
         elem->getElementsByTagName("Element", polyXML);
         p->elements.resize(polyXML.size());
-        for (unsigned int i = 0, size = polyXML.size(); i < size; ++i)
+        for (size_t i = 0, size = polyXML.size(); i < size; ++i)
         {
             p->elements[i].reset(new SFAPolygon());
             parseSFAGeometryFromXML(polyXML[i], p->elements[i].get());
@@ -2341,7 +2341,7 @@ void DerivedXMLParser::parseSFAGeometryFromXML(const XMLElem elem, SFAGeometry *
         std::vector<XMLElem> lineXML;
         elem->getElementsByTagName("Element", lineXML);
         p->elements.resize(lineXML.size());
-        for (unsigned int i = 0, size = lineXML.size(); i < size; ++i)
+        for (size_t i = 0, size = lineXML.size(); i < size; ++i)
         {
             p->elements[i].reset(new SFALineString());
             parseSFAGeometryFromXML(lineXML[i], p->elements[i].get());
@@ -2353,7 +2353,7 @@ void DerivedXMLParser::parseSFAGeometryFromXML(const XMLElem elem, SFAGeometry *
         std::vector<XMLElem> vXML;
         elem->getElementsByTagName("Vertex", vXML);
         p->vertices.resize(vXML.size());
-        for (unsigned int i = 0, size = vXML.size(); i < size; ++i)
+        for (size_t i = 0, size = vXML.size(); i < size; ++i)
         {
             p->vertices[i].reset(new SFAPoint());
             parseSFAGeometryFromXML(vXML[i], p->vertices[i].get());

--- a/six/modules/c++/six.sidd/source/ExploitationFeatures.cpp
+++ b/six/modules/c++/six.sidd/source/ExploitationFeatures.cpp
@@ -112,10 +112,10 @@ Product::Product() :
 {
 }
 
-ExploitationFeatures::ExploitationFeatures(unsigned int numCollections)
+ExploitationFeatures::ExploitationFeatures(size_t numCollections)
 {
     collections.resize(numCollections);
-    for (unsigned int i = 0; i < numCollections; ++i)
+    for (size_t i = 0; i < numCollections; ++i)
     {
         collections[i].reset(new Collection());
     }


### PR DESCRIPTION
Had to leave in a couple empty default ctors, since those classes now have custom copy ctors.