### PR TITLE
Removed the trailing newline from the version string

### DIFF
--- a/six/modules/c++/cphd/source/FileHeader.cpp
+++ b/six/modules/c++/cphd/source/FileHeader.cpp
@@ -70,7 +70,12 @@ std::string FileHeader::readVersion(io::SeekableInputStream& inStream)
     {
         throw except::Exception(Ctxt("Not a CPHD file"));
     }
-    return kvPair.second;
+    
+    // Remove any trailing whitespace from the version
+    std::string ret = kvPair.second;
+    str::trim(ret);
+
+    return ret;
 }
 
 void FileHeader::tokenize(const std::string& in,


### PR DESCRIPTION
As part of the construction of a CPHDReader object, the FileHeader::readVersion function reads a newline into the mVersion member string.  Afterwards, when the FileHeader::toString function is called, a second newline is added after the version key-value pair.  (A check with a hex editor confirms that each of the CPHD files that we are reading has only a single newline character after the version identifier, conforming to the CPHD specification.)