### PR TITLE
Fix dump images indexing

### DIFF
--- a/six/modules/c++/samples/test_dump_images.cpp
+++ b/six/modules/c++/samples/test_dump_images.cpp
@@ -101,9 +101,7 @@ int main(int argc, char** argv)
             options(parser.parse(argc, argv));
 
         size_t startRow(options->get<size_t>("startRow"));
-        //long numRows(options->get<long>("numRows"));
         size_t startCol(options->get<size_t>("startCol"));
-        //long numCols(options->get<long>("numCols"));
         const bool isSIO(options->get<bool>("sio"));
         const bool oneRead(options->get<bool>("oneRead"));
         const std::string inputFile(options->get<std::string>("file"));

--- a/six/modules/c++/samples/test_dump_images.cpp
+++ b/six/modules/c++/samples/test_dump_images.cpp
@@ -19,6 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#include <sstream>
+#include <limits>
+
 #include <mem/ScopedArray.h>
 #include <import/cli.h>
 #include <import/six.h>
@@ -27,10 +30,10 @@
 #include <import/sio/lite.h>
 #include "utils.h"
 
-using namespace six;
-
-void writeSIOFileHeader(long numRows,
-                        long numCols,
+namespace
+{
+void writeSIOFileHeader(size_t numRows,
+                        size_t numCols,
                         six::PixelType pixelType,
                         io::OutputStream& outputStream)
 {
@@ -66,26 +69,23 @@ void writeSIOFileHeader(long numRows,
                           elementSize,
                           elementType).to(1, outputStream);
 }
+}
 
 int main(int argc, char** argv)
 {
-
     try
     {
         // create a parser and add our options to it
         cli::ArgumentParser parser;
         parser.setDescription(
                               "This program reads in a single SICD or SIDD file and dumps its images as separate files.");
-        parser.addArgument("-d --dir", "Write to output directory", cli::STORE)->setDefault(
-                                                                                            ".");
-        parser.addArgument("--sr", "Start Row", cli::STORE, "startRow", "ROW")->setDefault(
-                                                                                           0);
+        parser.addArgument("-d --dir", "Write to output directory", cli::STORE)->setDefault(".");
+        parser.addArgument("--sr", "Start Row", cli::STORE, "startRow", "ROW")->setDefault(0);
         parser.addArgument("--nr", "Number of Rows", cli::STORE, "numRows",
-                           "ROWS")->setDefault(-1);
-        parser.addArgument("--sc", "Start Col", cli::STORE, "startCol", "COL")->setDefault(
-                                                                                           0);
+                           "ROWS");
+        parser.addArgument("--sc", "Start Col", cli::STORE, "startCol", "COL")->setDefault(0);
         parser.addArgument("--nc", "Number of Cols", cli::STORE, "numCols",
-                           "COLS")->setDefault(-1);
+                           "COLS");
         parser.addArgument("--sio", "Write out an SIO instead of a RAW file",
                            cli::STORE_TRUE, "sio");
         parser.addArgument("-s --schema",
@@ -98,35 +98,35 @@ int main(int argc, char** argv)
                            "FILE", 1, 1);
 
         const std::auto_ptr<cli::Results>
-            options(parser.parse(argc, (const char**) argv));
+            options(parser.parse(argc, argv));
 
-        long startRow(options->get<long> ("startRow"));
-        long numRows(options->get<long> ("numRows"));
-        long startCol(options->get<long> ("startCol"));
-        long numCols(options->get<long> ("numCols"));
-        bool isSIO(options->get<bool> ("sio"));
-        bool oneRead(options->get<bool> ("oneRead"));
-        std::string inputFile(options->get<std::string> ("file"));
-        std::string outputDir(options->get<std::string> ("dir"));
+        size_t startRow(options->get<size_t>("startRow"));
+        //long numRows(options->get<long>("numRows"));
+        size_t startCol(options->get<size_t>("startCol"));
+        //long numCols(options->get<long>("numCols"));
+        const bool isSIO(options->get<bool>("sio"));
+        const bool oneRead(options->get<bool>("oneRead"));
+        const std::string inputFile(options->get<std::string>("file"));
+        const std::string outputDir(options->get<std::string>("dir"));
         std::vector<std::string> schemaPaths;
         getSchemaPaths(*options, "--schema", "schema", schemaPaths);
 
         // create an XML registry
         // The reason to do this is to avoid adding XMLControlCreators to the
         // XMLControlFactory singleton - this way has more fine-grained control
-        XMLControlRegistry xmlRegistry;
-        xmlRegistry.addCreator(DataType::COMPLEX, new XMLControlCreatorT<
-                six::sicd::ComplexXMLControl> ());
-        xmlRegistry.addCreator(DataType::DERIVED, new XMLControlCreatorT<
-                six::sidd::DerivedXMLControl> ());
+        six::XMLControlRegistry xmlRegistry;
+        xmlRegistry.addCreator(six::DataType::COMPLEX,
+                new six::XMLControlCreatorT<six::sicd::ComplexXMLControl> ());
+        xmlRegistry.addCreator(six::DataType::DERIVED,
+                new six::XMLControlCreatorT<six::sidd::DerivedXMLControl> ());
 
         // create a Reader registry (now, only NITF and TIFF)
-        ReadControlRegistry readerRegistry;
-        readerRegistry.addCreator(new NITFReadControlCreator());
+        six::ReadControlRegistry readerRegistry;
+        readerRegistry.addCreator(new six::NITFReadControlCreator());
         readerRegistry.addCreator(new six::sidd::GeoTIFFReadControlCreator());
 
         // get the correct ReadControl for the given file
-        const std::auto_ptr<ReadControl>
+        const std::auto_ptr<six::ReadControl>
             reader(readerRegistry.newReadControl(inputFile));
         // set the optional registry, since we have one
         reader->setXMLControlRegistry(&xmlRegistry);
@@ -134,20 +134,20 @@ int main(int argc, char** argv)
         // load the file
         reader->load(inputFile, schemaPaths);
 
-        Container* container = reader->getContainer();
+        six::Container* container = reader->getContainer();
         std::string base = sys::Path::basename(inputFile, true);
         size_t numImages = 0;
 
-        if (container->getDataType() == DataType::COMPLEX
+        if (container->getDataType() == six::DataType::COMPLEX
                 && container->getNumData() > 0)
         {
             numImages = 1;
         }
-        else if (container->getDataType() == DataType::DERIVED)
+        else if (container->getDataType() == six::DataType::DERIVED)
         {
             for (; numImages < container->getNumData()
                     && container->getData(numImages)->getDataType()
-                            == DataType::DERIVED; ++numImages)
+                            == six::DataType::DERIVED; ++numImages)
                 ;
         }
 
@@ -160,7 +160,7 @@ int main(int argc, char** argv)
         // first, write out the XMLs
         for (size_t i = 0, total = container->getNumData(); i < total; ++i)
         {
-            const Data* data = container->getData(i);
+            const six::Data* data = container->getData(i);
             std::string filename = FmtX("%s_DES_%d.xml", base.c_str(), i);
             std::string xmlFile = sys::Path::joinPaths(outputDir, filename);
             io::FileOutputStream xmlStream(xmlFile);
@@ -173,30 +173,27 @@ int main(int argc, char** argv)
         //  now, dump the images
         for (size_t ii = 0; ii < numImages; ++ii)
         {
-            const Data* const data = container->getData(ii);
+            const six::Data* const data = container->getData(ii);
             const size_t nbpp = data->getNumBytesPerPixel();
-            const size_t height = data->getNumRows();
-            const size_t width = data->getNumCols();
 
-            if (numRows == -1)
-                numRows = height;
+            const size_t numRows = options->hasValue("numRows") ?
+                    options->get<size_t>("numRows") : data->getNumRows();
 
-            if (numCols == -1)
-                numCols = width;
+            const size_t numCols = options->hasValue("numCols") ?
+                    options->get<size_t>("numCols") : data->getNumCols();
 
-            const std::string filename =
-                FmtX("%s_%d-%dx%d-%d_%d-image-%d.%s",
-                     base.c_str(),
-                     startRow,
-                     startRow + numRows,
-                     startCol,
-                     startCol + numCols,
-                     nbpp,
-                     ii,
-                     isSIO ? "sio" : "raw");
+            std::ostringstream filename;
+            filename << base << "_"
+                     << startRow << "-"
+                     << (startRow + numRows) << "x"
+                     << startCol << "-"
+                     << (startCol + numCols) << "_"
+                     << nbpp << "-image-"
+                     << ii
+                     << (isSIO ? "sio" : "raw");
 
             const std::string outputFile =
-                sys::Path::joinPaths(outputDir, filename);
+                sys::Path::joinPaths(outputDir, filename.str());
             io::FileOutputStream outputStream(outputFile);
 
             if (isSIO)
@@ -207,7 +204,7 @@ int main(int argc, char** argv)
                                    outputStream);
             }
 
-            Region region;
+            six::Region region;
             region.setStartRow(startRow);
             region.setStartCol(startCol);
             region.setNumCols(numCols);
@@ -216,8 +213,8 @@ int main(int argc, char** argv)
             {
                 region.setNumRows(numRows);
                 size_t totalBytes = nbpp * numCols * numRows;
-                const mem::ScopedArray<UByte>
-                    workBuffer(new UByte[totalBytes]);
+                const mem::ScopedArray<six::UByte>
+                    workBuffer(new six::UByte[totalBytes]);
                 region.setBuffer(workBuffer.get());
 
                 reader->interleaved(region, ii);
@@ -227,39 +224,40 @@ int main(int argc, char** argv)
             else
             {
                 region.setNumRows(1);
-                size_t nbpr = nbpp * width;
+                const size_t nbpr = nbpp * numCols;
 
                 // allocate this so we can reuse it for each row
-                const mem::ScopedArray<UByte> workBuffer(new UByte[nbpr]);
+                const mem::ScopedArray<six::UByte> workBuffer(new six::UByte[nbpr]);
                 region.setBuffer(workBuffer.get());
 
-                for (unsigned int jj = startRow;
+                for (size_t jj = startRow;
                      jj < numRows + startRow;
                      ++jj)
                 {
                     region.setStartRow(jj);
-                    UByte* line = reader->interleaved(region, ii);
+                    six::UByte* line = reader->interleaved(region, ii);
                     outputStream.write((const sys::byte*) line, nbpr);
                 }
             }
             outputStream.close();
             std::cout << "Wrote file: " << outputFile << std::endl;
         }
+
+        return 0;
     }
     catch (const except::Exception& e)
     {
-        std::cout << e.toString() << std::endl;
-        exit(1);
+        std::cerr << e.toString() << std::endl;
+        return 1;
     }
     catch (const std::exception& cppE)
     {
-        std::cout << "C++ exception: " << cppE.what() << std::endl;
-        exit(1);
+        std::cerr << "C++ exception: " << cppE.what() << std::endl;
+        return 1;
     }
     catch (...)
     {
-        std::cout << "Unknown exception" << std::endl;
-        exit(1);
+        std::cerr << "Unknown exception" << std::endl;
+        return 1;
     }
-    return 0;
 }

--- a/six/modules/c++/six/include/six/Types.h
+++ b/six/modules/c++/six/include/six/Types.h
@@ -267,9 +267,9 @@ struct LUT
 
     //!  Initialize with a number of entries and known output space
     LUT(size_t entries, size_t outputSpace) :
-        table(new unsigned char[entries * outputSpace]),
         numEntries(entries),
-        elementSize(outputSpace)
+        elementSize(outputSpace),
+        table(new unsigned char[entries * outputSpace])
     {
     }
 
@@ -277,9 +277,9 @@ struct LUT
     LUT(const unsigned char* interleavedLUT,
         size_t entries,
         size_t outputSpace) :
-        table(new unsigned char[entries * outputSpace]),
         numEntries(entries),
-        elementSize(outputSpace)
+        elementSize(outputSpace),
+        table(new unsigned char[entries * outputSpace])
     {
         memcpy(table.get(), interleavedLUT, numEntries * outputSpace);
     }


### PR DESCRIPTION
Fixed bug that occurred if you had a SIDD with two image segments with different sizes and didn't use --nr and --nc (previously -1 value was reserved which works fine with one image segment but then the first image segment's value was used for the second image segment).