### PR TITLE
Add python samples

### DIFF
--- a/six/modules/python/scene/source/generated/scene.py
+++ b/six/modules/python/scene/source/generated/scene.py
@@ -1016,9 +1016,12 @@ class SceneGeometry(_object):
         return _scene.SceneGeometry_getRotationAngle(self)
 
 
-    def getMultiPathVector(self):
-        """getMultiPathVector(SceneGeometry self) -> Vector3"""
-        return _scene.SceneGeometry_getMultiPathVector(self)
+    def getMultiPathVector(self, *args):
+        """
+        getMultiPathVector(SceneGeometry self, Vector3 normalVec) -> Vector3
+        getMultiPathVector(SceneGeometry self) -> Vector3
+        """
+        return _scene.SceneGeometry_getMultiPathVector(self, *args)
 
 
     def getMultiPathAngle(self):

--- a/six/modules/python/scene/source/generated/scene_wrap.cxx
+++ b/six/modules/python/scene/source/generated/scene_wrap.cxx
@@ -14033,7 +14033,71 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_SceneGeometry_getMultiPathVector(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_SceneGeometry_getMultiPathVector__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  scene::SceneGeometry *arg1 = (scene::SceneGeometry *) 0 ;
+  scene::Vector3 *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  scene::Vector3 result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:SceneGeometry_getMultiPathVector",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_scene__SceneGeometry, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SceneGeometry_getMultiPathVector" "', argument " "1"" of type '" "scene::SceneGeometry const *""'"); 
+  }
+  arg1 = reinterpret_cast< scene::SceneGeometry * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_math__linear__VectorNT_3_double_t,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SceneGeometry_getMultiPathVector" "', argument " "2"" of type '" "scene::Vector3 const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "SceneGeometry_getMultiPathVector" "', argument " "2"" of type '" "scene::Vector3 const &""'"); 
+  }
+  arg2 = reinterpret_cast< scene::Vector3 * >(argp2);
+  {
+    try
+    {
+      result = ((scene::SceneGeometry const *)arg1)->getMultiPathVector((scene::Vector3 const &)*arg2);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_NewPointerObj((new scene::Vector3(static_cast< const scene::Vector3& >(result))), SWIGTYPE_p_math__linear__VectorNT_3_double_t, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SceneGeometry_getMultiPathVector__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   scene::SceneGeometry *arg1 = (scene::SceneGeometry *) 0 ;
   void *argp1 = 0 ;
@@ -14082,6 +14146,50 @@ SWIGINTERN PyObject *_wrap_SceneGeometry_getMultiPathVector(PyObject *SWIGUNUSED
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_SceneGeometry_getMultiPathVector(PyObject *self, PyObject *args) {
+  int argc;
+  PyObject *argv[3] = {
+    0
+  };
+  int ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? (int)PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 2) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_scene__SceneGeometry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_SceneGeometry_getMultiPathVector__SWIG_1(self, args);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_scene__SceneGeometry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_math__linear__VectorNT_3_double_t, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_SceneGeometry_getMultiPathVector__SWIG_0(self, args);
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'SceneGeometry_getMultiPathVector'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    scene::SceneGeometry::getMultiPathVector(scene::Vector3 const &) const\n"
+    "    scene::SceneGeometry::getMultiPathVector() const\n");
+  return 0;
 }
 
 
@@ -26070,7 +26178,10 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SceneGeometry_getOPSlopeAngle", _wrap_SceneGeometry_getOPSlopeAngle, METH_VARARGS, (char *)"SceneGeometry_getOPSlopeAngle(SceneGeometry self) -> double"},
 	 { (char *)"SceneGeometry_getAzimuthAngle", _wrap_SceneGeometry_getAzimuthAngle, METH_VARARGS, (char *)"SceneGeometry_getAzimuthAngle(SceneGeometry self) -> double"},
 	 { (char *)"SceneGeometry_getRotationAngle", _wrap_SceneGeometry_getRotationAngle, METH_VARARGS, (char *)"SceneGeometry_getRotationAngle(SceneGeometry self) -> double"},
-	 { (char *)"SceneGeometry_getMultiPathVector", _wrap_SceneGeometry_getMultiPathVector, METH_VARARGS, (char *)"SceneGeometry_getMultiPathVector(SceneGeometry self) -> Vector3"},
+	 { (char *)"SceneGeometry_getMultiPathVector", _wrap_SceneGeometry_getMultiPathVector, METH_VARARGS, (char *)"\n"
+		"getMultiPathVector(Vector3 normalVec) -> Vector3\n"
+		"SceneGeometry_getMultiPathVector(SceneGeometry self) -> Vector3\n"
+		""},
 	 { (char *)"SceneGeometry_getMultiPathAngle", _wrap_SceneGeometry_getMultiPathAngle, METH_VARARGS, (char *)"SceneGeometry_getMultiPathAngle(SceneGeometry self) -> double"},
 	 { (char *)"SceneGeometry_getOPGroundTrackAngle", _wrap_SceneGeometry_getOPGroundTrackAngle, METH_VARARGS, (char *)"SceneGeometry_getOPGroundTrackAngle(SceneGeometry self) -> double"},
 	 { (char *)"SceneGeometry_getOPAngle", _wrap_SceneGeometry_getOPAngle, METH_VARARGS, (char *)"SceneGeometry_getOPAngle(SceneGeometry self, Vector3 vec) -> double"},

--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -2808,6 +2808,14 @@ class SixSicdUtilities(_object):
         getWidebandData = staticmethod(getWidebandData)
     __swig_getmethods__["getWidebandData"] = lambda x: getWidebandData
 
+    def getGroundPlaneNormal(data):
+        """getGroundPlaneNormal(ComplexData data) -> Vector3"""
+        return _six_sicd.SixSicdUtilities_getGroundPlaneNormal(data)
+
+    if _newclass:
+        getGroundPlaneNormal = staticmethod(getGroundPlaneNormal)
+    __swig_getmethods__["getGroundPlaneNormal"] = lambda x: getGroundPlaneNormal
+
     def __init__(self):
         """__init__(six::sicd::Utilities self) -> SixSicdUtilities"""
         this = _six_sicd.new_SixSicdUtilities()
@@ -2846,6 +2854,10 @@ def SixSicdUtilities_getWidebandData(*args):
     SixSicdUtilities_getWidebandData(std::string const & sicdPathname, VectorString schemaPaths, ComplexData complexData, RowColSizeT offset, RowColSizeT extent, std::complex< float > * buffer)
     """
     return _six_sicd.SixSicdUtilities_getWidebandData(*args)
+
+def SixSicdUtilities_getGroundPlaneNormal(data):
+    """SixSicdUtilities_getGroundPlaneNormal(ComplexData data) -> Vector3"""
+    return _six_sicd.SixSicdUtilities_getGroundPlaneNormal(data)
 
 class StdAutoCollectionInformation(_object):
     """Proxy of C++ std::auto_ptr<(six::sicd::CollectionInformation)> class"""

--- a/six/modules/python/six.sicd/tests/sicd_ground_to_pixel.py
+++ b/six/modules/python/six.sicd/tests/sicd_ground_to_pixel.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+#
+# =========================================================================
+# This file is part of six.sicd-python
+# =========================================================================
+#
+# (C) Copyright 2004 - 2016, MDA Information Systems LLC
+#
+# six.sicd-python is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; If not,
+# see <http://www.gnu.org/licenses/>.
+#
+
+# Simple program which takes in a SICD and ground point location and provides the
+# corresponding pixel row,col in the SICD
+# Ground point location can be provided in lat/lon, lat/lon/alt, or ECEF
+
+import sys, os, argparse, pdb
+from coda.math_linear import *
+from pysix import scene, six_base, six_sicd
+
+if __name__ == '__main__':
+    # Parse the command line
+    parser = argparse.ArgumentParser(description=
+    """Convert a scene (ground) point to a pixel location in a SICD.  Input can
+       be lat/lon (in which case the SCP's altitude will be used), lat/lon/alt, 
+       or ECEF.""")
+
+    parser.add_argument('--lat', help='Latitude', type=float)
+    parser.add_argument('--lon', help='Longitude', type=float)
+    parser.add_argument('--alt', help='Altitude in meters', type=float)
+    parser.add_argument('--ecef', nargs=3, help='ECEF meters <x y z>', type=float)
+    parser.add_argument('--sicd', help='SICD NITF pathname', required=True)
+    parser.add_argument('--schema', 
+        help="""Schema directory.  Required if SIX_SCHEMA_PATH environment
+                variable is not set.""")
+
+    args = parser.parse_args()
+    
+    # Set the schema paths
+    # Try to use the environment variable if we've got it
+    schemaPath = os.getenv('SIX_SCHEMA_PATH', args.schema)
+    if schemaPath == None:
+        sys.exit('If SIX_SCHEMA_PATH environment variable is not set, schema ' + 
+                 'dir must be passed in')
+    schemaPaths = six_base.VectorString()
+    schemaPaths.push_back(schemaPath)
+
+    # Read in the XML portion of the SICD
+    complexData = six_sicd.getComplexData(args.sicd, schemaPaths)
+
+    # Derive geometry info from this
+    geom = six_sicd.SixSicdUtilities.getSceneGeometry(complexData)
+    projModel = six_sicd.SixSicdUtilities.getProjectionModel(complexData, geom)
+    
+    # To actually call sceneToImage(), we need ECEF
+    # So if they gave us lat/lon, we need to convert
+    if args.lat != None:
+        alt = args.alt
+        if alt == None:
+            # We don't have an altitude so use the height at the reference point
+            alt = scene.Utilities.ecefToLatLon(geom.getReferencePosition()).getAlt()
+            print("Using SCP's height of %f meters" % alt)
+        latLonAlt = scene.LatLonAlt(args.lat, args.lon, alt)
+        groundPt = scene.Utilities.latLonToECEF(latLonAlt)
+    else:    
+        groundPt = coda.math_linear.Vector3()
+        for idx, val in enumerate(args.ecef):
+            groundPt[idx] = val
+    
+    # Convert to image coordinates
+    # This is in meters from the SCP
+    imagePt = projModel.sceneToImage(groundPt)
+    
+    # Convert to pixel coordinates
+    pixelRow = imagePt.row / complexData.grid.row.sampleSpacing + \
+            complexData.imageData.scpPixel.row - complexData.imageData.firstRow
+
+    pixelCol = imagePt.col / complexData.grid.col.sampleSpacing + \
+            complexData.imageData.scpPixel.col - complexData.imageData.firstCol
+
+    print("Row = %f, Col = %f" % (pixelRow, pixelCol))

--- a/six/modules/python/six.sicd/tests/sicd_pixel_to_ground.py
+++ b/six/modules/python/six.sicd/tests/sicd_pixel_to_ground.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+#
+# =========================================================================
+# This file is part of six.sicd-python
+# =========================================================================
+#
+# (C) Copyright 2004 - 2016, MDA Information Systems LLC
+#
+# six.sicd-python is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; If not,
+# see <http://www.gnu.org/licenses/>.
+#
+
+# Simple program which takes in a SICD and ground point location and provides the
+# corresponding pixel row,col in the SICD
+# Ground point location can be provided in lat/lon, lat/lon/alt, or ECEF
+
+import sys, os, argparse
+from coda.math_linear import *
+from coda.coda_types import *
+from pysix import scene, six_base, six_sicd
+
+if __name__ == '__main__':
+    # Parse the command line
+    parser = argparse.ArgumentParser(description=
+    """Convert a pixel location in a SICD to a scene (ground) point in 
+       lat/lon/alt and ECEF""")
+
+    parser.add_argument('--row', help='Image row (pixels)', type=float, required=True)
+    parser.add_argument('--col', help='Image col (pixels) ', type=float, required=True)
+    parser.add_argument('--alt', help='Altitude (meters)', type=float)
+    parser.add_argument('--sicd', help='SICD NITF pathname', required=True)
+    parser.add_argument('--schema', 
+        help="""Schema directory.  Required if SIX_SCHEMA_PATH environment
+                variable is not set.""")
+
+    args = parser.parse_args()
+    
+    # Set the schema paths
+    # Try to use the environment variable if we've got it
+    schemaPath = os.getenv('SIX_SCHEMA_PATH', args.schema)
+    if schemaPath == None:
+        sys.exit('If SIX_SCHEMA_PATH environment variable is not set, schema ' + 
+                 'dir must be passed in')
+    schemaPaths = six_base.VectorString()
+    schemaPaths.push_back(schemaPath)
+
+    # Read in the XML portion of the SICD
+    complexData = six_sicd.getComplexData(args.sicd, schemaPaths)
+
+    # Derive geometry info from this
+    geom = six_sicd.SixSicdUtilities.getSceneGeometry(complexData)
+    projModel = six_sicd.SixSicdUtilities.getProjectionModel(complexData, geom)
+
+    # Convert pixel location to meters from SCP
+    pixelLoc = coda.coda_types.RowColDouble(args.row, args.col)
+    imagePt = complexData.pixelToImagePoint(pixelLoc)
+
+    # Project to the ground plane
+    # We do this differently based on if we know the altitude or not
+    if args.alt:
+        groundPt = projModel.imageToScene(imagePt, args.alt)
+    else:
+        # Get the ground plane normal
+        # If the SICD defines an output plane, we'll base it on this
+        # Otherwise we'll use the ETP
+        groundPlaneNormal = six_sicd.SixSicdUtilities.getGroundPlaneNormal(complexData)
+    
+        groundPt = projModel.imageToScene(imagePt, geom.getReferencePosition(),
+                                          groundPlaneNormal)
+
+    print('ECEF (meters): %f %f %f' % (groundPt[0], groundPt[1], groundPt[2]))
+
+    # Convert to lat/lon/alt
+    latLonAlt = scene.Utilities.ecefToLatLon(groundPt)
+    print('Lat: %f  Lon: %f  Alt (m): %f' %
+          (latLonAlt.getLat(), latLonAlt.getLon(), latLonAlt.getAlt()))


### PR DESCRIPTION
* Added `getMultiPathVector()` and `six::sicd::Utilities::getGroundPlaneNormal()` to generated Python bindings that are checked in
* Updated `image_to_scene.cpp` to account for AOI'd SICDs properly and to use `getGroundPlaneNormal()` to use SICD output plane when available
* Added Python scripts to convert from SICD pixel to ECEF and vice versa

@chvink @JonathanMeans 