### PR TITLE
Add getMultiPathVector() overloading that sends in a normal vector

### DIFF
--- a/six/modules/c++/scene/include/scene/SceneGeometry.h
+++ b/six/modules/c++/scene/include/scene/SceneGeometry.h
@@ -252,6 +252,8 @@ public:
 
     double getRotationAngle() const;
 
+    Vector3 getMultiPathVector(const Vector3& normalVec) const;
+
     Vector3 getMultiPathVector() const;
 
     /*

--- a/six/modules/c++/scene/source/SceneGeometry.cpp
+++ b/six/modules/c++/scene/source/SceneGeometry.cpp
@@ -273,11 +273,9 @@ double SceneGeometry::getRotationAngle() const
     return -getImageAngle(mRg * -1);
 }
 
-Vector3 SceneGeometry::getMultiPathVector() const
+Vector3 SceneGeometry::getMultiPathVector(const Vector3& normalVec) const
 {
-    const Vector3 opZ = getOPZVector();
-
-    const double scale = mXs.dot(opZ) / mZs.dot(opZ);
+    const double scale = mXs.dot(normalVec) / mZs.dot(normalVec);
     return mXs - (mZs * scale);
 }
 


### PR DESCRIPTION
Need a convenience overloading so we can send in the ground plane normal when we don't have a z OP vector