### PR TITLE
Add functions to simplify converting from ComplexData to/from string

### DIFF
--- a/six/modules/c++/cphd/unittests/test_vbm.cpp
+++ b/six/modules/c++/cphd/unittests/test_vbm.cpp
@@ -29,10 +29,11 @@ static const size_t NUM_VECTORS = 7;
 
 namespace
 {
+// [-1000, 1000]
 double getRandom()
 {
-    double r = static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
-    return -1000.0  + r * (1000.0 + 1000.0), 2;
+    const double r = static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
+    return -1000.0  + r * 2000.0;
 }
 
 cphd::Vector3 getRandomVector3()

--- a/six/modules/c++/samples/check_valid_six.cpp
+++ b/six/modules/c++/samples/check_valid_six.cpp
@@ -152,10 +152,10 @@ int main(int argc, char** argv)
                         NITF_VER_UNKNOWN)
                 {
                     // Assume it's just a text file containing XML
-                    six::parseData(xmlRegistry,
-                                   inputPathname,
-                                   schemaPaths,
-                                   *log);
+                    six::parseDataFromFile(xmlRegistry,
+                                           inputPathname,
+                                           schemaPaths,
+                                           *log);
                 }
                 else
                 {

--- a/six/modules/c++/samples/test_six_xml_parsing.cpp
+++ b/six/modules/c++/samples/test_six_xml_parsing.cpp
@@ -115,10 +115,10 @@ void XMLVerifier::verify(const std::string& pathname) const
     inStream.write(reinterpret_cast<const sys::byte*>(inStr.c_str()),
                    inStr.length());
 
-    std::auto_ptr<six::Data> data(six::parseData(mXmlRegistry,
-                                                 pathname,
-                                                 mSchemaPaths,
-                                                 mLog));
+    std::auto_ptr<six::Data> data(six::parseDataFromFile(mXmlRegistry,
+                                                         pathname,
+                                                         mSchemaPaths,
+                                                         mLog));
 
     // Write it back out - this verifies both that the XML we write validates
     // against the schema and that our parser writes it without errors
@@ -148,7 +148,7 @@ void XMLVerifier::verify(const std::string& pathname) const
 
     // Now re-read the output and make sure the Data objects
     // are equal.
-    std::auto_ptr<six::Data> readData(six::parseData(mXmlRegistry,
+    std::auto_ptr<six::Data> readData(six::parseDataFromFile(mXmlRegistry,
         roundTrippedPath,
         mSchemaPaths,
         mLog));

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -251,6 +251,50 @@ public:
     * \return the unit vector normal to the ground plane
     */
     static Vector3 getGroundPlaneNormal(const ComplexData& data);
+
+    /*
+     * Parses the XML in 'xmlStream' and converts it into a ComplexData object.
+     * Throws if the underlying type is not complex.
+     *
+     * \param xmlStream Input stream containing XML
+     * \param schemaPaths Schema path(s)
+     * \param log Logger
+     *
+     * \return Data representation of 'xmlStr'
+     */
+    static std::auto_ptr<ComplexData> parseData(
+            ::io::InputStream& xmlStream,
+            const std::vector<std::string>& schemaPaths,
+            logging::Logger& log);
+
+    /*
+     * Parses the XML in 'pathname' and converts it into a ComplexData object.
+     * Throws if the underlying type is not complex.
+     *
+     * \param pathname File containing plain text XML (not a NITF)
+     * \param schemaPaths Schema path(s)
+     * \param log Logger
+     *
+     * \return Data representation of the contents of 'pathname'
+     */
+    static std::auto_ptr<ComplexData> parseDataFromFile(
+            const std::string& pathname,
+            const std::vector<std::string>& schemaPaths,
+            logging::Logger& log);
+
+    /*
+     * Parses the XML in 'xmlStr' and converts it into a ComplexData object.
+     *
+     * \param xmlStr XML document as a string
+     * \param schemaPaths Schema path(s)
+     * \param log Logger
+     *
+     * \return Data representation of 'xmlStr'
+     */
+    std::auto_ptr<ComplexData> parseDataFromString(
+        const std::string& xmlStr,
+        const std::vector<std::string>& schemaPaths,
+        logging::Logger& log);
 };
 }
 }

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -291,10 +291,26 @@ public:
      *
      * \return Data representation of 'xmlStr'
      */
-    std::auto_ptr<ComplexData> parseDataFromString(
+    static std::auto_ptr<ComplexData> parseDataFromString(
         const std::string& xmlStr,
         const std::vector<std::string>& schemaPaths,
         logging::Logger& log);
+
+    /*
+     * Converts 'data' back into a formatted XML string
+     *
+     * \param data Representation of SICD data
+     * \param schemaPaths Schema paths.  If empty, the SIX_SCHEMA_PATH
+     * environment variable will be used.
+     * \param logger Logger.  If NULL, no logger will be used.
+     *
+     * \return XML string representation of 'data'
+     */
+    static std::string toXMLString(
+    		const ComplexData& data,
+			const std::vector<std::string>& schemaPaths =
+					std::vector<std::string>(),
+			logging::Logger* logger = NULL);
 };
 }
 }

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -307,10 +307,10 @@ public:
      * \return XML string representation of 'data'
      */
     static std::string toXMLString(
-    		const ComplexData& data,
-			const std::vector<std::string>& schemaPaths =
-					std::vector<std::string>(),
-			logging::Logger* logger = NULL);
+            const ComplexData& data,
+            const std::vector<std::string>& schemaPaths =
+                    std::vector<std::string>(),
+            logging::Logger* logger = NULL);
 };
 }
 }

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -545,5 +545,20 @@ std::auto_ptr<ComplexData> Utilities::parseDataFromString(
     inStream.write(xmlStr);
     return parseData(inStream, schemaPaths, log);
 }
+
+std::string Utilities::toXMLString(const ComplexData& data,
+                                   const std::vector<std::string>& schemaPaths,
+                                   logging::Logger* logger)
+{
+    XMLControlRegistry xmlRegistry;
+    xmlRegistry.addCreator(DataType::COMPLEX,
+                           new XMLControlCreatorT<ComplexXMLControl>());
+
+    logging::NullLogger nullLogger;
+    return ::six::toValidXMLString(&data,
+    		                       schemaPaths,
+								   (logger == NULL) ? &nullLogger : logger,
+					               &xmlRegistry);
+}
 }
 }

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include <io/StringStream.h>
 #include <six/Utilities.h>
 #include <six/NITFReadControl.h>
 #include <six/sicd/ComplexXMLControl.h>
@@ -507,6 +508,42 @@ Vector3 Utilities::getGroundPlaneNormal(const ComplexData& data)
 
     return groundPlaneNormal.unit();
 }
-}
+
+std::auto_ptr<ComplexData> Utilities::parseData(
+        ::io::InputStream& xmlStream,
+        const std::vector<std::string>& schemaPaths,
+        logging::Logger& log)
+{
+    XMLControlRegistry xmlRegistry;
+    xmlRegistry.addCreator(DataType::COMPLEX,
+                           new XMLControlCreatorT<ComplexXMLControl>());
+
+    std::auto_ptr<Data> data(six::parseData(
+            xmlRegistry, xmlStream, schemaPaths, log));
+
+     std::auto_ptr<ComplexData> complexData(reinterpret_cast<ComplexData*>(
+             data.release()));
+
+     return complexData;
 }
 
+std::auto_ptr<ComplexData> Utilities::parseDataFromFile(
+        const std::string& pathname,
+        const std::vector<std::string>& schemaPaths,
+        logging::Logger& log)
+{
+    io::FileInputStream inStream(pathname);
+    return parseData(inStream, schemaPaths, log);
+}
+
+std::auto_ptr<ComplexData> Utilities::parseDataFromString(
+    const std::string& xmlStr,
+    const std::vector<std::string>& schemaPaths,
+    logging::Logger& log)
+{
+    io::StringStream inStream;
+    inStream.write(xmlStr);
+    return parseData(inStream, schemaPaths, log);
+}
+}
+}

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -556,9 +556,9 @@ std::string Utilities::toXMLString(const ComplexData& data,
 
     logging::NullLogger nullLogger;
     return ::six::toValidXMLString(&data,
-    		                       schemaPaths,
-								   (logger == NULL) ? &nullLogger : logger,
-					               &xmlRegistry);
+                                   schemaPaths,
+                                   (logger == NULL) ? &nullLogger : logger,
+                                   &xmlRegistry);
 }
 }
 }

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -169,16 +169,121 @@ template<> std::string toString(const six::LatLonCorners& corners);
 // Load the TRE plugins in the given directory
 void loadPluginDir(const std::string& pluginDir);
 
+/*
+ * Parses the XML in 'xmlStream' and converts it into a Data object
+ *
+ * \param xmlReg XML registry
+ * \param xmlStream Input stream containing XML
+ * \param dataType Complex vs. Derived.  If the resulting object is not the
+ * expected type, throw.  To avoid this check, set to NOT_SET.
+ * \param schemaPaths Schema path(s)
+ * \param log Logger
+ *
+ * \return Data representation of 'xmlStream'
+ */
 std::auto_ptr<Data> parseData(const XMLControlRegistry& xmlReg, 
                               ::io::InputStream& xmlStream, 
                               DataType dataType,
                               const std::vector<std::string>& schemaPaths,
                               logging::Logger& log);
 
+/*
+ * Parses the XML in 'xmlStream' and converts it into a Data object.  Same as
+ * above but doesn't require the data type to be known in advance.
+ *
+ * \param xmlReg XML registry
+ * \param xmlStream Input stream containing XML
+ * \param schemaPaths Schema path(s)
+ * \param log Logger
+ *
+ * \return Data representation of 'xmlStream'
+ */
+inline
 std::auto_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
+                              ::io::InputStream& xmlStream,
+                              const std::vector<std::string>& schemaPaths,
+                              logging::Logger& log)
+{
+    return parseData(xmlReg, xmlStream, DataType::NOT_SET, schemaPaths, log);
+}
+
+/*
+ * Parses the XML in 'pathname' and converts it into a Data object.
+ *
+ * \param xmlReg XML registry
+ * \param pathname File containing plain text XML (not a NITF)
+ * \param dataType Complex vs. Derived.  If the resulting object is not the
+ * expected type, throw.  To avoid this check, set to NOT_SET.
+ * \param schemaPaths Schema path(s)
+ * \param log Logger
+ *
+ * \return Data representation of the contents of 'pathname'
+ */
+std::auto_ptr<Data> parseDataFromFile(const XMLControlRegistry& xmlReg,
     const std::string& pathname,
+    DataType dataType,
     const std::vector<std::string>& schemaPaths,
     logging::Logger& log);
+
+/*
+ * Parses the XML in 'pathname' and converts it into a Data object.  Same as
+ * above but doesn't require the data type to be known in advance.
+ *
+ * \param xmlReg XML registry
+ * \param pathname File containing plain text XML (not a NITF)
+ * \param schemaPaths Schema path(s)
+ * \param log Logger
+ *
+ * \return Data representation of the contents of 'pathname'
+ */
+inline
+std::auto_ptr<Data> parseDataFromFile(const XMLControlRegistry& xmlReg,
+    const std::string& pathname,
+    const std::vector<std::string>& schemaPaths,
+    logging::Logger& log)
+{
+    return parseDataFromFile(xmlReg, pathname, DataType::NOT_SET, schemaPaths,
+                             log);
+}
+
+/*
+ * Parses the XML in 'xmlStr' and converts it into a Data object.
+ *
+ * \param xmlReg XML registry
+ * \param xmlStr XML document as a string
+ * \param dataType Complex vs. Derived.  If the resulting object is not the
+ * expected type, throw.  To avoid this check, set to NOT_SET.
+ * \param schemaPaths Schema path(s)
+ * \param log Logger
+ *
+ * \return Data representation of 'xmlStr'
+ */
+std::auto_ptr<Data> parseDataFromString(const XMLControlRegistry& xmlReg,
+    const std::string& xmlStr,
+    DataType dataType,
+    const std::vector<std::string>& schemaPaths,
+    logging::Logger& log);
+
+/*
+ * Parses the XML in 'xmlStr' and converts it into a Data object.  Same as
+ * above but doesn't require the data type to be known in advance.
+ *
+ * \param xmlReg XML registry
+ * \param xmlStr XML document as a string
+ * \param schemaPaths Schema path(s)
+ * \param log Logger
+ *
+ * \return Data representation of 'xmlStr'
+ */
+inline
+std::auto_ptr<Data> parseDataFromString(const XMLControlRegistry& xmlReg,
+    const std::string& xmlStr,
+    const std::vector<std::string>& schemaPaths,
+    logging::Logger& log)
+{
+    return parseDataFromString(xmlReg, xmlStr, DataType::NOT_SET, schemaPaths,
+                               log);
+}
 
 void getErrors(const ErrorStatistics* errorStats,
                const types::RgAz<double>& sampleSpacing,

--- a/six/modules/c++/six/include/six/XMLControlFactory.h
+++ b/six/modules/c++/six/include/six/XMLControlFactory.h
@@ -158,7 +158,7 @@ std::string toXMLString(const Data* data,
                         const XMLControlRegistry *xmlRegistry = NULL);
 
 /*!
- *  Additonally performs schema validation --
+ *  Additionally performs schema validation --
  *  This function must must receive a valid logger to print validation errors
  */
 std::string toValidXMLString(

--- a/six/modules/c++/six/source/Utilities.cpp
+++ b/six/modules/c++/six/source/Utilities.cpp
@@ -1055,7 +1055,7 @@ std::auto_ptr<Data> six::parseData(const XMLControlRegistry& xmlReg,
     else
         throw except::Exception(Ctxt("Unexpected XML type"));
     
-    //! Only SIDDs can have mismatch types
+    //! Only SIDDs can have mismatched types
     if (dataType == DataType::COMPLEX && dataType != xmlDataType)
     {
         throw except::Exception(Ctxt("Unexpected SIDD DES in SICD"));
@@ -1068,47 +1068,25 @@ std::auto_ptr<Data> six::parseData(const XMLControlRegistry& xmlReg,
     return std::auto_ptr<Data>(xmlControl->fromXML(doc, schemaPaths));
 }
 
-// In this case, we don't want to have to
-// know if it's complex vs. derived before this call
-std::auto_ptr<Data> six::parseData(const XMLControlRegistry& xmlReg,
+std::auto_ptr<Data> six::parseDataFromFile(const XMLControlRegistry& xmlReg,
     const std::string& pathname,
+    DataType dataType,
     const std::vector<std::string>& schemaPaths,
     logging::Logger& log)
 {
-    xml::lite::MinidomParser xmlParser;
-    xmlParser.preserveCharacterData(true);
     io::FileInputStream inStream(pathname);
-    try
-    {
-        xmlParser.parse(inStream);
-    }
-    catch (const except::Throwable& ex)
-    {
-        throw except::Exception(ex, Ctxt("Invalid XML data"));
-    }
-    const xml::lite::Document* const doc = xmlParser.getDocument();
+    return parseData(xmlReg, inStream, dataType, schemaPaths, log);
+}
 
-    //! Check the root localName for the XML type
-    const std::string xmlType = doc->getRootElement()->getLocalName();
-    DataType xmlDataType;
-    if (str::startsWith(xmlType, "SICD"))
-    {
-        xmlDataType = DataType::COMPLEX;
-    }
-    else if (str::startsWith(xmlType, "SIDD"))
-    {
-        xmlDataType = DataType::DERIVED;
-    }
-    else
-    {
-        throw except::Exception(Ctxt("Unexpected XML type"));
-    }
-
-    //! Create the correct type of XMLControl
-    const std::auto_ptr<six::XMLControl>
-        xmlControl(xmlReg.newXMLControl(xmlDataType, &log));
-
-    return std::auto_ptr<Data>(xmlControl->fromXML(doc, schemaPaths));
+std::auto_ptr<Data> six::parseDataFromString(const XMLControlRegistry& xmlReg,
+    const std::string& xmlStr,
+    DataType dataType,
+    const std::vector<std::string>& schemaPaths,
+    logging::Logger& log)
+{
+    io::StringStream inStream;
+    inStream.write(xmlStr);
+    return parseData(xmlReg, inStream, dataType, schemaPaths, log);
 }
 
 void six::getErrors(const ErrorStatistics* errorStats,

--- a/six/modules/python/cphd/source/cphd.i
+++ b/six/modules/python/cphd/source/cphd.i
@@ -24,8 +24,8 @@
 
 %feature("autodoc", "1");
 
-%include "std_string.i"
-%include "std_vector.i"
+%include <std_string.i>
+%include <std_vector.i>
 
 %import "sys.i"
 %import "types.i"
@@ -39,6 +39,7 @@
 %{
 #include "import/cphd.h"
 #include "import/six.h"
+#include "import/six/sicd.h"
 using six::Vector3;
 %}
 %ignore cphd::CPHDXMLControl::toXML(const Metadata& metadata);
@@ -203,5 +204,3 @@ SCOPED_COPYABLE(cphd,AreaPlane);
 SCOPED_COPYABLE(cphd,FxParameters);
 SCOPED_COPYABLE(cphd,TOAParameters);
 SCOPED_COPYABLE_RENAME(cphd,Antenna,CphdAntenna);
-
-

--- a/six/modules/python/cphd/source/generated/cphd_wrap.cxx
+++ b/six/modules/python/cphd/source/generated/cphd_wrap.cxx
@@ -3027,65 +3027,67 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__TOAParameters_t swig_types[54]
 #define SWIGTYPE_p_mem__SharedPtrT_io__SeekableInputStream_t swig_types[55]
 #define SWIGTYPE_p_mem__SharedPtrT_logging__Logger_t swig_types[56]
-#define SWIGTYPE_p_nitf__DateTime swig_types[57]
-#define SWIGTYPE_p_off_t swig_types[58]
-#define SWIGTYPE_p_p_PyObject swig_types[59]
-#define SWIGTYPE_p_pid_t swig_types[60]
-#define SWIGTYPE_p_scene__AngleMagnitude swig_types[61]
-#define SWIGTYPE_p_scene__FrameType swig_types[62]
-#define SWIGTYPE_p_scene__LatLon swig_types[63]
-#define SWIGTYPE_p_scene__LatLonAlt swig_types[64]
-#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[65]
-#define SWIGTYPE_p_six__BooleanType swig_types[66]
-#define SWIGTYPE_p_six__CollectType swig_types[67]
-#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[68]
-#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[69]
-#define SWIGTYPE_p_six__Data swig_types[70]
-#define SWIGTYPE_p_six__DataType swig_types[71]
-#define SWIGTYPE_p_six__FFTSign swig_types[72]
-#define SWIGTYPE_p_six__RadarModeType swig_types[73]
-#define SWIGTYPE_p_six__ReferencePoint swig_types[74]
-#define SWIGTYPE_p_six__sicd__AntennaParameters swig_types[75]
-#define SWIGTYPE_p_six__sicd__AreaDirectionParameters swig_types[76]
-#define SWIGTYPE_p_six__sicd__CollectionInformation swig_types[77]
-#define SWIGTYPE_p_six__sicd__ComplexData swig_types[78]
-#define SWIGTYPE_p_six__sicd__ElectricalBoresight swig_types[79]
-#define SWIGTYPE_p_six__sicd__GainAndPhasePolys swig_types[80]
-#define SWIGTYPE_p_six__sicd__HalfPowerBeamwidths swig_types[81]
-#define SWIGTYPE_p_size_t swig_types[82]
-#define SWIGTYPE_p_size_type swig_types[83]
-#define SWIGTYPE_p_ssize_t swig_types[84]
-#define SWIGTYPE_p_std__allocatorT_cphd__ArraySize_t swig_types[85]
-#define SWIGTYPE_p_std__allocatorT_cphd__ChannelParameters_t swig_types[86]
-#define SWIGTYPE_p_std__allocatorT_math__linear__VectorNT_3_double_t_t swig_types[87]
-#define SWIGTYPE_p_std__allocatorT_six__sicd__AntennaParameters_t swig_types[88]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__Antenna_t swig_types[89]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__DwellTimeParameters_t swig_types[90]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__FxParameters_t swig_types[91]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__TOAParameters_t swig_types[92]
-#define SWIGTYPE_p_std__invalid_argument swig_types[93]
-#define SWIGTYPE_p_std__ostream swig_types[94]
-#define SWIGTYPE_p_std__vectorT_cphd__ArraySize_std__allocatorT_cphd__ArraySize_t_t swig_types[95]
-#define SWIGTYPE_p_std__vectorT_cphd__ChannelParameters_std__allocatorT_cphd__ChannelParameters_t_t swig_types[96]
-#define SWIGTYPE_p_std__vectorT_math__linear__VectorNT_3_double_t_std__allocatorT_math__linear__VectorNT_3_double_t_t_t swig_types[97]
-#define SWIGTYPE_p_std__vectorT_math__poly__OneDT_Vector3_t_std__allocatorT_math__poly__OneDT_Vector3_t_t_t swig_types[98]
-#define SWIGTYPE_p_std__vectorT_six__sicd__AntennaParameters_std__allocatorT_six__sicd__AntennaParameters_t_t swig_types[99]
-#define SWIGTYPE_p_std__vectorT_unsigned_char_std__allocatorT_unsigned_char_t_t swig_types[100]
-#define SWIGTYPE_p_std__vectorT_void_const_p_std__allocatorT_void_const_p_t_t swig_types[101]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[102]
-#define SWIGTYPE_p_types__RowColT_double_t swig_types[103]
-#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[104]
-#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[105]
-#define SWIGTYPE_p_types__RowColT_size_t_t swig_types[106]
-#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[107]
-#define SWIGTYPE_p_uint16_t swig_types[108]
-#define SWIGTYPE_p_uint32_t swig_types[109]
-#define SWIGTYPE_p_uint64_t swig_types[110]
-#define SWIGTYPE_p_uint8_t swig_types[111]
-#define SWIGTYPE_p_unsigned_char swig_types[112]
-#define SWIGTYPE_p_value_type swig_types[113]
-static swig_type_info *swig_types[115];
-static swig_module_info swig_module = {swig_types, 114, 0, 0, 0, 0};
+#define SWIGTYPE_p_mt__SingletonT_six__XMLControlRegistry_true_t swig_types[57]
+#define SWIGTYPE_p_nitf__DateTime swig_types[58]
+#define SWIGTYPE_p_off_t swig_types[59]
+#define SWIGTYPE_p_p_PyObject swig_types[60]
+#define SWIGTYPE_p_pid_t swig_types[61]
+#define SWIGTYPE_p_scene__AngleMagnitude swig_types[62]
+#define SWIGTYPE_p_scene__FrameType swig_types[63]
+#define SWIGTYPE_p_scene__LatLon swig_types[64]
+#define SWIGTYPE_p_scene__LatLonAlt swig_types[65]
+#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[66]
+#define SWIGTYPE_p_six__BooleanType swig_types[67]
+#define SWIGTYPE_p_six__CollectType swig_types[68]
+#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[69]
+#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[70]
+#define SWIGTYPE_p_six__Data swig_types[71]
+#define SWIGTYPE_p_six__DataType swig_types[72]
+#define SWIGTYPE_p_six__FFTSign swig_types[73]
+#define SWIGTYPE_p_six__RadarModeType swig_types[74]
+#define SWIGTYPE_p_six__ReferencePoint swig_types[75]
+#define SWIGTYPE_p_six__XMLControlCreator swig_types[76]
+#define SWIGTYPE_p_six__sicd__AntennaParameters swig_types[77]
+#define SWIGTYPE_p_six__sicd__AreaDirectionParameters swig_types[78]
+#define SWIGTYPE_p_six__sicd__CollectionInformation swig_types[79]
+#define SWIGTYPE_p_six__sicd__ComplexData swig_types[80]
+#define SWIGTYPE_p_six__sicd__ElectricalBoresight swig_types[81]
+#define SWIGTYPE_p_six__sicd__GainAndPhasePolys swig_types[82]
+#define SWIGTYPE_p_six__sicd__HalfPowerBeamwidths swig_types[83]
+#define SWIGTYPE_p_size_t swig_types[84]
+#define SWIGTYPE_p_size_type swig_types[85]
+#define SWIGTYPE_p_ssize_t swig_types[86]
+#define SWIGTYPE_p_std__allocatorT_cphd__ArraySize_t swig_types[87]
+#define SWIGTYPE_p_std__allocatorT_cphd__ChannelParameters_t swig_types[88]
+#define SWIGTYPE_p_std__allocatorT_math__linear__VectorNT_3_double_t_t swig_types[89]
+#define SWIGTYPE_p_std__allocatorT_six__sicd__AntennaParameters_t swig_types[90]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__Antenna_t swig_types[91]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__DwellTimeParameters_t swig_types[92]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__FxParameters_t swig_types[93]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__TOAParameters_t swig_types[94]
+#define SWIGTYPE_p_std__invalid_argument swig_types[95]
+#define SWIGTYPE_p_std__ostream swig_types[96]
+#define SWIGTYPE_p_std__vectorT_cphd__ArraySize_std__allocatorT_cphd__ArraySize_t_t swig_types[97]
+#define SWIGTYPE_p_std__vectorT_cphd__ChannelParameters_std__allocatorT_cphd__ChannelParameters_t_t swig_types[98]
+#define SWIGTYPE_p_std__vectorT_math__linear__VectorNT_3_double_t_std__allocatorT_math__linear__VectorNT_3_double_t_t_t swig_types[99]
+#define SWIGTYPE_p_std__vectorT_math__poly__OneDT_Vector3_t_std__allocatorT_math__poly__OneDT_Vector3_t_t_t swig_types[100]
+#define SWIGTYPE_p_std__vectorT_six__sicd__AntennaParameters_std__allocatorT_six__sicd__AntennaParameters_t_t swig_types[101]
+#define SWIGTYPE_p_std__vectorT_unsigned_char_std__allocatorT_unsigned_char_t_t swig_types[102]
+#define SWIGTYPE_p_std__vectorT_void_const_p_std__allocatorT_void_const_p_t_t swig_types[103]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[104]
+#define SWIGTYPE_p_types__RowColT_double_t swig_types[105]
+#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[106]
+#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[107]
+#define SWIGTYPE_p_types__RowColT_size_t_t swig_types[108]
+#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[109]
+#define SWIGTYPE_p_uint16_t swig_types[110]
+#define SWIGTYPE_p_uint32_t swig_types[111]
+#define SWIGTYPE_p_uint64_t swig_types[112]
+#define SWIGTYPE_p_uint8_t swig_types[113]
+#define SWIGTYPE_p_unsigned_char swig_types[114]
+#define SWIGTYPE_p_value_type swig_types[115]
+static swig_type_info *swig_types[117];
+static swig_module_info swig_module = {swig_types, 116, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -52735,6 +52737,7 @@ static swig_type_info _swigt__p_mem__ScopedCopyablePtrT_cphd__FxParameters_t = {
 static swig_type_info _swigt__p_mem__ScopedCopyablePtrT_cphd__TOAParameters_t = {"_p_mem__ScopedCopyablePtrT_cphd__TOAParameters_t", "mem::ScopedCopyablePtr< cphd::TOAParameters > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mem__SharedPtrT_io__SeekableInputStream_t = {"_p_mem__SharedPtrT_io__SeekableInputStream_t", "mem::SharedPtr< io::SeekableInputStream > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mem__SharedPtrT_logging__Logger_t = {"_p_mem__SharedPtrT_logging__Logger_t", "mem::SharedPtr< logging::Logger > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mt__SingletonT_six__XMLControlRegistry_true_t = {"_p_mt__SingletonT_six__XMLControlRegistry_true_t", "six::XMLControlFactory *|mt::Singleton< six::XMLControlRegistry,true > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf__DateTime = {"_p_nitf__DateTime", "nitf::DateTime *|six::DateTime *|cphd::DateTime *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_off_t = {"_p_off_t", "off_t *|sys::Off_T *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_p_PyObject = {"_p_p_PyObject", "PyObject **", 0, 0, (void*)0, 0};
@@ -52753,6 +52756,7 @@ static swig_type_info _swigt__p_six__DataType = {"_p_six__DataType", "six::DataT
 static swig_type_info _swigt__p_six__FFTSign = {"_p_six__FFTSign", "six::FFTSign *|cphd::FFTSign *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__RadarModeType = {"_p_six__RadarModeType", "six::RadarModeType *|cphd::RadarModeType *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__ReferencePoint = {"_p_six__ReferencePoint", "six::ReferencePoint *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_six__XMLControlCreator = {"_p_six__XMLControlCreator", "six::XMLControlCreator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__AntennaParameters = {"_p_six__sicd__AntennaParameters", "std::vector< six::sicd::AntennaParameters >::value_type *|six::sicd::AntennaParameters *|cphd::AntennaParameters *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__AreaDirectionParameters = {"_p_six__sicd__AreaDirectionParameters", "six::sicd::AreaDirectionParameters *|cphd::AreaDirectionParameters *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__CollectionInformation = {"_p_six__sicd__CollectionInformation", "six::sicd::CollectionInformation *|cphd::CollectionInformation *", 0, 0, (void*)0, 0};
@@ -52851,6 +52855,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mem__ScopedCopyablePtrT_cphd__TOAParameters_t,
   &_swigt__p_mem__SharedPtrT_io__SeekableInputStream_t,
   &_swigt__p_mem__SharedPtrT_logging__Logger_t,
+  &_swigt__p_mt__SingletonT_six__XMLControlRegistry_true_t,
   &_swigt__p_nitf__DateTime,
   &_swigt__p_off_t,
   &_swigt__p_p_PyObject,
@@ -52869,6 +52874,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_six__FFTSign,
   &_swigt__p_six__RadarModeType,
   &_swigt__p_six__ReferencePoint,
+  &_swigt__p_six__XMLControlCreator,
   &_swigt__p_six__sicd__AntennaParameters,
   &_swigt__p_six__sicd__AreaDirectionParameters,
   &_swigt__p_six__sicd__CollectionInformation,
@@ -52967,6 +52973,7 @@ static swig_cast_info _swigc__p_mem__ScopedCopyablePtrT_cphd__FxParameters_t[] =
 static swig_cast_info _swigc__p_mem__ScopedCopyablePtrT_cphd__TOAParameters_t[] = {  {&_swigt__p_mem__ScopedCopyablePtrT_cphd__TOAParameters_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mem__SharedPtrT_io__SeekableInputStream_t[] = {  {&_swigt__p_mem__SharedPtrT_io__SeekableInputStream_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mem__SharedPtrT_logging__Logger_t[] = {  {&_swigt__p_mem__SharedPtrT_logging__Logger_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mt__SingletonT_six__XMLControlRegistry_true_t[] = {  {&_swigt__p_mt__SingletonT_six__XMLControlRegistry_true_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_nitf__DateTime[] = {  {&_swigt__p_nitf__DateTime, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_off_t[] = {  {&_swigt__p_off_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_p_PyObject[] = {  {&_swigt__p_p_PyObject, 0, 0, 0},{0, 0, 0, 0}};
@@ -52985,6 +52992,7 @@ static swig_cast_info _swigc__p_six__DataType[] = {  {&_swigt__p_six__DataType, 
 static swig_cast_info _swigc__p_six__FFTSign[] = {  {&_swigt__p_six__FFTSign, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__RadarModeType[] = {  {&_swigt__p_six__RadarModeType, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__ReferencePoint[] = {  {&_swigt__p_six__ReferencePoint, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_six__XMLControlCreator[] = {  {&_swigt__p_six__XMLControlCreator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__AntennaParameters[] = {  {&_swigt__p_six__sicd__AntennaParameters, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__AreaDirectionParameters[] = {  {&_swigt__p_six__sicd__AreaDirectionParameters, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__CollectionInformation[] = {  {&_swigt__p_six__sicd__CollectionInformation, 0, 0, 0},{0, 0, 0, 0}};
@@ -53083,6 +53091,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mem__ScopedCopyablePtrT_cphd__TOAParameters_t,
   _swigc__p_mem__SharedPtrT_io__SeekableInputStream_t,
   _swigc__p_mem__SharedPtrT_logging__Logger_t,
+  _swigc__p_mt__SingletonT_six__XMLControlRegistry_true_t,
   _swigc__p_nitf__DateTime,
   _swigc__p_off_t,
   _swigc__p_p_PyObject,
@@ -53101,6 +53110,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_six__FFTSign,
   _swigc__p_six__RadarModeType,
   _swigc__p_six__ReferencePoint,
+  _swigc__p_six__XMLControlCreator,
   _swigc__p_six__sicd__AntennaParameters,
   _swigc__p_six__sicd__AreaDirectionParameters,
   _swigc__p_six__sicd__CollectionInformation,

--- a/six/modules/python/cphd/source/generated/cphd_wrap.cxx
+++ b/six/modules/python/cphd/source/generated/cphd_wrap.cxx
@@ -3040,50 +3040,52 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_six__CollectType swig_types[67]
 #define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[68]
 #define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[69]
-#define SWIGTYPE_p_six__DataType swig_types[70]
-#define SWIGTYPE_p_six__FFTSign swig_types[71]
-#define SWIGTYPE_p_six__RadarModeType swig_types[72]
-#define SWIGTYPE_p_six__ReferencePoint swig_types[73]
-#define SWIGTYPE_p_six__sicd__AntennaParameters swig_types[74]
-#define SWIGTYPE_p_six__sicd__AreaDirectionParameters swig_types[75]
-#define SWIGTYPE_p_six__sicd__CollectionInformation swig_types[76]
-#define SWIGTYPE_p_six__sicd__ElectricalBoresight swig_types[77]
-#define SWIGTYPE_p_six__sicd__GainAndPhasePolys swig_types[78]
-#define SWIGTYPE_p_six__sicd__HalfPowerBeamwidths swig_types[79]
-#define SWIGTYPE_p_size_t swig_types[80]
-#define SWIGTYPE_p_size_type swig_types[81]
-#define SWIGTYPE_p_ssize_t swig_types[82]
-#define SWIGTYPE_p_std__allocatorT_cphd__ArraySize_t swig_types[83]
-#define SWIGTYPE_p_std__allocatorT_cphd__ChannelParameters_t swig_types[84]
-#define SWIGTYPE_p_std__allocatorT_math__linear__VectorNT_3_double_t_t swig_types[85]
-#define SWIGTYPE_p_std__allocatorT_six__sicd__AntennaParameters_t swig_types[86]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__Antenna_t swig_types[87]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__DwellTimeParameters_t swig_types[88]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__FxParameters_t swig_types[89]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__TOAParameters_t swig_types[90]
-#define SWIGTYPE_p_std__invalid_argument swig_types[91]
-#define SWIGTYPE_p_std__ostream swig_types[92]
-#define SWIGTYPE_p_std__vectorT_cphd__ArraySize_std__allocatorT_cphd__ArraySize_t_t swig_types[93]
-#define SWIGTYPE_p_std__vectorT_cphd__ChannelParameters_std__allocatorT_cphd__ChannelParameters_t_t swig_types[94]
-#define SWIGTYPE_p_std__vectorT_math__linear__VectorNT_3_double_t_std__allocatorT_math__linear__VectorNT_3_double_t_t_t swig_types[95]
-#define SWIGTYPE_p_std__vectorT_math__poly__OneDT_Vector3_t_std__allocatorT_math__poly__OneDT_Vector3_t_t_t swig_types[96]
-#define SWIGTYPE_p_std__vectorT_six__sicd__AntennaParameters_std__allocatorT_six__sicd__AntennaParameters_t_t swig_types[97]
-#define SWIGTYPE_p_std__vectorT_unsigned_char_std__allocatorT_unsigned_char_t_t swig_types[98]
-#define SWIGTYPE_p_std__vectorT_void_const_p_std__allocatorT_void_const_p_t_t swig_types[99]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[100]
-#define SWIGTYPE_p_types__RowColT_double_t swig_types[101]
-#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[102]
-#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[103]
-#define SWIGTYPE_p_types__RowColT_size_t_t swig_types[104]
-#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[105]
-#define SWIGTYPE_p_uint16_t swig_types[106]
-#define SWIGTYPE_p_uint32_t swig_types[107]
-#define SWIGTYPE_p_uint64_t swig_types[108]
-#define SWIGTYPE_p_uint8_t swig_types[109]
-#define SWIGTYPE_p_unsigned_char swig_types[110]
-#define SWIGTYPE_p_value_type swig_types[111]
-static swig_type_info *swig_types[113];
-static swig_module_info swig_module = {swig_types, 112, 0, 0, 0, 0};
+#define SWIGTYPE_p_six__Data swig_types[70]
+#define SWIGTYPE_p_six__DataType swig_types[71]
+#define SWIGTYPE_p_six__FFTSign swig_types[72]
+#define SWIGTYPE_p_six__RadarModeType swig_types[73]
+#define SWIGTYPE_p_six__ReferencePoint swig_types[74]
+#define SWIGTYPE_p_six__sicd__AntennaParameters swig_types[75]
+#define SWIGTYPE_p_six__sicd__AreaDirectionParameters swig_types[76]
+#define SWIGTYPE_p_six__sicd__CollectionInformation swig_types[77]
+#define SWIGTYPE_p_six__sicd__ComplexData swig_types[78]
+#define SWIGTYPE_p_six__sicd__ElectricalBoresight swig_types[79]
+#define SWIGTYPE_p_six__sicd__GainAndPhasePolys swig_types[80]
+#define SWIGTYPE_p_six__sicd__HalfPowerBeamwidths swig_types[81]
+#define SWIGTYPE_p_size_t swig_types[82]
+#define SWIGTYPE_p_size_type swig_types[83]
+#define SWIGTYPE_p_ssize_t swig_types[84]
+#define SWIGTYPE_p_std__allocatorT_cphd__ArraySize_t swig_types[85]
+#define SWIGTYPE_p_std__allocatorT_cphd__ChannelParameters_t swig_types[86]
+#define SWIGTYPE_p_std__allocatorT_math__linear__VectorNT_3_double_t_t swig_types[87]
+#define SWIGTYPE_p_std__allocatorT_six__sicd__AntennaParameters_t swig_types[88]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__Antenna_t swig_types[89]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__DwellTimeParameters_t swig_types[90]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__FxParameters_t swig_types[91]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__TOAParameters_t swig_types[92]
+#define SWIGTYPE_p_std__invalid_argument swig_types[93]
+#define SWIGTYPE_p_std__ostream swig_types[94]
+#define SWIGTYPE_p_std__vectorT_cphd__ArraySize_std__allocatorT_cphd__ArraySize_t_t swig_types[95]
+#define SWIGTYPE_p_std__vectorT_cphd__ChannelParameters_std__allocatorT_cphd__ChannelParameters_t_t swig_types[96]
+#define SWIGTYPE_p_std__vectorT_math__linear__VectorNT_3_double_t_std__allocatorT_math__linear__VectorNT_3_double_t_t_t swig_types[97]
+#define SWIGTYPE_p_std__vectorT_math__poly__OneDT_Vector3_t_std__allocatorT_math__poly__OneDT_Vector3_t_t_t swig_types[98]
+#define SWIGTYPE_p_std__vectorT_six__sicd__AntennaParameters_std__allocatorT_six__sicd__AntennaParameters_t_t swig_types[99]
+#define SWIGTYPE_p_std__vectorT_unsigned_char_std__allocatorT_unsigned_char_t_t swig_types[100]
+#define SWIGTYPE_p_std__vectorT_void_const_p_std__allocatorT_void_const_p_t_t swig_types[101]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[102]
+#define SWIGTYPE_p_types__RowColT_double_t swig_types[103]
+#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[104]
+#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[105]
+#define SWIGTYPE_p_types__RowColT_size_t_t swig_types[106]
+#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[107]
+#define SWIGTYPE_p_uint16_t swig_types[108]
+#define SWIGTYPE_p_uint32_t swig_types[109]
+#define SWIGTYPE_p_uint64_t swig_types[110]
+#define SWIGTYPE_p_uint8_t swig_types[111]
+#define SWIGTYPE_p_unsigned_char swig_types[112]
+#define SWIGTYPE_p_value_type swig_types[113]
+static swig_type_info *swig_types[115];
+static swig_module_info swig_module = {swig_types, 114, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -4572,6 +4574,7 @@ namespace swig
 
 #include "import/cphd.h"
 #include "import/six.h"
+#include "import/six/sicd.h"
 using six::Vector3;
 
 
@@ -52672,6 +52675,9 @@ static void *_p_scene__LatLonAltTo_p_scene__LatLon(void *x, int *SWIGUNUSEDPARM(
 static void *_p_io__FileInputStreamOSTo_p_io__SeekableInputStream(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((io::SeekableInputStream *)  ((io::FileInputStreamOS *) x));
 }
+static void *_p_six__sicd__ComplexDataTo_p_six__Data(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((six::Data *)  ((six::sicd::ComplexData *) x));
+}
 static swig_type_info _swigt__p_ConstParameterCollectionIteratorT = {"_p_ConstParameterCollectionIteratorT", "ConstParameterCollectionIteratorT *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_Like_T = {"_p_Like_T", "Like_T *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_ParameterCollectionIteratorT = {"_p_ParameterCollectionIteratorT", "ParameterCollectionIteratorT *", 0, 0, (void*)0, 0};
@@ -52742,6 +52748,7 @@ static swig_type_info _swigt__p_six__BooleanType = {"_p_six__BooleanType", "six:
 static swig_type_info _swigt__p_six__CollectType = {"_p_six__CollectType", "six::CollectType *|cphd::CollectType *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__CornersT_scene__LatLonAlt_t = {"_p_six__CornersT_scene__LatLonAlt_t", "six::Corners< scene::LatLonAlt > *|six::LatLonAltCorners *|cphd::LatLonAltCorners *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__CornersT_scene__LatLon_t = {"_p_six__CornersT_scene__LatLon_t", "six::LatLonCorners *|cphd::LatLonCorners *|six::Corners< scene::LatLon > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_six__Data = {"_p_six__Data", "six::Data *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__DataType = {"_p_six__DataType", "six::DataType *|cphd::DataType *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__FFTSign = {"_p_six__FFTSign", "six::FFTSign *|cphd::FFTSign *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__RadarModeType = {"_p_six__RadarModeType", "six::RadarModeType *|cphd::RadarModeType *", 0, 0, (void*)0, 0};
@@ -52749,6 +52756,7 @@ static swig_type_info _swigt__p_six__ReferencePoint = {"_p_six__ReferencePoint",
 static swig_type_info _swigt__p_six__sicd__AntennaParameters = {"_p_six__sicd__AntennaParameters", "std::vector< six::sicd::AntennaParameters >::value_type *|six::sicd::AntennaParameters *|cphd::AntennaParameters *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__AreaDirectionParameters = {"_p_six__sicd__AreaDirectionParameters", "six::sicd::AreaDirectionParameters *|cphd::AreaDirectionParameters *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__CollectionInformation = {"_p_six__sicd__CollectionInformation", "six::sicd::CollectionInformation *|cphd::CollectionInformation *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_six__sicd__ComplexData = {"_p_six__sicd__ComplexData", "six::sicd::ComplexData *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__ElectricalBoresight = {"_p_six__sicd__ElectricalBoresight", "six::sicd::ElectricalBoresight *|cphd::ElectricalBoresight *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__GainAndPhasePolys = {"_p_six__sicd__GainAndPhasePolys", "six::sicd::GainAndPhasePolys *|cphd::GainAndPhasePolys *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__HalfPowerBeamwidths = {"_p_six__sicd__HalfPowerBeamwidths", "six::sicd::HalfPowerBeamwidths *|cphd::HalfPowerBeamwidths *", 0, 0, (void*)0, 0};
@@ -52856,6 +52864,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_six__CollectType,
   &_swigt__p_six__CornersT_scene__LatLonAlt_t,
   &_swigt__p_six__CornersT_scene__LatLon_t,
+  &_swigt__p_six__Data,
   &_swigt__p_six__DataType,
   &_swigt__p_six__FFTSign,
   &_swigt__p_six__RadarModeType,
@@ -52863,6 +52872,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_six__sicd__AntennaParameters,
   &_swigt__p_six__sicd__AreaDirectionParameters,
   &_swigt__p_six__sicd__CollectionInformation,
+  &_swigt__p_six__sicd__ComplexData,
   &_swigt__p_six__sicd__ElectricalBoresight,
   &_swigt__p_six__sicd__GainAndPhasePolys,
   &_swigt__p_six__sicd__HalfPowerBeamwidths,
@@ -52970,6 +52980,7 @@ static swig_cast_info _swigc__p_six__BooleanType[] = {  {&_swigt__p_six__Boolean
 static swig_cast_info _swigc__p_six__CollectType[] = {  {&_swigt__p_six__CollectType, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__CornersT_scene__LatLonAlt_t[] = {  {&_swigt__p_six__CornersT_scene__LatLonAlt_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__CornersT_scene__LatLon_t[] = {  {&_swigt__p_six__CornersT_scene__LatLon_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_six__Data[] = {  {&_swigt__p_six__Data, 0, 0, 0},  {&_swigt__p_six__sicd__ComplexData, _p_six__sicd__ComplexDataTo_p_six__Data, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__DataType[] = {  {&_swigt__p_six__DataType, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__FFTSign[] = {  {&_swigt__p_six__FFTSign, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__RadarModeType[] = {  {&_swigt__p_six__RadarModeType, 0, 0, 0},{0, 0, 0, 0}};
@@ -52977,6 +52988,7 @@ static swig_cast_info _swigc__p_six__ReferencePoint[] = {  {&_swigt__p_six__Refe
 static swig_cast_info _swigc__p_six__sicd__AntennaParameters[] = {  {&_swigt__p_six__sicd__AntennaParameters, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__AreaDirectionParameters[] = {  {&_swigt__p_six__sicd__AreaDirectionParameters, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__CollectionInformation[] = {  {&_swigt__p_six__sicd__CollectionInformation, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_six__sicd__ComplexData[] = {  {&_swigt__p_six__sicd__ComplexData, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__ElectricalBoresight[] = {  {&_swigt__p_six__sicd__ElectricalBoresight, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__GainAndPhasePolys[] = {  {&_swigt__p_six__sicd__GainAndPhasePolys, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__HalfPowerBeamwidths[] = {  {&_swigt__p_six__sicd__HalfPowerBeamwidths, 0, 0, 0},{0, 0, 0, 0}};
@@ -53084,6 +53096,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_six__CollectType,
   _swigc__p_six__CornersT_scene__LatLonAlt_t,
   _swigc__p_six__CornersT_scene__LatLon_t,
+  _swigc__p_six__Data,
   _swigc__p_six__DataType,
   _swigc__p_six__FFTSign,
   _swigc__p_six__RadarModeType,
@@ -53091,6 +53104,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_six__sicd__AntennaParameters,
   _swigc__p_six__sicd__AreaDirectionParameters,
   _swigc__p_six__sicd__CollectionInformation,
+  _swigc__p_six__sicd__ComplexData,
   _swigc__p_six__sicd__ElectricalBoresight,
   _swigc__p_six__sicd__GainAndPhasePolys,
   _swigc__p_six__sicd__HalfPowerBeamwidths,

--- a/six/modules/python/scene/source/scene.i
+++ b/six/modules/python/scene/source/scene.i
@@ -26,8 +26,8 @@
 
 %feature("autodoc", "1");
 
-%include "std_vector.i"
-%include "std_string.i"
+%include <std_vector.i>
+%include <std_string.i>
 
 %import "except.i"
 %import "math_linear.i"

--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -2839,10 +2839,25 @@ class SixSicdUtilities(_object):
         parseDataFromFile = staticmethod(parseDataFromFile)
     __swig_getmethods__["parseDataFromFile"] = lambda x: parseDataFromFile
 
-    def parseDataFromString(self, xmlStr, schemaPaths, log):
-        """parseDataFromString(SixSicdUtilities self, std::string const & xmlStr, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::sicd::ComplexData >"""
-        return _six_sicd.SixSicdUtilities_parseDataFromString(self, xmlStr, schemaPaths, log)
+    def parseDataFromString(xmlStr, schemaPaths, log):
+        """parseDataFromString(std::string const & xmlStr, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::sicd::ComplexData >"""
+        return _six_sicd.SixSicdUtilities_parseDataFromString(xmlStr, schemaPaths, log)
 
+    if _newclass:
+        parseDataFromString = staticmethod(parseDataFromString)
+    __swig_getmethods__["parseDataFromString"] = lambda x: parseDataFromString
+
+    def toXMLString(*args):
+        """
+        toXMLString(ComplexData data, VectorString schemaPaths, logging::Logger * logger=None) -> std::string
+        toXMLString(ComplexData data, VectorString schemaPaths) -> std::string
+        toXMLString(ComplexData data) -> std::string
+        """
+        return _six_sicd.SixSicdUtilities_toXMLString(*args)
+
+    if _newclass:
+        toXMLString = staticmethod(toXMLString)
+    __swig_getmethods__["toXMLString"] = lambda x: toXMLString
 
     def __init__(self):
         """__init__(six::sicd::Utilities self) -> SixSicdUtilities"""
@@ -2901,6 +2916,18 @@ def SixSicdUtilities_parseData(xmlStream, schemaPaths, log):
 def SixSicdUtilities_parseDataFromFile(pathname, schemaPaths, log):
     """SixSicdUtilities_parseDataFromFile(std::string const & pathname, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::sicd::ComplexData >"""
     return _six_sicd.SixSicdUtilities_parseDataFromFile(pathname, schemaPaths, log)
+
+def SixSicdUtilities_parseDataFromString(xmlStr, schemaPaths, log):
+    """SixSicdUtilities_parseDataFromString(std::string const & xmlStr, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::sicd::ComplexData >"""
+    return _six_sicd.SixSicdUtilities_parseDataFromString(xmlStr, schemaPaths, log)
+
+def SixSicdUtilities_toXMLString(*args):
+    """
+    toXMLString(ComplexData data, VectorString schemaPaths, logging::Logger * logger=None) -> std::string
+    toXMLString(ComplexData data, VectorString schemaPaths) -> std::string
+    SixSicdUtilities_toXMLString(ComplexData data) -> std::string
+    """
+    return _six_sicd.SixSicdUtilities_toXMLString(*args)
 
 class StdAutoCollectionInformation(_object):
     """Proxy of C++ std::auto_ptr<(six::sicd::CollectionInformation)> class"""

--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -2789,6 +2789,17 @@ class SixSicdUtilities(_object):
         readSicd = staticmethod(readSicd)
     __swig_getmethods__["readSicd"] = lambda x: readSicd
 
+    def getComplexData(*args):
+        """
+        getComplexData(std::string const & sicdPathname, VectorString schemaPaths) -> std::auto_ptr< six::sicd::ComplexData >
+        getComplexData(NITFReadControl & reader) -> std::auto_ptr< six::sicd::ComplexData >
+        """
+        return _six_sicd.SixSicdUtilities_getComplexData(*args)
+
+    if _newclass:
+        getComplexData = staticmethod(getComplexData)
+    __swig_getmethods__["getComplexData"] = lambda x: getComplexData
+
     def getWidebandData(*args):
         """
         getWidebandData(NITFReadControl & reader, ComplexData complexData, std::complex< float > * buffer)
@@ -2860,6 +2871,13 @@ def SixSicdUtilities_getValidDataPolygon(sicdData, projection, validData):
 def SixSicdUtilities_readSicd(sicdPathname, schemaPaths, complexData, widebandData):
     """SixSicdUtilities_readSicd(std::string const & sicdPathname, VectorString schemaPaths, std::auto_ptr< six::sicd::ComplexData > & complexData, std::vector< std::complex< float >,std::allocator< std::complex< float > > > & widebandData)"""
     return _six_sicd.SixSicdUtilities_readSicd(sicdPathname, schemaPaths, complexData, widebandData)
+
+def SixSicdUtilities_getComplexData(*args):
+    """
+    getComplexData(std::string const & sicdPathname, VectorString schemaPaths) -> std::auto_ptr< six::sicd::ComplexData >
+    SixSicdUtilities_getComplexData(NITFReadControl & reader) -> std::auto_ptr< six::sicd::ComplexData >
+    """
+    return _six_sicd.SixSicdUtilities_getComplexData(*args)
 
 def SixSicdUtilities_getWidebandData(*args):
     """
@@ -9426,7 +9444,7 @@ import numpy as np
 from pysix.six_base import VectorString
 
 def read(inputPathname, schemaPaths = VectorString()):
-    complexData = getComplexData(inputPathname, schemaPaths)
+    complexData = SixSicdUtilities.getComplexData(inputPathname, schemaPaths)
 
 #Numpy has no concept of complex integers, so dtype will always be complex64
     widebandData = np.empty(shape = (complexData.getNumRows(), complexData.getNumCols()), dtype = "complex64")

--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -206,10 +206,6 @@ import pysix.scene
 import coda.mem
 import coda.coda_io
 
-def getComplexData(sicdPathname, schemaPaths):
-    """getComplexData(std::string const & sicdPathname, VectorString schemaPaths) -> ComplexData"""
-    return _six_sicd.getComplexData(sicdPathname, schemaPaths)
-
 def asComplexData(data):
     """asComplexData(Data data) -> ComplexData"""
     return _six_sicd.asComplexData(data)
@@ -2816,6 +2812,27 @@ class SixSicdUtilities(_object):
         getGroundPlaneNormal = staticmethod(getGroundPlaneNormal)
     __swig_getmethods__["getGroundPlaneNormal"] = lambda x: getGroundPlaneNormal
 
+    def parseData(xmlStream, schemaPaths, log):
+        """parseData(InputStream xmlStream, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::sicd::ComplexData >"""
+        return _six_sicd.SixSicdUtilities_parseData(xmlStream, schemaPaths, log)
+
+    if _newclass:
+        parseData = staticmethod(parseData)
+    __swig_getmethods__["parseData"] = lambda x: parseData
+
+    def parseDataFromFile(pathname, schemaPaths, log):
+        """parseDataFromFile(std::string const & pathname, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::sicd::ComplexData >"""
+        return _six_sicd.SixSicdUtilities_parseDataFromFile(pathname, schemaPaths, log)
+
+    if _newclass:
+        parseDataFromFile = staticmethod(parseDataFromFile)
+    __swig_getmethods__["parseDataFromFile"] = lambda x: parseDataFromFile
+
+    def parseDataFromString(self, xmlStr, schemaPaths, log):
+        """parseDataFromString(SixSicdUtilities self, std::string const & xmlStr, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::sicd::ComplexData >"""
+        return _six_sicd.SixSicdUtilities_parseDataFromString(self, xmlStr, schemaPaths, log)
+
+
     def __init__(self):
         """__init__(six::sicd::Utilities self) -> SixSicdUtilities"""
         this = _six_sicd.new_SixSicdUtilities()
@@ -2858,6 +2875,14 @@ def SixSicdUtilities_getWidebandData(*args):
 def SixSicdUtilities_getGroundPlaneNormal(data):
     """SixSicdUtilities_getGroundPlaneNormal(ComplexData data) -> Vector3"""
     return _six_sicd.SixSicdUtilities_getGroundPlaneNormal(data)
+
+def SixSicdUtilities_parseData(xmlStream, schemaPaths, log):
+    """SixSicdUtilities_parseData(InputStream xmlStream, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::sicd::ComplexData >"""
+    return _six_sicd.SixSicdUtilities_parseData(xmlStream, schemaPaths, log)
+
+def SixSicdUtilities_parseDataFromFile(pathname, schemaPaths, log):
+    """SixSicdUtilities_parseDataFromFile(std::string const & pathname, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::sicd::ComplexData >"""
+    return _six_sicd.SixSicdUtilities_parseDataFromFile(pathname, schemaPaths, log)
 
 class StdAutoCollectionInformation(_object):
     """Proxy of C++ std::auto_ptr<(six::sicd::CollectionInformation)> class"""

--- a/six/modules/python/six.sicd/source/six_sicd.i
+++ b/six/modules/python/six.sicd/source/six_sicd.i
@@ -122,24 +122,19 @@ Data* readNITF(const std::string& pathname,
 %ignore mem::ScopedCopyablePtr::operator!=;
 %ignore mem::ScopedCopyablePtr::operator==;
 
-%include "std_vector.i"
-%include "std_string.i"
-%include "std_complex.i"
-%include "std_pair.i"
+%include <std_vector.i>
+%include <std_string.i>
+%include <std_complex.i>
+%include <std_pair.i>
+%include <std_auto_ptr.i>
 
 %import "math_poly.i"
 %import "six.i"
 %import "io.i"
 %import "mem.i"
 
-/* wrap around auto_ptr */
-%inline
-%{
-six::sicd::ComplexData * getComplexData( const std::string& sicdPathname, const std::vector<std::string>& schemaPaths ) {
-  std::auto_ptr<six::sicd::ComplexData> retv = Utilities::getComplexData(sicdPathname, schemaPaths);
-  return retv.release();
-}
-%}
+// This allows functions that return auto_ptrs to work properly
+%auto_ptr(six::sicd::ComplexData);
 
 /* wrap that function defined in the header section */
 six::sicd::ComplexData * asComplexData(six::Data* data);

--- a/six/modules/python/six.sicd/source/six_sicd.i
+++ b/six/modules/python/six.sicd/source/six_sicd.i
@@ -145,10 +145,6 @@ void writeNITF(const std::string& pathname, const std::vector<std::string>&
 Data* readNITF(const std::string& pathname,
         const std::vector<std::string>& schemaPaths);
 
-
-/* this version of the function returns the auto_ptr, ignore it */
-%rename ("$ignore", fullname=1) "six::sicd::Utilities::getComplexData";
-
 /* prevent name conflicts */
 %rename ("SixSicdUtilities") six::sicd::Utilities;
 
@@ -273,7 +269,7 @@ import numpy as np
 from pysix.six_base import VectorString
 
 def read(inputPathname, schemaPaths = VectorString()):
-    complexData = getComplexData(inputPathname, schemaPaths)
+    complexData = SixSicdUtilities.getComplexData(inputPathname, schemaPaths)
 
     #Numpy has no concept of complex integers, so dtype will always be complex64
     widebandData = np.empty(shape = (complexData.getNumRows(), complexData.getNumCols()), dtype = "complex64")

--- a/six/modules/python/six.sicd/tests/sicd_ground_to_pixel.py
+++ b/six/modules/python/six.sicd/tests/sicd_ground_to_pixel.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     schemaPaths.push_back(schemaPath)
 
     # Read in the XML portion of the SICD
-    complexData = six_sicd.getComplexData(args.sicd, schemaPaths)
+    complexData = six_sicd.SixSicdUtilities.getComplexData(args.sicd, schemaPaths)
 
     # Derive geometry info from this
     geom = six_sicd.SixSicdUtilities.getSceneGeometry(complexData)

--- a/six/modules/python/six.sicd/tests/sicd_pixel_to_ground.py
+++ b/six/modules/python/six.sicd/tests/sicd_pixel_to_ground.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     schemaPaths.push_back(schemaPath)
 
     # Read in the XML portion of the SICD
-    complexData = six_sicd.getComplexData(args.sicd, schemaPaths)
+    complexData = six_sicd.SixSicdUtilities.getComplexData(args.sicd, schemaPaths)
 
     # Derive geometry info from this
     geom = six_sicd.SixSicdUtilities.getSceneGeometry(complexData)

--- a/six/modules/python/six.sicd/tests/test_read_sicd_xml.py
+++ b/six/modules/python/six.sicd/tests/test_read_sicd_xml.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+#
+# =========================================================================
+# This file is part of six.sicd-python
+# =========================================================================
+#
+# (C) Copyright 2004 - 2015, MDA Information Systems LLC
+#
+# six.sicd-python is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; If not,
+# see <http://www.gnu.org/licenses/>.
+#
+
+# Simple program to show how you can go from XML to and from SIX
+
+from pysix.six_sicd import *
+from pysix.six_base import *
+from coda.coda_logging import *
+import sys, os
+
+# Parse the command line
+if len(sys.argv) != 2:
+    sys.exit('Usage ' + sys.argv[0] + ' <XML pathname>')
+
+xmlPathname = sys.argv[1]
+
+schemaPaths = VectorString()
+schemaPaths.push_back(os.environ['SIX_SCHEMA_PATH'])
+logger = NullLogger()
+
+# Go from XML file on disk to ComplexData
+data = SixSicdUtilities.parseDataFromFile(xmlPathname, schemaPaths, logger)
+print data.getNumRows()
+
+# Go from ComplexData to string
+xmlStr = SixSicdUtilities.toXMLString(data, schemaPaths, logger)
+print xmlStr
+
+# Go from string back to ComplexData
+data2 = SixSicdUtilities.parseDataFromString(xmlStr, schemaPaths, logger)
+
+# Back to string one last time to compare
+xmlStr2 = SixSicdUtilities.toXMLString(data2, schemaPaths, logger)
+
+if xmlStr == xmlStr2:
+    print('Strings match')
+else:
+    sys.exit('Strings do not match!')

--- a/six/modules/python/six.sicd/tests/test_read_sicd_xml.py
+++ b/six/modules/python/six.sicd/tests/test_read_sicd_xml.py
@@ -41,11 +41,19 @@ logger = NullLogger()
 
 # Go from XML file on disk to ComplexData
 data = SixSicdUtilities.parseDataFromFile(xmlPathname, schemaPaths, logger)
-print data.getNumRows()
 
 # Go from ComplexData to string
 xmlStr = SixSicdUtilities.toXMLString(data, schemaPaths, logger)
-print xmlStr
+print(xmlStr)
+
+# Print a few things to show that we really parsed this into an object
+print("file is " + str(data.getNumRows()) + "x" + str(data.getNumCols()))
+print(str(data.getNumBytesPerPixel()) + " bytes per pixel")
+print( "tx polarization: " + data.radarCollection.txPolarization.toString())
+print("image formation algorithm: " + data.imageFormation.imageFormationAlgorithm.toString())
+print("graze angle: " + str(data.scpcoa.grazeAngle))
+print("slant range: " + str(data.scpcoa.slantRange))
+print("radar mode: " + data.collectionInformation.radarMode.toString())
 
 # Go from string back to ComplexData
 data2 = SixSicdUtilities.parseDataFromString(xmlStr, schemaPaths, logger)

--- a/six/modules/python/six.sicd/tests/test_read_sicd_xml.py
+++ b/six/modules/python/six.sicd/tests/test_read_sicd_xml.py
@@ -31,16 +31,32 @@ import sys, os
 
 # Parse the command line
 if len(sys.argv) != 2:
-    sys.exit('Usage ' + sys.argv[0] + ' <XML pathname>')
+    sys.exit('Usage ' + sys.argv[0] + ' <XML or NITF pathname>')
 
-xmlPathname = sys.argv[1]
+inPathname = sys.argv[1]
 
 schemaPaths = VectorString()
 schemaPaths.push_back(os.environ['SIX_SCHEMA_PATH'])
 logger = NullLogger()
 
+# The point of this script is to show we can hop back and forth with
+# just XML strings so if they gave us a NITF, grab the XML out of it
+# and write it to a text file
+gotNITF = inPathname.endswith('.ntf') or inPathname.endswith('.nitf')
+if gotNITF:
+    xmlPathname = inPathname + '.xml'
+    data = SixSicdUtilities.getComplexData(inPathname, schemaPaths)
+    xmlStr = SixSicdUtilities.toXMLString(data, schemaPaths, logger)
+    file = open(xmlPathname, 'w')
+    file.write(xmlStr)
+    file.close()
+else:
+    xmlPathname = inPathname
+
 # Go from XML file on disk to ComplexData
 data = SixSicdUtilities.parseDataFromFile(xmlPathname, schemaPaths, logger)
+if gotNITF:
+    os.remove(xmlPathname)
 
 # Go from ComplexData to string
 xmlStr = SixSicdUtilities.toXMLString(data, schemaPaths, logger)

--- a/six/modules/python/six.sicd/tests/test_six_sicd.py
+++ b/six/modules/python/six.sicd/tests/test_six_sicd.py
@@ -84,7 +84,7 @@ def roundTrip(filename):
 def loadSicd(filename):
   vs = VectorString()
   vs.push_back( os.environ['SIX_SCHEMA_PATH'] )
-  cmplx = getComplexData(filename, vs)
+  cmplx = SixSicdUtilities.getComplexData(filename, vs)
   showInfo(cmplx)
   out_filename = 'from_sicd_' + os.path.basename(filename) + '.xml'
   xml_ctrl = ComplexXMLControl()

--- a/six/modules/python/six/source/generated/six_base.py
+++ b/six/modules/python/six/source/generated/six_base.py
@@ -4189,6 +4189,27 @@ def loadPluginDir(pluginDir):
     """loadPluginDir(std::string const & pluginDir)"""
     return _six_base.loadPluginDir(pluginDir)
 
+def parseData(*args):
+    """
+    parseData(XMLControlRegistry const & xmlReg, ::io::InputStream & xmlStream, DataType dataType, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >
+    parseData(XMLControlRegistry const & xmlReg, ::io::InputStream & xmlStream, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >
+    """
+    return _six_base.parseData(*args)
+
+def parseDataFromFile(*args):
+    """
+    parseDataFromFile(XMLControlRegistry const & xmlReg, std::string const & pathname, DataType dataType, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >
+    parseDataFromFile(XMLControlRegistry const & xmlReg, std::string const & pathname, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >
+    """
+    return _six_base.parseDataFromFile(*args)
+
+def parseDataFromString(*args):
+    """
+    parseDataFromString(XMLControlRegistry const & xmlReg, std::string const & xmlStr, DataType dataType, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >
+    parseDataFromString(XMLControlRegistry const & xmlReg, std::string const & xmlStr, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >
+    """
+    return _six_base.parseDataFromString(*args)
+
 def getErrors(errorStats, sampleSpacing, errors):
     """getErrors(ErrorStatistics errorStats, RgAzDouble sampleSpacing, Errors errors)"""
     return _six_base.getErrors(errorStats, sampleSpacing, errors)

--- a/six/modules/python/six/source/generated/six_base.py
+++ b/six/modules/python/six/source/generated/six_base.py
@@ -4271,6 +4271,78 @@ class Options(_object):
 Options_swigregister = _six_base.Options_swigregister
 Options_swigregister(Options)
 
+class XMLControlCreator(_object):
+    """Proxy of C++ six::XMLControlCreator class"""
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, XMLControlCreator, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, XMLControlCreator, name)
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined - class is abstract")
+    __repr__ = _swig_repr
+    __swig_destroy__ = _six_base.delete_XMLControlCreator
+    __del__ = lambda self: None
+
+    def newXMLControl(self, log):
+        """newXMLControl(XMLControlCreator self, logging::Logger * log) -> XMLControl"""
+        return _six_base.XMLControlCreator_newXMLControl(self, log)
+
+XMLControlCreator_swigregister = _six_base.XMLControlCreator_swigregister
+XMLControlCreator_swigregister(XMLControlCreator)
+
+class XMLControlRegistry(_object):
+    """Proxy of C++ six::XMLControlRegistry class"""
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, XMLControlRegistry, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, XMLControlRegistry, name)
+    __repr__ = _swig_repr
+
+    def __init__(self):
+        """__init__(six::XMLControlRegistry self) -> XMLControlRegistry"""
+        this = _six_base.new_XMLControlRegistry()
+        try:
+            self.this.append(this)
+        except:
+            self.this = this
+    __swig_destroy__ = _six_base.delete_XMLControlRegistry
+    __del__ = lambda self: None
+
+    def addCreator(self, *args):
+        """
+        addCreator(XMLControlRegistry self, std::string const & identifier, std::auto_ptr< six::XMLControlCreator > creator)
+        addCreator(XMLControlRegistry self, std::string const & identifier, XMLControlCreator creator)
+        addCreator(XMLControlRegistry self, DataType dataType, std::auto_ptr< six::XMLControlCreator > creator)
+        addCreator(XMLControlRegistry self, DataType dataType, XMLControlCreator creator)
+        """
+        return _six_base.XMLControlRegistry_addCreator(self, *args)
+
+
+    def newXMLControl(self, *args):
+        """
+        newXMLControl(XMLControlRegistry self, std::string const & identifier, logging::Logger * log) -> XMLControl
+        newXMLControl(XMLControlRegistry self, DataType dataType, logging::Logger * log) -> XMLControl
+        """
+        return _six_base.XMLControlRegistry_newXMLControl(self, *args)
+
+XMLControlRegistry_swigregister = _six_base.XMLControlRegistry_swigregister
+XMLControlRegistry_swigregister(XMLControlRegistry)
+
+
+def toXMLString(data, xmlRegistry=None):
+    """
+    toXMLString(Data data, XMLControlRegistry xmlRegistry=None) -> std::string
+    toXMLString(Data data) -> std::string
+    """
+    return _six_base.toXMLString(data, xmlRegistry)
+
+def toValidXMLString(data, schemaPaths, log, xmlRegistry=None):
+    """
+    toValidXMLString(Data data, VectorString schemaPaths, logging::Logger * log, XMLControlRegistry xmlRegistry=None) -> std::string
+    toValidXMLString(Data data, VectorString schemaPaths, logging::Logger * log) -> std::string
+    """
+    return _six_base.toValidXMLString(data, schemaPaths, log, xmlRegistry)
 class VectorString(_object):
     """Proxy of C++ std::vector<(std::string)> class"""
     __swig_setmethods__ = {}

--- a/six/modules/python/six/source/generated/six_base_wrap.cxx
+++ b/six/modules/python/six/source/generated/six_base_wrap.cxx
@@ -2976,153 +2976,155 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_ParameterCollectionIteratorT swig_types[3]
 #define SWIGTYPE_p_ParameterIter swig_types[4]
 #define SWIGTYPE_p_ParameterMap swig_types[5]
-#define SWIGTYPE_p_allocator_type swig_types[6]
-#define SWIGTYPE_p_char swig_types[7]
-#define SWIGTYPE_p_difference_type swig_types[8]
-#define SWIGTYPE_p_except__BadCastException swig_types[9]
-#define SWIGTYPE_p_except__Context swig_types[10]
-#define SWIGTYPE_p_except__Exception swig_types[11]
-#define SWIGTYPE_p_except__FileNotFoundException swig_types[12]
-#define SWIGTYPE_p_except__IOException swig_types[13]
-#define SWIGTYPE_p_except__IndexOutOfRangeException swig_types[14]
-#define SWIGTYPE_p_except__InvalidArgumentException swig_types[15]
-#define SWIGTYPE_p_except__InvalidFormatException swig_types[16]
-#define SWIGTYPE_p_except__KeyAlreadyExistsException swig_types[17]
-#define SWIGTYPE_p_except__NoSuchKeyException swig_types[18]
-#define SWIGTYPE_p_except__NoSuchReferenceException swig_types[19]
-#define SWIGTYPE_p_except__NotImplementedException swig_types[20]
-#define SWIGTYPE_p_except__NullPointerReferenceException swig_types[21]
-#define SWIGTYPE_p_except__OutOfMemoryException swig_types[22]
-#define SWIGTYPE_p_except__ParseException swig_types[23]
-#define SWIGTYPE_p_except__SerializationException swig_types[24]
-#define SWIGTYPE_p_except__Throwable swig_types[25]
-#define SWIGTYPE_p_int swig_types[26]
-#define SWIGTYPE_p_int16_t swig_types[27]
-#define SWIGTYPE_p_int32_t swig_types[28]
-#define SWIGTYPE_p_int64_t swig_types[29]
-#define SWIGTYPE_p_int8_t swig_types[30]
-#define SWIGTYPE_p_logging__Logger swig_types[31]
-#define SWIGTYPE_p_math__linear__VectorNT_2_double_t swig_types[32]
-#define SWIGTYPE_p_math__linear__VectorNT_3_double_t swig_types[33]
-#define SWIGTYPE_p_math__linear__VectorT_double_t swig_types[34]
-#define SWIGTYPE_p_math__poly__OneDT_double_t swig_types[35]
-#define SWIGTYPE_p_math__poly__OneDT_math__linear__VectorNT_3_double_t_t swig_types[36]
-#define SWIGTYPE_p_math__poly__TwoDT_double_t swig_types[37]
-#define SWIGTYPE_p_mem__ScopedCloneablePtrT_six__AmplitudeTable_t swig_types[38]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__Components_t swig_types[39]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__CompositeSCP_t swig_types[40]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__CorrCoefs_t swig_types[41]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__ErrorStatistics_t swig_types[42]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__IonoError_t swig_types[43]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__PosVelError_t swig_types[44]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__RadarSensor_t swig_types[45]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__Radiometric_t swig_types[46]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__TropoError_t swig_types[47]
-#define SWIGTYPE_p_nitf_DateTime swig_types[48]
-#define SWIGTYPE_p_nitf__DateTime swig_types[49]
-#define SWIGTYPE_p_nitf__FileSecurity swig_types[50]
-#define SWIGTYPE_p_nitf__NITFException swig_types[51]
-#define SWIGTYPE_p_off_t swig_types[52]
-#define SWIGTYPE_p_p_PyObject swig_types[53]
-#define SWIGTYPE_p_pid_t swig_types[54]
-#define SWIGTYPE_p_scene__AngleMagnitude swig_types[55]
-#define SWIGTYPE_p_scene__Errors swig_types[56]
-#define SWIGTYPE_p_scene__FrameType swig_types[57]
-#define SWIGTYPE_p_scene__LatLon swig_types[58]
-#define SWIGTYPE_p_scene__LatLonAlt swig_types[59]
-#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[60]
-#define SWIGTYPE_p_six__AmplitudeTable swig_types[61]
-#define SWIGTYPE_p_six__AppliedType swig_types[62]
-#define SWIGTYPE_p_six__AutofocusType swig_types[63]
-#define SWIGTYPE_p_six__BooleanType swig_types[64]
-#define SWIGTYPE_p_six__ByteSwapping swig_types[65]
-#define SWIGTYPE_p_six__Classification swig_types[66]
-#define SWIGTYPE_p_six__CollectType swig_types[67]
-#define SWIGTYPE_p_six__ComplexImageGridType swig_types[68]
-#define SWIGTYPE_p_six__ComplexImagePlaneType swig_types[69]
-#define SWIGTYPE_p_six__Components swig_types[70]
-#define SWIGTYPE_p_six__CompositeSCP swig_types[71]
-#define SWIGTYPE_p_six__Constants swig_types[72]
-#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[73]
-#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[74]
-#define SWIGTYPE_p_six__CorrCoefs swig_types[75]
-#define SWIGTYPE_p_six__DESValidationException swig_types[76]
-#define SWIGTYPE_p_six__Data swig_types[77]
-#define SWIGTYPE_p_six__DataType swig_types[78]
-#define SWIGTYPE_p_six__DecimationMethod swig_types[79]
-#define SWIGTYPE_p_six__DecorrType swig_types[80]
-#define SWIGTYPE_p_six__DemodType swig_types[81]
-#define SWIGTYPE_p_six__DisplayType swig_types[82]
-#define SWIGTYPE_p_six__DualPolarizationType swig_types[83]
-#define SWIGTYPE_p_six__EarthModelType swig_types[84]
-#define SWIGTYPE_p_six__ErrorStatistics swig_types[85]
-#define SWIGTYPE_p_six__FFTSign swig_types[86]
-#define SWIGTYPE_p_six__ImageBeamCompensationType swig_types[87]
-#define SWIGTYPE_p_six__ImageFormationType swig_types[88]
-#define SWIGTYPE_p_six__Init swig_types[89]
-#define SWIGTYPE_p_six__IonoError swig_types[90]
-#define SWIGTYPE_p_six__LUT swig_types[91]
-#define SWIGTYPE_p_six__MagnificationMethod swig_types[92]
-#define SWIGTYPE_p_six__MissingRequiredException swig_types[93]
-#define SWIGTYPE_p_six__NoiseLevel swig_types[94]
-#define SWIGTYPE_p_six__Options swig_types[95]
-#define SWIGTYPE_p_six__OrientationType swig_types[96]
-#define SWIGTYPE_p_six__Parameter swig_types[97]
-#define SWIGTYPE_p_six__ParameterCollection swig_types[98]
-#define SWIGTYPE_p_six__PixelType swig_types[99]
-#define SWIGTYPE_p_six__PolarizationSequenceType swig_types[100]
-#define SWIGTYPE_p_six__PolarizationType swig_types[101]
-#define SWIGTYPE_p_six__PosVelError swig_types[102]
-#define SWIGTYPE_p_six__ProjectionType swig_types[103]
-#define SWIGTYPE_p_six__RMAlgoType swig_types[104]
-#define SWIGTYPE_p_six__RadarModeType swig_types[105]
-#define SWIGTYPE_p_six__RadarSensor swig_types[106]
-#define SWIGTYPE_p_six__Radiometric swig_types[107]
-#define SWIGTYPE_p_six__ReferencePoint swig_types[108]
-#define SWIGTYPE_p_six__RegionType swig_types[109]
-#define SWIGTYPE_p_six__RowColEnum swig_types[110]
-#define SWIGTYPE_p_six__SCP swig_types[111]
-#define SWIGTYPE_p_six__SCPType swig_types[112]
-#define SWIGTYPE_p_six__SideOfTrackType swig_types[113]
-#define SWIGTYPE_p_six__SlowTimeBeamCompensationType swig_types[114]
-#define SWIGTYPE_p_six__TropoError swig_types[115]
-#define SWIGTYPE_p_six__UninitializedValueException swig_types[116]
-#define SWIGTYPE_p_six__XMLControl swig_types[117]
-#define SWIGTYPE_p_six__XYZEnum swig_types[118]
-#define SWIGTYPE_p_size_t swig_types[119]
-#define SWIGTYPE_p_size_type swig_types[120]
-#define SWIGTYPE_p_ssize_t swig_types[121]
-#define SWIGTYPE_p_std__allocatorT_std__string_t swig_types[122]
-#define SWIGTYPE_p_std__auto_ptrT_six__AmplitudeTable_t swig_types[123]
-#define SWIGTYPE_p_std__auto_ptrT_six__Components_t swig_types[124]
-#define SWIGTYPE_p_std__auto_ptrT_six__CompositeSCP_t swig_types[125]
-#define SWIGTYPE_p_std__auto_ptrT_six__CorrCoefs_t swig_types[126]
-#define SWIGTYPE_p_std__auto_ptrT_six__ErrorStatistics_t swig_types[127]
-#define SWIGTYPE_p_std__auto_ptrT_six__IonoError_t swig_types[128]
-#define SWIGTYPE_p_std__auto_ptrT_six__PosVelError_t swig_types[129]
-#define SWIGTYPE_p_std__auto_ptrT_six__RadarSensor_t swig_types[130]
-#define SWIGTYPE_p_std__auto_ptrT_six__Radiometric_t swig_types[131]
-#define SWIGTYPE_p_std__auto_ptrT_six__TropoError_t swig_types[132]
-#define SWIGTYPE_p_std__invalid_argument swig_types[133]
-#define SWIGTYPE_p_std__mapT_std__string_six__Parameter_t__const_iterator swig_types[134]
-#define SWIGTYPE_p_std__ostream swig_types[135]
-#define SWIGTYPE_p_std__string swig_types[136]
-#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[137]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[138]
-#define SWIGTYPE_p_types__RgAzT_double_t swig_types[139]
-#define SWIGTYPE_p_types__RowColT_double_t swig_types[140]
-#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[141]
-#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[142]
-#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[143]
-#define SWIGTYPE_p_uint16_t swig_types[144]
-#define SWIGTYPE_p_uint32_t swig_types[145]
-#define SWIGTYPE_p_uint64_t swig_types[146]
-#define SWIGTYPE_p_uint8_t swig_types[147]
-#define SWIGTYPE_p_unsigned_char swig_types[148]
-#define SWIGTYPE_p_value_type swig_types[149]
-#define SWIGTYPE_p_xml__lite__Document swig_types[150]
-static swig_type_info *swig_types[152];
-static swig_module_info swig_module = {swig_types, 151, 0, 0, 0, 0};
+#define SWIGTYPE_p_XMLControlRegistry swig_types[6]
+#define SWIGTYPE_p_allocator_type swig_types[7]
+#define SWIGTYPE_p_char swig_types[8]
+#define SWIGTYPE_p_difference_type swig_types[9]
+#define SWIGTYPE_p_except__BadCastException swig_types[10]
+#define SWIGTYPE_p_except__Context swig_types[11]
+#define SWIGTYPE_p_except__Exception swig_types[12]
+#define SWIGTYPE_p_except__FileNotFoundException swig_types[13]
+#define SWIGTYPE_p_except__IOException swig_types[14]
+#define SWIGTYPE_p_except__IndexOutOfRangeException swig_types[15]
+#define SWIGTYPE_p_except__InvalidArgumentException swig_types[16]
+#define SWIGTYPE_p_except__InvalidFormatException swig_types[17]
+#define SWIGTYPE_p_except__KeyAlreadyExistsException swig_types[18]
+#define SWIGTYPE_p_except__NoSuchKeyException swig_types[19]
+#define SWIGTYPE_p_except__NoSuchReferenceException swig_types[20]
+#define SWIGTYPE_p_except__NotImplementedException swig_types[21]
+#define SWIGTYPE_p_except__NullPointerReferenceException swig_types[22]
+#define SWIGTYPE_p_except__OutOfMemoryException swig_types[23]
+#define SWIGTYPE_p_except__ParseException swig_types[24]
+#define SWIGTYPE_p_except__SerializationException swig_types[25]
+#define SWIGTYPE_p_except__Throwable swig_types[26]
+#define SWIGTYPE_p_int swig_types[27]
+#define SWIGTYPE_p_int16_t swig_types[28]
+#define SWIGTYPE_p_int32_t swig_types[29]
+#define SWIGTYPE_p_int64_t swig_types[30]
+#define SWIGTYPE_p_int8_t swig_types[31]
+#define SWIGTYPE_p_io__InputStream swig_types[32]
+#define SWIGTYPE_p_logging__Logger swig_types[33]
+#define SWIGTYPE_p_math__linear__VectorNT_2_double_t swig_types[34]
+#define SWIGTYPE_p_math__linear__VectorNT_3_double_t swig_types[35]
+#define SWIGTYPE_p_math__linear__VectorT_double_t swig_types[36]
+#define SWIGTYPE_p_math__poly__OneDT_double_t swig_types[37]
+#define SWIGTYPE_p_math__poly__OneDT_math__linear__VectorNT_3_double_t_t swig_types[38]
+#define SWIGTYPE_p_math__poly__TwoDT_double_t swig_types[39]
+#define SWIGTYPE_p_mem__ScopedCloneablePtrT_six__AmplitudeTable_t swig_types[40]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__Components_t swig_types[41]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__CompositeSCP_t swig_types[42]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__CorrCoefs_t swig_types[43]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__ErrorStatistics_t swig_types[44]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__IonoError_t swig_types[45]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__PosVelError_t swig_types[46]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__RadarSensor_t swig_types[47]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__Radiometric_t swig_types[48]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__TropoError_t swig_types[49]
+#define SWIGTYPE_p_nitf_DateTime swig_types[50]
+#define SWIGTYPE_p_nitf__DateTime swig_types[51]
+#define SWIGTYPE_p_nitf__FileSecurity swig_types[52]
+#define SWIGTYPE_p_nitf__NITFException swig_types[53]
+#define SWIGTYPE_p_off_t swig_types[54]
+#define SWIGTYPE_p_p_PyObject swig_types[55]
+#define SWIGTYPE_p_pid_t swig_types[56]
+#define SWIGTYPE_p_scene__AngleMagnitude swig_types[57]
+#define SWIGTYPE_p_scene__Errors swig_types[58]
+#define SWIGTYPE_p_scene__FrameType swig_types[59]
+#define SWIGTYPE_p_scene__LatLon swig_types[60]
+#define SWIGTYPE_p_scene__LatLonAlt swig_types[61]
+#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[62]
+#define SWIGTYPE_p_six__AmplitudeTable swig_types[63]
+#define SWIGTYPE_p_six__AppliedType swig_types[64]
+#define SWIGTYPE_p_six__AutofocusType swig_types[65]
+#define SWIGTYPE_p_six__BooleanType swig_types[66]
+#define SWIGTYPE_p_six__ByteSwapping swig_types[67]
+#define SWIGTYPE_p_six__Classification swig_types[68]
+#define SWIGTYPE_p_six__CollectType swig_types[69]
+#define SWIGTYPE_p_six__ComplexImageGridType swig_types[70]
+#define SWIGTYPE_p_six__ComplexImagePlaneType swig_types[71]
+#define SWIGTYPE_p_six__Components swig_types[72]
+#define SWIGTYPE_p_six__CompositeSCP swig_types[73]
+#define SWIGTYPE_p_six__Constants swig_types[74]
+#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[75]
+#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[76]
+#define SWIGTYPE_p_six__CorrCoefs swig_types[77]
+#define SWIGTYPE_p_six__DESValidationException swig_types[78]
+#define SWIGTYPE_p_six__Data swig_types[79]
+#define SWIGTYPE_p_six__DataType swig_types[80]
+#define SWIGTYPE_p_six__DecimationMethod swig_types[81]
+#define SWIGTYPE_p_six__DecorrType swig_types[82]
+#define SWIGTYPE_p_six__DemodType swig_types[83]
+#define SWIGTYPE_p_six__DisplayType swig_types[84]
+#define SWIGTYPE_p_six__DualPolarizationType swig_types[85]
+#define SWIGTYPE_p_six__EarthModelType swig_types[86]
+#define SWIGTYPE_p_six__ErrorStatistics swig_types[87]
+#define SWIGTYPE_p_six__FFTSign swig_types[88]
+#define SWIGTYPE_p_six__ImageBeamCompensationType swig_types[89]
+#define SWIGTYPE_p_six__ImageFormationType swig_types[90]
+#define SWIGTYPE_p_six__Init swig_types[91]
+#define SWIGTYPE_p_six__IonoError swig_types[92]
+#define SWIGTYPE_p_six__LUT swig_types[93]
+#define SWIGTYPE_p_six__MagnificationMethod swig_types[94]
+#define SWIGTYPE_p_six__MissingRequiredException swig_types[95]
+#define SWIGTYPE_p_six__NoiseLevel swig_types[96]
+#define SWIGTYPE_p_six__Options swig_types[97]
+#define SWIGTYPE_p_six__OrientationType swig_types[98]
+#define SWIGTYPE_p_six__Parameter swig_types[99]
+#define SWIGTYPE_p_six__ParameterCollection swig_types[100]
+#define SWIGTYPE_p_six__PixelType swig_types[101]
+#define SWIGTYPE_p_six__PolarizationSequenceType swig_types[102]
+#define SWIGTYPE_p_six__PolarizationType swig_types[103]
+#define SWIGTYPE_p_six__PosVelError swig_types[104]
+#define SWIGTYPE_p_six__ProjectionType swig_types[105]
+#define SWIGTYPE_p_six__RMAlgoType swig_types[106]
+#define SWIGTYPE_p_six__RadarModeType swig_types[107]
+#define SWIGTYPE_p_six__RadarSensor swig_types[108]
+#define SWIGTYPE_p_six__Radiometric swig_types[109]
+#define SWIGTYPE_p_six__ReferencePoint swig_types[110]
+#define SWIGTYPE_p_six__RegionType swig_types[111]
+#define SWIGTYPE_p_six__RowColEnum swig_types[112]
+#define SWIGTYPE_p_six__SCP swig_types[113]
+#define SWIGTYPE_p_six__SCPType swig_types[114]
+#define SWIGTYPE_p_six__SideOfTrackType swig_types[115]
+#define SWIGTYPE_p_six__SlowTimeBeamCompensationType swig_types[116]
+#define SWIGTYPE_p_six__TropoError swig_types[117]
+#define SWIGTYPE_p_six__UninitializedValueException swig_types[118]
+#define SWIGTYPE_p_six__XMLControl swig_types[119]
+#define SWIGTYPE_p_six__XYZEnum swig_types[120]
+#define SWIGTYPE_p_size_t swig_types[121]
+#define SWIGTYPE_p_size_type swig_types[122]
+#define SWIGTYPE_p_ssize_t swig_types[123]
+#define SWIGTYPE_p_std__allocatorT_std__string_t swig_types[124]
+#define SWIGTYPE_p_std__auto_ptrT_six__AmplitudeTable_t swig_types[125]
+#define SWIGTYPE_p_std__auto_ptrT_six__Components_t swig_types[126]
+#define SWIGTYPE_p_std__auto_ptrT_six__CompositeSCP_t swig_types[127]
+#define SWIGTYPE_p_std__auto_ptrT_six__CorrCoefs_t swig_types[128]
+#define SWIGTYPE_p_std__auto_ptrT_six__ErrorStatistics_t swig_types[129]
+#define SWIGTYPE_p_std__auto_ptrT_six__IonoError_t swig_types[130]
+#define SWIGTYPE_p_std__auto_ptrT_six__PosVelError_t swig_types[131]
+#define SWIGTYPE_p_std__auto_ptrT_six__RadarSensor_t swig_types[132]
+#define SWIGTYPE_p_std__auto_ptrT_six__Radiometric_t swig_types[133]
+#define SWIGTYPE_p_std__auto_ptrT_six__TropoError_t swig_types[134]
+#define SWIGTYPE_p_std__invalid_argument swig_types[135]
+#define SWIGTYPE_p_std__mapT_std__string_six__Parameter_t__const_iterator swig_types[136]
+#define SWIGTYPE_p_std__ostream swig_types[137]
+#define SWIGTYPE_p_std__string swig_types[138]
+#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[139]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[140]
+#define SWIGTYPE_p_types__RgAzT_double_t swig_types[141]
+#define SWIGTYPE_p_types__RowColT_double_t swig_types[142]
+#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[143]
+#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[144]
+#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[145]
+#define SWIGTYPE_p_uint16_t swig_types[146]
+#define SWIGTYPE_p_uint32_t swig_types[147]
+#define SWIGTYPE_p_uint64_t swig_types[148]
+#define SWIGTYPE_p_uint8_t swig_types[149]
+#define SWIGTYPE_p_unsigned_char swig_types[150]
+#define SWIGTYPE_p_value_type swig_types[151]
+#define SWIGTYPE_p_xml__lite__Document swig_types[152]
+static swig_type_info *swig_types[154];
+static swig_module_info swig_module = {swig_types, 153, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3614,17 +3616,6 @@ using std::ptrdiff_t;
 #include "import/nitf.hpp"
 
 using namespace six;
-
-six::Data * parseDataNoAutoPtr(const XMLControlRegistry& xmlReg,
-                      ::io::InputStream& xmlStream,
-                      DataType dataType,
-                      const std::vector<std::string>& schemaPaths,
-                      logging::Logger& log)
-{
-  std::auto_ptr<Data> retv = six::parseData(xmlReg, xmlStream, dataType, schemaPaths, log);
-  return retv.release();
-}
-
 
 
 namespace swig {  
@@ -58198,6 +58189,837 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_parseData__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  XMLControlRegistry *arg1 = 0 ;
+  ::io::InputStream *arg2 = 0 ;
+  six::DataType arg3 ;
+  std::vector< std::string,std::allocator< std::string > > *arg4 = 0 ;
+  logging::Logger *arg5 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  std::auto_ptr< six::Data > result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:parseData",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_XMLControlRegistry,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "parseData" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseData" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  arg1 = reinterpret_cast< XMLControlRegistry * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_io__InputStream,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "parseData" "', argument " "2"" of type '" "::io::InputStream &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseData" "', argument " "2"" of type '" "::io::InputStream &""'"); 
+  }
+  arg2 = reinterpret_cast< ::io::InputStream * >(argp2);
+  {
+    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_six__DataType,  0  | 0);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "parseData" "', argument " "3"" of type '" "six::DataType""'"); 
+    }  
+    if (!argp3) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseData" "', argument " "3"" of type '" "six::DataType""'");
+    } else {
+      six::DataType * temp = reinterpret_cast< six::DataType * >(argp3);
+      arg3 = *temp;
+      if (SWIG_IsNewObj(res3)) delete temp;
+    }
+  }
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t,  0  | 0);
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "parseData" "', argument " "4"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseData" "', argument " "4"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  arg4 = reinterpret_cast< std::vector< std::string,std::allocator< std::string > > * >(argp4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5, SWIGTYPE_p_logging__Logger,  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "parseData" "', argument " "5"" of type '" "logging::Logger &""'"); 
+  }
+  if (!argp5) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseData" "', argument " "5"" of type '" "logging::Logger &""'"); 
+  }
+  arg5 = reinterpret_cast< logging::Logger * >(argp5);
+  {
+    try
+    {
+      result = six::parseData((XMLControlRegistry const &)*arg1,*arg2,arg3,(std::vector< std::string,std::allocator< std::string > > const &)*arg4,*arg5);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  
+  resultobj = SWIG_NewPointerObj((&result)->release(), SWIGTYPE_p_six__Data, SWIG_POINTER_OWN |  0 );
+  
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_parseData__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  XMLControlRegistry *arg1 = 0 ;
+  ::io::InputStream *arg2 = 0 ;
+  std::vector< std::string,std::allocator< std::string > > *arg3 = 0 ;
+  logging::Logger *arg4 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  std::auto_ptr< six::Data > result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:parseData",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_XMLControlRegistry,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "parseData" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseData" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  arg1 = reinterpret_cast< XMLControlRegistry * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_io__InputStream,  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "parseData" "', argument " "2"" of type '" "::io::InputStream &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseData" "', argument " "2"" of type '" "::io::InputStream &""'"); 
+  }
+  arg2 = reinterpret_cast< ::io::InputStream * >(argp2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "parseData" "', argument " "3"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseData" "', argument " "3"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  arg3 = reinterpret_cast< std::vector< std::string,std::allocator< std::string > > * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_logging__Logger,  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "parseData" "', argument " "4"" of type '" "logging::Logger &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseData" "', argument " "4"" of type '" "logging::Logger &""'"); 
+  }
+  arg4 = reinterpret_cast< logging::Logger * >(argp4);
+  {
+    try
+    {
+      result = six::parseData((XMLControlRegistry const &)*arg1,*arg2,(std::vector< std::string,std::allocator< std::string > > const &)*arg3,*arg4);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  
+  resultobj = SWIG_NewPointerObj((&result)->release(), SWIGTYPE_p_six__Data, SWIG_POINTER_OWN |  0 );
+  
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_parseData(PyObject *self, PyObject *args) {
+  int argc;
+  PyObject *argv[6] = {
+    0
+  };
+  int ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? (int)PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 5) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 4) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_io__InputStream, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_logging__Logger, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_parseData__SWIG_1(self, args);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 5) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_io__InputStream, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_six__DataType, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          int res = SWIG_ConvertPtr(argv[3], 0, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_logging__Logger, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              return _wrap_parseData__SWIG_0(self, args);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'parseData'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    six::parseData(XMLControlRegistry const &,::io::InputStream &,six::DataType,std::vector< std::string,std::allocator< std::string > > const &,logging::Logger &)\n"
+    "    six::parseData(XMLControlRegistry const &,::io::InputStream &,std::vector< std::string,std::allocator< std::string > > const &,logging::Logger &)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_parseDataFromFile__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  XMLControlRegistry *arg1 = 0 ;
+  std::string *arg2 = 0 ;
+  six::DataType arg3 ;
+  std::vector< std::string,std::allocator< std::string > > *arg4 = 0 ;
+  logging::Logger *arg5 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  std::auto_ptr< six::Data > result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:parseDataFromFile",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_XMLControlRegistry,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "parseDataFromFile" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromFile" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  arg1 = reinterpret_cast< XMLControlRegistry * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "parseDataFromFile" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromFile" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  {
+    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_six__DataType,  0  | 0);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "parseDataFromFile" "', argument " "3"" of type '" "six::DataType""'"); 
+    }  
+    if (!argp3) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromFile" "', argument " "3"" of type '" "six::DataType""'");
+    } else {
+      six::DataType * temp = reinterpret_cast< six::DataType * >(argp3);
+      arg3 = *temp;
+      if (SWIG_IsNewObj(res3)) delete temp;
+    }
+  }
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t,  0  | 0);
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "parseDataFromFile" "', argument " "4"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromFile" "', argument " "4"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  arg4 = reinterpret_cast< std::vector< std::string,std::allocator< std::string > > * >(argp4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5, SWIGTYPE_p_logging__Logger,  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "parseDataFromFile" "', argument " "5"" of type '" "logging::Logger &""'"); 
+  }
+  if (!argp5) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromFile" "', argument " "5"" of type '" "logging::Logger &""'"); 
+  }
+  arg5 = reinterpret_cast< logging::Logger * >(argp5);
+  {
+    try
+    {
+      result = six::parseDataFromFile((XMLControlRegistry const &)*arg1,(std::string const &)*arg2,arg3,(std::vector< std::string,std::allocator< std::string > > const &)*arg4,*arg5);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  
+  resultobj = SWIG_NewPointerObj((&result)->release(), SWIGTYPE_p_six__Data, SWIG_POINTER_OWN |  0 );
+  
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_parseDataFromFile__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  XMLControlRegistry *arg1 = 0 ;
+  std::string *arg2 = 0 ;
+  std::vector< std::string,std::allocator< std::string > > *arg3 = 0 ;
+  logging::Logger *arg4 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  std::auto_ptr< six::Data > result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:parseDataFromFile",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_XMLControlRegistry,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "parseDataFromFile" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromFile" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  arg1 = reinterpret_cast< XMLControlRegistry * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "parseDataFromFile" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromFile" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "parseDataFromFile" "', argument " "3"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromFile" "', argument " "3"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  arg3 = reinterpret_cast< std::vector< std::string,std::allocator< std::string > > * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_logging__Logger,  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "parseDataFromFile" "', argument " "4"" of type '" "logging::Logger &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromFile" "', argument " "4"" of type '" "logging::Logger &""'"); 
+  }
+  arg4 = reinterpret_cast< logging::Logger * >(argp4);
+  {
+    try
+    {
+      result = six::parseDataFromFile((XMLControlRegistry const &)*arg1,(std::string const &)*arg2,(std::vector< std::string,std::allocator< std::string > > const &)*arg3,*arg4);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  
+  resultobj = SWIG_NewPointerObj((&result)->release(), SWIGTYPE_p_six__Data, SWIG_POINTER_OWN |  0 );
+  
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_parseDataFromFile(PyObject *self, PyObject *args) {
+  int argc;
+  PyObject *argv[6] = {
+    0
+  };
+  int ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? (int)PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 5) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 4) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_logging__Logger, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_parseDataFromFile__SWIG_1(self, args);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 5) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_six__DataType, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          int res = SWIG_ConvertPtr(argv[3], 0, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_logging__Logger, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              return _wrap_parseDataFromFile__SWIG_0(self, args);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'parseDataFromFile'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    six::parseDataFromFile(XMLControlRegistry const &,std::string const &,six::DataType,std::vector< std::string,std::allocator< std::string > > const &,logging::Logger &)\n"
+    "    six::parseDataFromFile(XMLControlRegistry const &,std::string const &,std::vector< std::string,std::allocator< std::string > > const &,logging::Logger &)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_parseDataFromString__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  XMLControlRegistry *arg1 = 0 ;
+  std::string *arg2 = 0 ;
+  six::DataType arg3 ;
+  std::vector< std::string,std::allocator< std::string > > *arg4 = 0 ;
+  logging::Logger *arg5 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  void *argp5 = 0 ;
+  int res5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  std::auto_ptr< six::Data > result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:parseDataFromString",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_XMLControlRegistry,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "parseDataFromString" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromString" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  arg1 = reinterpret_cast< XMLControlRegistry * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "parseDataFromString" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromString" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  {
+    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_six__DataType,  0  | 0);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "parseDataFromString" "', argument " "3"" of type '" "six::DataType""'"); 
+    }  
+    if (!argp3) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromString" "', argument " "3"" of type '" "six::DataType""'");
+    } else {
+      six::DataType * temp = reinterpret_cast< six::DataType * >(argp3);
+      arg3 = *temp;
+      if (SWIG_IsNewObj(res3)) delete temp;
+    }
+  }
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t,  0  | 0);
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "parseDataFromString" "', argument " "4"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromString" "', argument " "4"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  arg4 = reinterpret_cast< std::vector< std::string,std::allocator< std::string > > * >(argp4);
+  res5 = SWIG_ConvertPtr(obj4, &argp5, SWIGTYPE_p_logging__Logger,  0 );
+  if (!SWIG_IsOK(res5)) {
+    SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "parseDataFromString" "', argument " "5"" of type '" "logging::Logger &""'"); 
+  }
+  if (!argp5) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromString" "', argument " "5"" of type '" "logging::Logger &""'"); 
+  }
+  arg5 = reinterpret_cast< logging::Logger * >(argp5);
+  {
+    try
+    {
+      result = six::parseDataFromString((XMLControlRegistry const &)*arg1,(std::string const &)*arg2,arg3,(std::vector< std::string,std::allocator< std::string > > const &)*arg4,*arg5);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  
+  resultobj = SWIG_NewPointerObj((&result)->release(), SWIGTYPE_p_six__Data, SWIG_POINTER_OWN |  0 );
+  
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_parseDataFromString__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  XMLControlRegistry *arg1 = 0 ;
+  std::string *arg2 = 0 ;
+  std::vector< std::string,std::allocator< std::string > > *arg3 = 0 ;
+  logging::Logger *arg4 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  std::auto_ptr< six::Data > result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:parseDataFromString",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_XMLControlRegistry,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "parseDataFromString" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromString" "', argument " "1"" of type '" "XMLControlRegistry const &""'"); 
+  }
+  arg1 = reinterpret_cast< XMLControlRegistry * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "parseDataFromString" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromString" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "parseDataFromString" "', argument " "3"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromString" "', argument " "3"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  arg3 = reinterpret_cast< std::vector< std::string,std::allocator< std::string > > * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4, SWIGTYPE_p_logging__Logger,  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "parseDataFromString" "', argument " "4"" of type '" "logging::Logger &""'"); 
+  }
+  if (!argp4) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "parseDataFromString" "', argument " "4"" of type '" "logging::Logger &""'"); 
+  }
+  arg4 = reinterpret_cast< logging::Logger * >(argp4);
+  {
+    try
+    {
+      result = six::parseDataFromString((XMLControlRegistry const &)*arg1,(std::string const &)*arg2,(std::vector< std::string,std::allocator< std::string > > const &)*arg3,*arg4);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  
+  resultobj = SWIG_NewPointerObj((&result)->release(), SWIGTYPE_p_six__Data, SWIG_POINTER_OWN |  0 );
+  
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_parseDataFromString(PyObject *self, PyObject *args) {
+  int argc;
+  PyObject *argv[6] = {
+    0
+  };
+  int ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? (int)PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 5) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 4) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_logging__Logger, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_parseDataFromString__SWIG_1(self, args);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 5) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_six__DataType, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          int res = SWIG_ConvertPtr(argv[3], 0, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            void *vptr = 0;
+            int res = SWIG_ConvertPtr(argv[4], &vptr, SWIGTYPE_p_logging__Logger, 0);
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              return _wrap_parseDataFromString__SWIG_0(self, args);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'parseDataFromString'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    six::parseDataFromString(XMLControlRegistry const &,std::string const &,six::DataType,std::vector< std::string,std::allocator< std::string > > const &,logging::Logger &)\n"
+    "    six::parseDataFromString(XMLControlRegistry const &,std::string const &,std::vector< std::string,std::allocator< std::string > > const &,logging::Logger &)\n");
+  return 0;
+}
+
+
 SWIGINTERN PyObject *_wrap_getErrors(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   six::ErrorStatistics *arg1 = (six::ErrorStatistics *) 0 ;
@@ -79971,6 +80793,18 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"XMLControl_swigregister", XMLControl_swigregister, METH_VARARGS, NULL},
 	 { (char *)"remapZeroTo360", _wrap_remapZeroTo360, METH_VARARGS, (char *)"remapZeroTo360(double degree) -> double"},
 	 { (char *)"loadPluginDir", _wrap_loadPluginDir, METH_VARARGS, (char *)"loadPluginDir(std::string const & pluginDir)"},
+	 { (char *)"parseData", _wrap_parseData, METH_VARARGS, (char *)"\n"
+		"parseData(XMLControlRegistry const & xmlReg, ::io::InputStream & xmlStream, DataType dataType, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >\n"
+		"parseData(XMLControlRegistry const & xmlReg, ::io::InputStream & xmlStream, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >\n"
+		""},
+	 { (char *)"parseDataFromFile", _wrap_parseDataFromFile, METH_VARARGS, (char *)"\n"
+		"parseDataFromFile(XMLControlRegistry const & xmlReg, std::string const & pathname, DataType dataType, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >\n"
+		"parseDataFromFile(XMLControlRegistry const & xmlReg, std::string const & pathname, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >\n"
+		""},
+	 { (char *)"parseDataFromString", _wrap_parseDataFromString, METH_VARARGS, (char *)"\n"
+		"parseDataFromString(XMLControlRegistry const & xmlReg, std::string const & xmlStr, DataType dataType, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >\n"
+		"parseDataFromString(XMLControlRegistry const & xmlReg, std::string const & xmlStr, VectorString schemaPaths, logging::Logger & log) -> std::auto_ptr< six::Data >\n"
+		""},
 	 { (char *)"getErrors", _wrap_getErrors, METH_VARARGS, (char *)"getErrors(ErrorStatistics errorStats, RgAzDouble sampleSpacing, Errors errors)"},
 	 { (char *)"delete_Options", _wrap_delete_Options, METH_VARARGS, (char *)"delete_Options(Options self)"},
 	 { (char *)"Options_getParameter", _wrap_Options_getParameter, METH_VARARGS, (char *)"\n"
@@ -80522,6 +81356,7 @@ static swig_type_info _swigt__p_Options = {"_p_Options", "Options *", 0, 0, (voi
 static swig_type_info _swigt__p_ParameterCollectionIteratorT = {"_p_ParameterCollectionIteratorT", "ParameterCollectionIteratorT *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_ParameterIter = {"_p_ParameterIter", "ParameterIter *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_ParameterMap = {"_p_ParameterMap", "ParameterMap *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_XMLControlRegistry = {"_p_XMLControlRegistry", "XMLControlRegistry *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_allocator_type = {"_p_allocator_type", "allocator_type *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *|sys::byte *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_difference_type = {"_p_difference_type", "difference_type *", 0, 0, (void*)0, 0};
@@ -80547,6 +81382,7 @@ static swig_type_info _swigt__p_int16_t = {"_p_int16_t", "sys::Int16_T *|int16_t
 static swig_type_info _swigt__p_int32_t = {"_p_int32_t", "sys::Int32_T *|int32_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_int64_t = {"_p_int64_t", "sys::Int64_T *|int64_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_int8_t = {"_p_int8_t", "sys::Int8_T *|int8_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_io__InputStream = {"_p_io__InputStream", "::io::InputStream *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_logging__Logger = {"_p_logging__Logger", "logging::Logger *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_math__linear__VectorNT_2_double_t = {"_p_math__linear__VectorNT_2_double_t", "scene::Vector2 *|math::linear::VectorN< 2,double > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_math__linear__VectorNT_3_double_t = {"_p_math__linear__VectorNT_3_double_t", "Vector3 *|scene::Vector3 *|six::Vector3 *|math::linear::VectorN< 3,double > *", 0, 0, (void*)0, 0};
@@ -80675,6 +81511,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_ParameterCollectionIteratorT,
   &_swigt__p_ParameterIter,
   &_swigt__p_ParameterMap,
+  &_swigt__p_XMLControlRegistry,
   &_swigt__p_allocator_type,
   &_swigt__p_char,
   &_swigt__p_difference_type,
@@ -80700,6 +81537,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_int32_t,
   &_swigt__p_int64_t,
   &_swigt__p_int8_t,
+  &_swigt__p_io__InputStream,
   &_swigt__p_logging__Logger,
   &_swigt__p_math__linear__VectorNT_2_double_t,
   &_swigt__p_math__linear__VectorNT_3_double_t,
@@ -80828,6 +81666,7 @@ static swig_cast_info _swigc__p_Options[] = {  {&_swigt__p_Options, 0, 0, 0},{0,
 static swig_cast_info _swigc__p_ParameterCollectionIteratorT[] = {  {&_swigt__p_ParameterCollectionIteratorT, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_ParameterIter[] = {  {&_swigt__p_ParameterIter, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_ParameterMap[] = {  {&_swigt__p_ParameterMap, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_XMLControlRegistry[] = {  {&_swigt__p_XMLControlRegistry, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_allocator_type[] = {  {&_swigt__p_allocator_type, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_difference_type[] = {  {&_swigt__p_difference_type, 0, 0, 0},{0, 0, 0, 0}};
@@ -80853,6 +81692,7 @@ static swig_cast_info _swigc__p_int16_t[] = {  {&_swigt__p_int16_t, 0, 0, 0},{0,
 static swig_cast_info _swigc__p_int32_t[] = {  {&_swigt__p_int32_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_int64_t[] = {  {&_swigt__p_int64_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_int8_t[] = {  {&_swigt__p_int8_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_io__InputStream[] = {  {&_swigt__p_io__InputStream, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_logging__Logger[] = {  {&_swigt__p_logging__Logger, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_math__linear__VectorNT_2_double_t[] = {  {&_swigt__p_math__linear__VectorNT_2_double_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_math__linear__VectorNT_3_double_t[] = {  {&_swigt__p_math__linear__VectorNT_3_double_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -80981,6 +81821,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_ParameterCollectionIteratorT,
   _swigc__p_ParameterIter,
   _swigc__p_ParameterMap,
+  _swigc__p_XMLControlRegistry,
   _swigc__p_allocator_type,
   _swigc__p_char,
   _swigc__p_difference_type,
@@ -81006,6 +81847,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_int32_t,
   _swigc__p_int64_t,
   _swigc__p_int8_t,
+  _swigc__p_io__InputStream,
   _swigc__p_logging__Logger,
   _swigc__p_math__linear__VectorNT_2_double_t,
   _swigc__p_math__linear__VectorNT_3_double_t,

--- a/six/modules/python/six/source/generated/six_base_wrap.cxx
+++ b/six/modules/python/six/source/generated/six_base_wrap.cxx
@@ -3020,111 +3020,115 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__RadarSensor_t swig_types[47]
 #define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__Radiometric_t swig_types[48]
 #define SWIGTYPE_p_mem__ScopedCopyablePtrT_six__TropoError_t swig_types[49]
-#define SWIGTYPE_p_nitf_DateTime swig_types[50]
-#define SWIGTYPE_p_nitf__DateTime swig_types[51]
-#define SWIGTYPE_p_nitf__FileSecurity swig_types[52]
-#define SWIGTYPE_p_nitf__NITFException swig_types[53]
-#define SWIGTYPE_p_off_t swig_types[54]
-#define SWIGTYPE_p_p_PyObject swig_types[55]
-#define SWIGTYPE_p_pid_t swig_types[56]
-#define SWIGTYPE_p_scene__AngleMagnitude swig_types[57]
-#define SWIGTYPE_p_scene__Errors swig_types[58]
-#define SWIGTYPE_p_scene__FrameType swig_types[59]
-#define SWIGTYPE_p_scene__LatLon swig_types[60]
-#define SWIGTYPE_p_scene__LatLonAlt swig_types[61]
-#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[62]
-#define SWIGTYPE_p_six__AmplitudeTable swig_types[63]
-#define SWIGTYPE_p_six__AppliedType swig_types[64]
-#define SWIGTYPE_p_six__AutofocusType swig_types[65]
-#define SWIGTYPE_p_six__BooleanType swig_types[66]
-#define SWIGTYPE_p_six__ByteSwapping swig_types[67]
-#define SWIGTYPE_p_six__Classification swig_types[68]
-#define SWIGTYPE_p_six__CollectType swig_types[69]
-#define SWIGTYPE_p_six__ComplexImageGridType swig_types[70]
-#define SWIGTYPE_p_six__ComplexImagePlaneType swig_types[71]
-#define SWIGTYPE_p_six__Components swig_types[72]
-#define SWIGTYPE_p_six__CompositeSCP swig_types[73]
-#define SWIGTYPE_p_six__Constants swig_types[74]
-#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[75]
-#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[76]
-#define SWIGTYPE_p_six__CorrCoefs swig_types[77]
-#define SWIGTYPE_p_six__DESValidationException swig_types[78]
-#define SWIGTYPE_p_six__Data swig_types[79]
-#define SWIGTYPE_p_six__DataType swig_types[80]
-#define SWIGTYPE_p_six__DecimationMethod swig_types[81]
-#define SWIGTYPE_p_six__DecorrType swig_types[82]
-#define SWIGTYPE_p_six__DemodType swig_types[83]
-#define SWIGTYPE_p_six__DisplayType swig_types[84]
-#define SWIGTYPE_p_six__DualPolarizationType swig_types[85]
-#define SWIGTYPE_p_six__EarthModelType swig_types[86]
-#define SWIGTYPE_p_six__ErrorStatistics swig_types[87]
-#define SWIGTYPE_p_six__FFTSign swig_types[88]
-#define SWIGTYPE_p_six__ImageBeamCompensationType swig_types[89]
-#define SWIGTYPE_p_six__ImageFormationType swig_types[90]
-#define SWIGTYPE_p_six__Init swig_types[91]
-#define SWIGTYPE_p_six__IonoError swig_types[92]
-#define SWIGTYPE_p_six__LUT swig_types[93]
-#define SWIGTYPE_p_six__MagnificationMethod swig_types[94]
-#define SWIGTYPE_p_six__MissingRequiredException swig_types[95]
-#define SWIGTYPE_p_six__NoiseLevel swig_types[96]
-#define SWIGTYPE_p_six__Options swig_types[97]
-#define SWIGTYPE_p_six__OrientationType swig_types[98]
-#define SWIGTYPE_p_six__Parameter swig_types[99]
-#define SWIGTYPE_p_six__ParameterCollection swig_types[100]
-#define SWIGTYPE_p_six__PixelType swig_types[101]
-#define SWIGTYPE_p_six__PolarizationSequenceType swig_types[102]
-#define SWIGTYPE_p_six__PolarizationType swig_types[103]
-#define SWIGTYPE_p_six__PosVelError swig_types[104]
-#define SWIGTYPE_p_six__ProjectionType swig_types[105]
-#define SWIGTYPE_p_six__RMAlgoType swig_types[106]
-#define SWIGTYPE_p_six__RadarModeType swig_types[107]
-#define SWIGTYPE_p_six__RadarSensor swig_types[108]
-#define SWIGTYPE_p_six__Radiometric swig_types[109]
-#define SWIGTYPE_p_six__ReferencePoint swig_types[110]
-#define SWIGTYPE_p_six__RegionType swig_types[111]
-#define SWIGTYPE_p_six__RowColEnum swig_types[112]
-#define SWIGTYPE_p_six__SCP swig_types[113]
-#define SWIGTYPE_p_six__SCPType swig_types[114]
-#define SWIGTYPE_p_six__SideOfTrackType swig_types[115]
-#define SWIGTYPE_p_six__SlowTimeBeamCompensationType swig_types[116]
-#define SWIGTYPE_p_six__TropoError swig_types[117]
-#define SWIGTYPE_p_six__UninitializedValueException swig_types[118]
-#define SWIGTYPE_p_six__XMLControl swig_types[119]
-#define SWIGTYPE_p_six__XYZEnum swig_types[120]
-#define SWIGTYPE_p_size_t swig_types[121]
-#define SWIGTYPE_p_size_type swig_types[122]
-#define SWIGTYPE_p_ssize_t swig_types[123]
-#define SWIGTYPE_p_std__allocatorT_std__string_t swig_types[124]
-#define SWIGTYPE_p_std__auto_ptrT_six__AmplitudeTable_t swig_types[125]
-#define SWIGTYPE_p_std__auto_ptrT_six__Components_t swig_types[126]
-#define SWIGTYPE_p_std__auto_ptrT_six__CompositeSCP_t swig_types[127]
-#define SWIGTYPE_p_std__auto_ptrT_six__CorrCoefs_t swig_types[128]
-#define SWIGTYPE_p_std__auto_ptrT_six__ErrorStatistics_t swig_types[129]
-#define SWIGTYPE_p_std__auto_ptrT_six__IonoError_t swig_types[130]
-#define SWIGTYPE_p_std__auto_ptrT_six__PosVelError_t swig_types[131]
-#define SWIGTYPE_p_std__auto_ptrT_six__RadarSensor_t swig_types[132]
-#define SWIGTYPE_p_std__auto_ptrT_six__Radiometric_t swig_types[133]
-#define SWIGTYPE_p_std__auto_ptrT_six__TropoError_t swig_types[134]
-#define SWIGTYPE_p_std__invalid_argument swig_types[135]
-#define SWIGTYPE_p_std__mapT_std__string_six__Parameter_t__const_iterator swig_types[136]
-#define SWIGTYPE_p_std__ostream swig_types[137]
-#define SWIGTYPE_p_std__string swig_types[138]
-#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[139]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[140]
-#define SWIGTYPE_p_types__RgAzT_double_t swig_types[141]
-#define SWIGTYPE_p_types__RowColT_double_t swig_types[142]
-#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[143]
-#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[144]
-#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[145]
-#define SWIGTYPE_p_uint16_t swig_types[146]
-#define SWIGTYPE_p_uint32_t swig_types[147]
-#define SWIGTYPE_p_uint64_t swig_types[148]
-#define SWIGTYPE_p_uint8_t swig_types[149]
-#define SWIGTYPE_p_unsigned_char swig_types[150]
-#define SWIGTYPE_p_value_type swig_types[151]
-#define SWIGTYPE_p_xml__lite__Document swig_types[152]
-static swig_type_info *swig_types[154];
-static swig_module_info swig_module = {swig_types, 153, 0, 0, 0, 0};
+#define SWIGTYPE_p_mt__SingletonT_six__XMLControlRegistry_true_t swig_types[50]
+#define SWIGTYPE_p_nitf_DateTime swig_types[51]
+#define SWIGTYPE_p_nitf__DateTime swig_types[52]
+#define SWIGTYPE_p_nitf__FileSecurity swig_types[53]
+#define SWIGTYPE_p_nitf__NITFException swig_types[54]
+#define SWIGTYPE_p_off_t swig_types[55]
+#define SWIGTYPE_p_p_PyObject swig_types[56]
+#define SWIGTYPE_p_pid_t swig_types[57]
+#define SWIGTYPE_p_scene__AngleMagnitude swig_types[58]
+#define SWIGTYPE_p_scene__Errors swig_types[59]
+#define SWIGTYPE_p_scene__FrameType swig_types[60]
+#define SWIGTYPE_p_scene__LatLon swig_types[61]
+#define SWIGTYPE_p_scene__LatLonAlt swig_types[62]
+#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[63]
+#define SWIGTYPE_p_six__AmplitudeTable swig_types[64]
+#define SWIGTYPE_p_six__AppliedType swig_types[65]
+#define SWIGTYPE_p_six__AutofocusType swig_types[66]
+#define SWIGTYPE_p_six__BooleanType swig_types[67]
+#define SWIGTYPE_p_six__ByteSwapping swig_types[68]
+#define SWIGTYPE_p_six__Classification swig_types[69]
+#define SWIGTYPE_p_six__CollectType swig_types[70]
+#define SWIGTYPE_p_six__ComplexImageGridType swig_types[71]
+#define SWIGTYPE_p_six__ComplexImagePlaneType swig_types[72]
+#define SWIGTYPE_p_six__Components swig_types[73]
+#define SWIGTYPE_p_six__CompositeSCP swig_types[74]
+#define SWIGTYPE_p_six__Constants swig_types[75]
+#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[76]
+#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[77]
+#define SWIGTYPE_p_six__CorrCoefs swig_types[78]
+#define SWIGTYPE_p_six__DESValidationException swig_types[79]
+#define SWIGTYPE_p_six__Data swig_types[80]
+#define SWIGTYPE_p_six__DataType swig_types[81]
+#define SWIGTYPE_p_six__DecimationMethod swig_types[82]
+#define SWIGTYPE_p_six__DecorrType swig_types[83]
+#define SWIGTYPE_p_six__DemodType swig_types[84]
+#define SWIGTYPE_p_six__DisplayType swig_types[85]
+#define SWIGTYPE_p_six__DualPolarizationType swig_types[86]
+#define SWIGTYPE_p_six__EarthModelType swig_types[87]
+#define SWIGTYPE_p_six__ErrorStatistics swig_types[88]
+#define SWIGTYPE_p_six__FFTSign swig_types[89]
+#define SWIGTYPE_p_six__ImageBeamCompensationType swig_types[90]
+#define SWIGTYPE_p_six__ImageFormationType swig_types[91]
+#define SWIGTYPE_p_six__Init swig_types[92]
+#define SWIGTYPE_p_six__IonoError swig_types[93]
+#define SWIGTYPE_p_six__LUT swig_types[94]
+#define SWIGTYPE_p_six__MagnificationMethod swig_types[95]
+#define SWIGTYPE_p_six__MissingRequiredException swig_types[96]
+#define SWIGTYPE_p_six__NoiseLevel swig_types[97]
+#define SWIGTYPE_p_six__Options swig_types[98]
+#define SWIGTYPE_p_six__OrientationType swig_types[99]
+#define SWIGTYPE_p_six__Parameter swig_types[100]
+#define SWIGTYPE_p_six__ParameterCollection swig_types[101]
+#define SWIGTYPE_p_six__PixelType swig_types[102]
+#define SWIGTYPE_p_six__PolarizationSequenceType swig_types[103]
+#define SWIGTYPE_p_six__PolarizationType swig_types[104]
+#define SWIGTYPE_p_six__PosVelError swig_types[105]
+#define SWIGTYPE_p_six__ProjectionType swig_types[106]
+#define SWIGTYPE_p_six__RMAlgoType swig_types[107]
+#define SWIGTYPE_p_six__RadarModeType swig_types[108]
+#define SWIGTYPE_p_six__RadarSensor swig_types[109]
+#define SWIGTYPE_p_six__Radiometric swig_types[110]
+#define SWIGTYPE_p_six__ReferencePoint swig_types[111]
+#define SWIGTYPE_p_six__RegionType swig_types[112]
+#define SWIGTYPE_p_six__RowColEnum swig_types[113]
+#define SWIGTYPE_p_six__SCP swig_types[114]
+#define SWIGTYPE_p_six__SCPType swig_types[115]
+#define SWIGTYPE_p_six__SideOfTrackType swig_types[116]
+#define SWIGTYPE_p_six__SlowTimeBeamCompensationType swig_types[117]
+#define SWIGTYPE_p_six__TropoError swig_types[118]
+#define SWIGTYPE_p_six__UninitializedValueException swig_types[119]
+#define SWIGTYPE_p_six__XMLControl swig_types[120]
+#define SWIGTYPE_p_six__XMLControlCreator swig_types[121]
+#define SWIGTYPE_p_six__XMLControlRegistry swig_types[122]
+#define SWIGTYPE_p_six__XYZEnum swig_types[123]
+#define SWIGTYPE_p_size_t swig_types[124]
+#define SWIGTYPE_p_size_type swig_types[125]
+#define SWIGTYPE_p_ssize_t swig_types[126]
+#define SWIGTYPE_p_std__allocatorT_std__string_t swig_types[127]
+#define SWIGTYPE_p_std__auto_ptrT_six__AmplitudeTable_t swig_types[128]
+#define SWIGTYPE_p_std__auto_ptrT_six__Components_t swig_types[129]
+#define SWIGTYPE_p_std__auto_ptrT_six__CompositeSCP_t swig_types[130]
+#define SWIGTYPE_p_std__auto_ptrT_six__CorrCoefs_t swig_types[131]
+#define SWIGTYPE_p_std__auto_ptrT_six__ErrorStatistics_t swig_types[132]
+#define SWIGTYPE_p_std__auto_ptrT_six__IonoError_t swig_types[133]
+#define SWIGTYPE_p_std__auto_ptrT_six__PosVelError_t swig_types[134]
+#define SWIGTYPE_p_std__auto_ptrT_six__RadarSensor_t swig_types[135]
+#define SWIGTYPE_p_std__auto_ptrT_six__Radiometric_t swig_types[136]
+#define SWIGTYPE_p_std__auto_ptrT_six__TropoError_t swig_types[137]
+#define SWIGTYPE_p_std__auto_ptrT_six__XMLControlCreator_t swig_types[138]
+#define SWIGTYPE_p_std__invalid_argument swig_types[139]
+#define SWIGTYPE_p_std__mapT_std__string_six__Parameter_t__const_iterator swig_types[140]
+#define SWIGTYPE_p_std__ostream swig_types[141]
+#define SWIGTYPE_p_std__string swig_types[142]
+#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[143]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[144]
+#define SWIGTYPE_p_types__RgAzT_double_t swig_types[145]
+#define SWIGTYPE_p_types__RowColT_double_t swig_types[146]
+#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[147]
+#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[148]
+#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[149]
+#define SWIGTYPE_p_uint16_t swig_types[150]
+#define SWIGTYPE_p_uint32_t swig_types[151]
+#define SWIGTYPE_p_uint64_t swig_types[152]
+#define SWIGTYPE_p_uint8_t swig_types[153]
+#define SWIGTYPE_p_unsigned_char swig_types[154]
+#define SWIGTYPE_p_value_type swig_types[155]
+#define SWIGTYPE_p_xml__lite__Document swig_types[156]
+static swig_type_info *swig_types[158];
+static swig_module_info swig_module = {swig_types, 157, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -59785,6 +59789,1231 @@ SWIGINTERN PyObject *Options_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObje
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_delete_XMLControlCreator(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlCreator *arg1 = (six::XMLControlCreator *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_XMLControlCreator",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__XMLControlCreator, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_XMLControlCreator" "', argument " "1"" of type '" "six::XMLControlCreator *""'"); 
+  }
+  arg1 = reinterpret_cast< six::XMLControlCreator * >(argp1);
+  {
+    try
+    {
+      delete arg1;
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_XMLControlCreator_newXMLControl(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlCreator *arg1 = (six::XMLControlCreator *) 0 ;
+  logging::Logger *arg2 = (logging::Logger *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  six::XMLControl *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:XMLControlCreator_newXMLControl",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__XMLControlCreator, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "XMLControlCreator_newXMLControl" "', argument " "1"" of type '" "six::XMLControlCreator const *""'"); 
+  }
+  arg1 = reinterpret_cast< six::XMLControlCreator * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_logging__Logger, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "XMLControlCreator_newXMLControl" "', argument " "2"" of type '" "logging::Logger *""'"); 
+  }
+  arg2 = reinterpret_cast< logging::Logger * >(argp2);
+  {
+    try
+    {
+      result = (six::XMLControl *)((six::XMLControlCreator const *)arg1)->newXMLControl(arg2);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_six__XMLControl, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *XMLControlCreator_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_six__XMLControlCreator, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_new_XMLControlRegistry(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlRegistry *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_XMLControlRegistry")) SWIG_fail;
+  {
+    try
+    {
+      result = (six::XMLControlRegistry *)new six::XMLControlRegistry();
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_six__XMLControlRegistry, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_XMLControlRegistry(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlRegistry *arg1 = (six::XMLControlRegistry *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_XMLControlRegistry",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__XMLControlRegistry, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_XMLControlRegistry" "', argument " "1"" of type '" "six::XMLControlRegistry *""'"); 
+  }
+  arg1 = reinterpret_cast< six::XMLControlRegistry * >(argp1);
+  {
+    try
+    {
+      delete arg1;
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_XMLControlRegistry_addCreator__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlRegistry *arg1 = (six::XMLControlRegistry *) 0 ;
+  std::string *arg2 = 0 ;
+  std::auto_ptr< six::XMLControlCreator > arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:XMLControlRegistry_addCreator",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__XMLControlRegistry, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "XMLControlRegistry_addCreator" "', argument " "1"" of type '" "six::XMLControlRegistry *""'"); 
+  }
+  arg1 = reinterpret_cast< six::XMLControlRegistry * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "XMLControlRegistry_addCreator" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "XMLControlRegistry_addCreator" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  {
+    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_std__auto_ptrT_six__XMLControlCreator_t,  0  | 0);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "XMLControlRegistry_addCreator" "', argument " "3"" of type '" "std::auto_ptr< six::XMLControlCreator >""'"); 
+    }  
+    if (!argp3) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "XMLControlRegistry_addCreator" "', argument " "3"" of type '" "std::auto_ptr< six::XMLControlCreator >""'");
+    } else {
+      std::auto_ptr< six::XMLControlCreator > * temp = reinterpret_cast< std::auto_ptr< six::XMLControlCreator > * >(argp3);
+      arg3 = *temp;
+      if (SWIG_IsNewObj(res3)) delete temp;
+    }
+  }
+  {
+    try
+    {
+      (arg1)->addCreator((std::string const &)*arg2,arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_XMLControlRegistry_addCreator__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlRegistry *arg1 = (six::XMLControlRegistry *) 0 ;
+  std::string *arg2 = 0 ;
+  six::XMLControlCreator *arg3 = (six::XMLControlCreator *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:XMLControlRegistry_addCreator",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__XMLControlRegistry, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "XMLControlRegistry_addCreator" "', argument " "1"" of type '" "six::XMLControlRegistry *""'"); 
+  }
+  arg1 = reinterpret_cast< six::XMLControlRegistry * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "XMLControlRegistry_addCreator" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "XMLControlRegistry_addCreator" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_six__XMLControlCreator, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "XMLControlRegistry_addCreator" "', argument " "3"" of type '" "six::XMLControlCreator *""'"); 
+  }
+  arg3 = reinterpret_cast< six::XMLControlCreator * >(argp3);
+  {
+    try
+    {
+      (arg1)->addCreator((std::string const &)*arg2,arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_XMLControlRegistry_addCreator__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlRegistry *arg1 = (six::XMLControlRegistry *) 0 ;
+  six::DataType arg2 ;
+  std::auto_ptr< six::XMLControlCreator > arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  void *argp3 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:XMLControlRegistry_addCreator",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__XMLControlRegistry, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "XMLControlRegistry_addCreator" "', argument " "1"" of type '" "six::XMLControlRegistry *""'"); 
+  }
+  arg1 = reinterpret_cast< six::XMLControlRegistry * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_six__DataType,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "XMLControlRegistry_addCreator" "', argument " "2"" of type '" "six::DataType""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "XMLControlRegistry_addCreator" "', argument " "2"" of type '" "six::DataType""'");
+    } else {
+      six::DataType * temp = reinterpret_cast< six::DataType * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  {
+    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_std__auto_ptrT_six__XMLControlCreator_t,  0  | 0);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "XMLControlRegistry_addCreator" "', argument " "3"" of type '" "std::auto_ptr< six::XMLControlCreator >""'"); 
+    }  
+    if (!argp3) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "XMLControlRegistry_addCreator" "', argument " "3"" of type '" "std::auto_ptr< six::XMLControlCreator >""'");
+    } else {
+      std::auto_ptr< six::XMLControlCreator > * temp = reinterpret_cast< std::auto_ptr< six::XMLControlCreator > * >(argp3);
+      arg3 = *temp;
+      if (SWIG_IsNewObj(res3)) delete temp;
+    }
+  }
+  {
+    try
+    {
+      (arg1)->addCreator(arg2,arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_XMLControlRegistry_addCreator__SWIG_3(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlRegistry *arg1 = (six::XMLControlRegistry *) 0 ;
+  six::DataType arg2 ;
+  six::XMLControlCreator *arg3 = (six::XMLControlCreator *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:XMLControlRegistry_addCreator",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__XMLControlRegistry, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "XMLControlRegistry_addCreator" "', argument " "1"" of type '" "six::XMLControlRegistry *""'"); 
+  }
+  arg1 = reinterpret_cast< six::XMLControlRegistry * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_six__DataType,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "XMLControlRegistry_addCreator" "', argument " "2"" of type '" "six::DataType""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "XMLControlRegistry_addCreator" "', argument " "2"" of type '" "six::DataType""'");
+    } else {
+      six::DataType * temp = reinterpret_cast< six::DataType * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_six__XMLControlCreator, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "XMLControlRegistry_addCreator" "', argument " "3"" of type '" "six::XMLControlCreator *""'"); 
+  }
+  arg3 = reinterpret_cast< six::XMLControlCreator * >(argp3);
+  {
+    try
+    {
+      (arg1)->addCreator(arg2,arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_XMLControlRegistry_addCreator(PyObject *self, PyObject *args) {
+  int argc;
+  PyObject *argv[4] = {
+    0
+  };
+  int ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? (int)PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 3) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_six__DataType, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_std__auto_ptrT_six__XMLControlCreator_t, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_XMLControlRegistry_addCreator__SWIG_2(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_six__DataType, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_six__XMLControlCreator, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_XMLControlRegistry_addCreator__SWIG_3(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_std__auto_ptrT_six__XMLControlCreator_t, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_XMLControlRegistry_addCreator__SWIG_0(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_six__XMLControlCreator, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_XMLControlRegistry_addCreator__SWIG_1(self, args);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'XMLControlRegistry_addCreator'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    six::XMLControlRegistry::addCreator(std::string const &,std::auto_ptr< six::XMLControlCreator >)\n"
+    "    six::XMLControlRegistry::addCreator(std::string const &,six::XMLControlCreator *)\n"
+    "    six::XMLControlRegistry::addCreator(six::DataType,std::auto_ptr< six::XMLControlCreator >)\n"
+    "    six::XMLControlRegistry::addCreator(six::DataType,six::XMLControlCreator *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_XMLControlRegistry_newXMLControl__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlRegistry *arg1 = (six::XMLControlRegistry *) 0 ;
+  std::string *arg2 = 0 ;
+  logging::Logger *arg3 = (logging::Logger *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  six::XMLControl *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:XMLControlRegistry_newXMLControl",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__XMLControlRegistry, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "XMLControlRegistry_newXMLControl" "', argument " "1"" of type '" "six::XMLControlRegistry const *""'"); 
+  }
+  arg1 = reinterpret_cast< six::XMLControlRegistry * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "XMLControlRegistry_newXMLControl" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "XMLControlRegistry_newXMLControl" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_logging__Logger, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "XMLControlRegistry_newXMLControl" "', argument " "3"" of type '" "logging::Logger *""'"); 
+  }
+  arg3 = reinterpret_cast< logging::Logger * >(argp3);
+  {
+    try
+    {
+      result = (six::XMLControl *)((six::XMLControlRegistry const *)arg1)->newXMLControl((std::string const &)*arg2,arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_six__XMLControl, 0 |  0 );
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_XMLControlRegistry_newXMLControl__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::XMLControlRegistry *arg1 = (six::XMLControlRegistry *) 0 ;
+  six::DataType arg2 ;
+  logging::Logger *arg3 = (logging::Logger *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  six::XMLControl *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:XMLControlRegistry_newXMLControl",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__XMLControlRegistry, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "XMLControlRegistry_newXMLControl" "', argument " "1"" of type '" "six::XMLControlRegistry const *""'"); 
+  }
+  arg1 = reinterpret_cast< six::XMLControlRegistry * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_six__DataType,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "XMLControlRegistry_newXMLControl" "', argument " "2"" of type '" "six::DataType""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "XMLControlRegistry_newXMLControl" "', argument " "2"" of type '" "six::DataType""'");
+    } else {
+      six::DataType * temp = reinterpret_cast< six::DataType * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_logging__Logger, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "XMLControlRegistry_newXMLControl" "', argument " "3"" of type '" "logging::Logger *""'"); 
+  }
+  arg3 = reinterpret_cast< logging::Logger * >(argp3);
+  {
+    try
+    {
+      result = (six::XMLControl *)((six::XMLControlRegistry const *)arg1)->newXMLControl(arg2,arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_six__XMLControl, 0 |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_XMLControlRegistry_newXMLControl(PyObject *self, PyObject *args) {
+  int argc;
+  PyObject *argv[4] = {
+    0
+  };
+  int ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? (int)PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 3) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_six__DataType, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_logging__Logger, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_XMLControlRegistry_newXMLControl__SWIG_1(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__XMLControlRegistry, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_logging__Logger, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_XMLControlRegistry_newXMLControl__SWIG_0(self, args);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'XMLControlRegistry_newXMLControl'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    six::XMLControlRegistry::newXMLControl(std::string const &,logging::Logger *) const\n"
+    "    six::XMLControlRegistry::newXMLControl(six::DataType,logging::Logger *) const\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *XMLControlRegistry_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_six__XMLControlRegistry, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
+SWIGINTERN PyObject *_wrap_toXMLString__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::Data *arg1 = (six::Data *) 0 ;
+  six::XMLControlRegistry *arg2 = (six::XMLControlRegistry *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  std::string result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:toXMLString",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__Data, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "toXMLString" "', argument " "1"" of type '" "six::Data const *""'"); 
+  }
+  arg1 = reinterpret_cast< six::Data * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_six__XMLControlRegistry, 0 |  0 );
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "toXMLString" "', argument " "2"" of type '" "six::XMLControlRegistry const *""'"); 
+  }
+  arg2 = reinterpret_cast< six::XMLControlRegistry * >(argp2);
+  {
+    try
+    {
+      result = six::toXMLString((six::Data const *)arg1,(six::XMLControlRegistry const *)arg2);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_From_std_string(static_cast< std::string >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_toXMLString__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::Data *arg1 = (six::Data *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  std::string result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:toXMLString",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__Data, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "toXMLString" "', argument " "1"" of type '" "six::Data const *""'"); 
+  }
+  arg1 = reinterpret_cast< six::Data * >(argp1);
+  {
+    try
+    {
+      result = six::toXMLString((six::Data const *)arg1);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_From_std_string(static_cast< std::string >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_toXMLString(PyObject *self, PyObject *args) {
+  int argc;
+  PyObject *argv[3] = {
+    0
+  };
+  int ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? (int)PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 2) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 1) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__Data, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_toXMLString__SWIG_1(self, args);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__Data, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_six__XMLControlRegistry, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_toXMLString__SWIG_0(self, args);
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'toXMLString'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    six::toXMLString(six::Data const *,six::XMLControlRegistry const *)\n"
+    "    six::toXMLString(six::Data const *)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_toValidXMLString__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::Data *arg1 = (six::Data *) 0 ;
+  std::vector< std::string,std::allocator< std::string > > *arg2 = 0 ;
+  logging::Logger *arg3 = (logging::Logger *) 0 ;
+  six::XMLControlRegistry *arg4 = (six::XMLControlRegistry *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  void *argp4 = 0 ;
+  int res4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  std::string result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:toValidXMLString",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__Data, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "toValidXMLString" "', argument " "1"" of type '" "six::Data const *""'"); 
+  }
+  arg1 = reinterpret_cast< six::Data * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "toValidXMLString" "', argument " "2"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "toValidXMLString" "', argument " "2"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< std::string,std::allocator< std::string > > * >(argp2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_logging__Logger, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "toValidXMLString" "', argument " "3"" of type '" "logging::Logger *""'"); 
+  }
+  arg3 = reinterpret_cast< logging::Logger * >(argp3);
+  res4 = SWIG_ConvertPtr(obj3, &argp4,SWIGTYPE_p_six__XMLControlRegistry, 0 |  0 );
+  if (!SWIG_IsOK(res4)) {
+    SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "toValidXMLString" "', argument " "4"" of type '" "six::XMLControlRegistry const *""'"); 
+  }
+  arg4 = reinterpret_cast< six::XMLControlRegistry * >(argp4);
+  {
+    try
+    {
+      result = six::toValidXMLString((six::Data const *)arg1,(std::vector< std::string,std::allocator< std::string > > const &)*arg2,arg3,(six::XMLControlRegistry const *)arg4);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_From_std_string(static_cast< std::string >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_toValidXMLString__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  six::Data *arg1 = (six::Data *) 0 ;
+  std::vector< std::string,std::allocator< std::string > > *arg2 = 0 ;
+  logging::Logger *arg3 = (logging::Logger *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 = 0 ;
+  int res2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  std::string result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:toValidXMLString",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_six__Data, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "toValidXMLString" "', argument " "1"" of type '" "six::Data const *""'"); 
+  }
+  arg1 = reinterpret_cast< six::Data * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1, &argp2, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t,  0  | 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "toValidXMLString" "', argument " "2"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  if (!argp2) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "toValidXMLString" "', argument " "2"" of type '" "std::vector< std::string,std::allocator< std::string > > const &""'"); 
+  }
+  arg2 = reinterpret_cast< std::vector< std::string,std::allocator< std::string > > * >(argp2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3,SWIGTYPE_p_logging__Logger, 0 |  0 );
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "toValidXMLString" "', argument " "3"" of type '" "logging::Logger *""'"); 
+  }
+  arg3 = reinterpret_cast< logging::Logger * >(argp3);
+  {
+    try
+    {
+      result = six::toValidXMLString((six::Data const *)arg1,(std::vector< std::string,std::allocator< std::string > > const &)*arg2,arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_From_std_string(static_cast< std::string >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_toValidXMLString(PyObject *self, PyObject *args) {
+  int argc;
+  PyObject *argv[5] = {
+    0
+  };
+  int ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? (int)PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 4) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__Data, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_logging__Logger, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_toValidXMLString__SWIG_1(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_six__Data, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_ConvertPtr(argv[1], 0, SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        void *vptr = 0;
+        int res = SWIG_ConvertPtr(argv[2], &vptr, SWIGTYPE_p_logging__Logger, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          void *vptr = 0;
+          int res = SWIG_ConvertPtr(argv[3], &vptr, SWIGTYPE_p_six__XMLControlRegistry, 0);
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_toValidXMLString__SWIG_0(self, args);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'toValidXMLString'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    six::toValidXMLString(six::Data const *,std::vector< std::string,std::allocator< std::string > > const &,logging::Logger *,six::XMLControlRegistry const *)\n"
+    "    six::toValidXMLString(six::Data const *,std::vector< std::string,std::allocator< std::string > > const &,logging::Logger *)\n");
+  return 0;
+}
+
+
 SWIGINTERN PyObject *_wrap_VectorString_iterator(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< std::string > *arg1 = (std::vector< std::string > *) 0 ;
@@ -80819,6 +82048,30 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"Options___ne__", _wrap_Options___ne__, METH_VARARGS, (char *)"Options___ne__(Options self, Options rhs) -> bool"},
 	 { (char *)"new_Options", _wrap_new_Options, METH_VARARGS, (char *)"new_Options() -> Options"},
 	 { (char *)"Options_swigregister", Options_swigregister, METH_VARARGS, NULL},
+	 { (char *)"delete_XMLControlCreator", _wrap_delete_XMLControlCreator, METH_VARARGS, (char *)"delete_XMLControlCreator(XMLControlCreator self)"},
+	 { (char *)"XMLControlCreator_newXMLControl", _wrap_XMLControlCreator_newXMLControl, METH_VARARGS, (char *)"XMLControlCreator_newXMLControl(XMLControlCreator self, logging::Logger * log) -> XMLControl"},
+	 { (char *)"XMLControlCreator_swigregister", XMLControlCreator_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_XMLControlRegistry", _wrap_new_XMLControlRegistry, METH_VARARGS, (char *)"new_XMLControlRegistry() -> XMLControlRegistry"},
+	 { (char *)"delete_XMLControlRegistry", _wrap_delete_XMLControlRegistry, METH_VARARGS, (char *)"delete_XMLControlRegistry(XMLControlRegistry self)"},
+	 { (char *)"XMLControlRegistry_addCreator", _wrap_XMLControlRegistry_addCreator, METH_VARARGS, (char *)"\n"
+		"addCreator(std::string const & identifier, std::auto_ptr< six::XMLControlCreator > creator)\n"
+		"addCreator(std::string const & identifier, XMLControlCreator creator)\n"
+		"addCreator(DataType dataType, std::auto_ptr< six::XMLControlCreator > creator)\n"
+		"XMLControlRegistry_addCreator(XMLControlRegistry self, DataType dataType, XMLControlCreator creator)\n"
+		""},
+	 { (char *)"XMLControlRegistry_newXMLControl", _wrap_XMLControlRegistry_newXMLControl, METH_VARARGS, (char *)"\n"
+		"newXMLControl(std::string const & identifier, logging::Logger * log) -> XMLControl\n"
+		"XMLControlRegistry_newXMLControl(XMLControlRegistry self, DataType dataType, logging::Logger * log) -> XMLControl\n"
+		""},
+	 { (char *)"XMLControlRegistry_swigregister", XMLControlRegistry_swigregister, METH_VARARGS, NULL},
+	 { (char *)"toXMLString", _wrap_toXMLString, METH_VARARGS, (char *)"\n"
+		"toXMLString(Data data, XMLControlRegistry xmlRegistry=None) -> std::string\n"
+		"toXMLString(Data data) -> std::string\n"
+		""},
+	 { (char *)"toValidXMLString", _wrap_toValidXMLString, METH_VARARGS, (char *)"\n"
+		"toValidXMLString(Data data, VectorString schemaPaths, logging::Logger * log, XMLControlRegistry xmlRegistry=None) -> std::string\n"
+		"toValidXMLString(Data data, VectorString schemaPaths, logging::Logger * log) -> std::string\n"
+		""},
 	 { (char *)"VectorString_iterator", _wrap_VectorString_iterator, METH_VARARGS, (char *)"VectorString_iterator(VectorString self) -> SwigPyIterator"},
 	 { (char *)"VectorString___nonzero__", _wrap_VectorString___nonzero__, METH_VARARGS, (char *)"VectorString___nonzero__(VectorString self) -> bool"},
 	 { (char *)"VectorString___bool__", _wrap_VectorString___bool__, METH_VARARGS, (char *)"VectorString___bool__(VectorString self) -> bool"},
@@ -81400,6 +82653,7 @@ static swig_type_info _swigt__p_mem__ScopedCopyablePtrT_six__PosVelError_t = {"_
 static swig_type_info _swigt__p_mem__ScopedCopyablePtrT_six__RadarSensor_t = {"_p_mem__ScopedCopyablePtrT_six__RadarSensor_t", "mem::ScopedCopyablePtr< six::RadarSensor > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mem__ScopedCopyablePtrT_six__Radiometric_t = {"_p_mem__ScopedCopyablePtrT_six__Radiometric_t", "mem::ScopedCopyablePtr< six::Radiometric > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_mem__ScopedCopyablePtrT_six__TropoError_t = {"_p_mem__ScopedCopyablePtrT_six__TropoError_t", "mem::ScopedCopyablePtr< six::TropoError > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_mt__SingletonT_six__XMLControlRegistry_true_t = {"_p_mt__SingletonT_six__XMLControlRegistry_true_t", "six::XMLControlFactory *|mt::Singleton< six::XMLControlRegistry,true > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf_DateTime = {"_p_nitf_DateTime", "nitf_DateTime *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf__DateTime = {"_p_nitf__DateTime", "nitf::DateTime *|six::DateTime *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf__FileSecurity = {"_p_nitf__FileSecurity", "nitf::FileSecurity *", 0, 0, (void*)0, 0};
@@ -81470,6 +82724,8 @@ static swig_type_info _swigt__p_six__SlowTimeBeamCompensationType = {"_p_six__Sl
 static swig_type_info _swigt__p_six__TropoError = {"_p_six__TropoError", "six::TropoError *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__UninitializedValueException = {"_p_six__UninitializedValueException", "six::UninitializedValueException *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__XMLControl = {"_p_six__XMLControl", "six::XMLControl *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_six__XMLControlCreator = {"_p_six__XMLControlCreator", "six::XMLControlCreator *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_six__XMLControlRegistry = {"_p_six__XMLControlRegistry", "six::XMLControlRegistry *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__XYZEnum = {"_p_six__XYZEnum", "six::XYZEnum *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_size_t = {"_p_size_t", "sys::Size_T *|size_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_size_type = {"_p_size_type", "size_type *", 0, 0, (void*)0, 0};
@@ -81485,6 +82741,7 @@ static swig_type_info _swigt__p_std__auto_ptrT_six__PosVelError_t = {"_p_std__au
 static swig_type_info _swigt__p_std__auto_ptrT_six__RadarSensor_t = {"_p_std__auto_ptrT_six__RadarSensor_t", "std::auto_ptr< six::RadarSensor > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__auto_ptrT_six__Radiometric_t = {"_p_std__auto_ptrT_six__Radiometric_t", "std::auto_ptr< six::Radiometric > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__auto_ptrT_six__TropoError_t = {"_p_std__auto_ptrT_six__TropoError_t", "std::auto_ptr< six::TropoError > *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_std__auto_ptrT_six__XMLControlCreator_t = {"_p_std__auto_ptrT_six__XMLControlCreator_t", "std::auto_ptr< six::XMLControlCreator > *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__invalid_argument = {"_p_std__invalid_argument", "std::invalid_argument *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__mapT_std__string_six__Parameter_t__const_iterator = {"_p_std__mapT_std__string_six__Parameter_t__const_iterator", "std::map< std::string,six::Parameter >::const_iterator *|six::Options::ParameterIter *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_std__ostream = {"_p_std__ostream", "std::ostream *", 0, 0, (void*)0, 0};
@@ -81555,6 +82812,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_mem__ScopedCopyablePtrT_six__RadarSensor_t,
   &_swigt__p_mem__ScopedCopyablePtrT_six__Radiometric_t,
   &_swigt__p_mem__ScopedCopyablePtrT_six__TropoError_t,
+  &_swigt__p_mt__SingletonT_six__XMLControlRegistry_true_t,
   &_swigt__p_nitf_DateTime,
   &_swigt__p_nitf__DateTime,
   &_swigt__p_nitf__FileSecurity,
@@ -81625,6 +82883,8 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_six__TropoError,
   &_swigt__p_six__UninitializedValueException,
   &_swigt__p_six__XMLControl,
+  &_swigt__p_six__XMLControlCreator,
+  &_swigt__p_six__XMLControlRegistry,
   &_swigt__p_six__XYZEnum,
   &_swigt__p_size_t,
   &_swigt__p_size_type,
@@ -81640,6 +82900,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_std__auto_ptrT_six__RadarSensor_t,
   &_swigt__p_std__auto_ptrT_six__Radiometric_t,
   &_swigt__p_std__auto_ptrT_six__TropoError_t,
+  &_swigt__p_std__auto_ptrT_six__XMLControlCreator_t,
   &_swigt__p_std__invalid_argument,
   &_swigt__p_std__mapT_std__string_six__Parameter_t__const_iterator,
   &_swigt__p_std__ostream,
@@ -81710,6 +82971,7 @@ static swig_cast_info _swigc__p_mem__ScopedCopyablePtrT_six__PosVelError_t[] = {
 static swig_cast_info _swigc__p_mem__ScopedCopyablePtrT_six__RadarSensor_t[] = {  {&_swigt__p_mem__ScopedCopyablePtrT_six__RadarSensor_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mem__ScopedCopyablePtrT_six__Radiometric_t[] = {  {&_swigt__p_mem__ScopedCopyablePtrT_six__Radiometric_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_mem__ScopedCopyablePtrT_six__TropoError_t[] = {  {&_swigt__p_mem__ScopedCopyablePtrT_six__TropoError_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_mt__SingletonT_six__XMLControlRegistry_true_t[] = {  {&_swigt__p_mt__SingletonT_six__XMLControlRegistry_true_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_nitf_DateTime[] = {  {&_swigt__p_nitf_DateTime, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_nitf__DateTime[] = {  {&_swigt__p_nitf__DateTime, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_nitf__FileSecurity[] = {  {&_swigt__p_nitf__FileSecurity, 0, 0, 0},{0, 0, 0, 0}};
@@ -81780,6 +83042,8 @@ static swig_cast_info _swigc__p_six__SlowTimeBeamCompensationType[] = {  {&_swig
 static swig_cast_info _swigc__p_six__TropoError[] = {  {&_swigt__p_six__TropoError, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__UninitializedValueException[] = {  {&_swigt__p_six__UninitializedValueException, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__XMLControl[] = {  {&_swigt__p_six__XMLControl, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_six__XMLControlCreator[] = {  {&_swigt__p_six__XMLControlCreator, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_six__XMLControlRegistry[] = {  {&_swigt__p_six__XMLControlRegistry, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__XYZEnum[] = {  {&_swigt__p_six__XYZEnum, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_size_t[] = {  {&_swigt__p_size_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_size_type[] = {  {&_swigt__p_size_type, 0, 0, 0},{0, 0, 0, 0}};
@@ -81795,6 +83059,7 @@ static swig_cast_info _swigc__p_std__auto_ptrT_six__PosVelError_t[] = {  {&_swig
 static swig_cast_info _swigc__p_std__auto_ptrT_six__RadarSensor_t[] = {  {&_swigt__p_std__auto_ptrT_six__RadarSensor_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__auto_ptrT_six__Radiometric_t[] = {  {&_swigt__p_std__auto_ptrT_six__Radiometric_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__auto_ptrT_six__TropoError_t[] = {  {&_swigt__p_std__auto_ptrT_six__TropoError_t, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_std__auto_ptrT_six__XMLControlCreator_t[] = {  {&_swigt__p_std__auto_ptrT_six__XMLControlCreator_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__invalid_argument[] = {  {&_swigt__p_std__invalid_argument, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__mapT_std__string_six__Parameter_t__const_iterator[] = {  {&_swigt__p_std__mapT_std__string_six__Parameter_t__const_iterator, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_std__ostream[] = {  {&_swigt__p_std__ostream, 0, 0, 0},{0, 0, 0, 0}};
@@ -81865,6 +83130,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_mem__ScopedCopyablePtrT_six__RadarSensor_t,
   _swigc__p_mem__ScopedCopyablePtrT_six__Radiometric_t,
   _swigc__p_mem__ScopedCopyablePtrT_six__TropoError_t,
+  _swigc__p_mt__SingletonT_six__XMLControlRegistry_true_t,
   _swigc__p_nitf_DateTime,
   _swigc__p_nitf__DateTime,
   _swigc__p_nitf__FileSecurity,
@@ -81935,6 +83201,8 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_six__TropoError,
   _swigc__p_six__UninitializedValueException,
   _swigc__p_six__XMLControl,
+  _swigc__p_six__XMLControlCreator,
+  _swigc__p_six__XMLControlRegistry,
   _swigc__p_six__XYZEnum,
   _swigc__p_size_t,
   _swigc__p_size_type,
@@ -81950,6 +83218,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_std__auto_ptrT_six__RadarSensor_t,
   _swigc__p_std__auto_ptrT_six__Radiometric_t,
   _swigc__p_std__auto_ptrT_six__TropoError_t,
+  _swigc__p_std__auto_ptrT_six__XMLControlCreator_t,
   _swigc__p_std__invalid_argument,
   _swigc__p_std__mapT_std__string_six__Parameter_t__const_iterator,
   _swigc__p_std__ostream,

--- a/six/modules/python/six/source/six.i
+++ b/six/modules/python/six/source/six.i
@@ -24,8 +24,9 @@
 
 %feature("autodoc","1");
 
-%include "std_vector.i"
-%include "std_string.i"
+%include <std_vector.i>
+%include <std_string.i>
+%include <std_auto_ptr.i>
 
 %{
 
@@ -42,18 +43,10 @@ using std::ptrdiff_t;
 #include "import/nitf.hpp"
 
 using namespace six;
-
-six::Data * parseDataNoAutoPtr(const XMLControlRegistry& xmlReg,
-                      ::io::InputStream& xmlStream,
-                      DataType dataType,
-                      const std::vector<std::string>& schemaPaths,
-                      logging::Logger& log)
-{
-  std::auto_ptr<Data> retv = six::parseData(xmlReg, xmlStream, dataType, schemaPaths, log);
-  return retv.release();
-}
-
 %}
+
+// This allows functions that return auto_ptrs to work properly
+%auto_ptr(six::Data);
 
 %ignore mem::ScopedCopyablePtr::operator!=;
 %ignore mem::ScopedCopyablePtr::operator==;
@@ -70,12 +63,6 @@ six::Data * parseDataNoAutoPtr(const XMLControlRegistry& xmlReg,
 /* parametric elt-size array */
 /* will probably want it eventually, but it looks like six.sicd doesn't use it */
 %ignore "LUT";
-
-/* auto_ptr causes problems, as well as
- * xml factory stuff that we'll just
- * put aside for now
- */
-%ignore parseData;
 
 /* ignore some useless (in Python) functions in ParameterCollection */
 %ignore six::ParameterCollection::begin;

--- a/six/modules/python/six/source/six.i
+++ b/six/modules/python/six/source/six.i
@@ -45,8 +45,9 @@ using std::ptrdiff_t;
 using namespace six;
 %}
 
-// This allows functions that return auto_ptrs to work properly
+// This allows functions that deal with auto_ptrs to work properly
 %auto_ptr(six::Data);
+%auto_ptr(six::XMLControlCreator);
 
 %ignore mem::ScopedCopyablePtr::operator!=;
 %ignore mem::ScopedCopyablePtr::operator==;
@@ -87,6 +88,7 @@ using namespace six;
 %include "six/XMLControl.h"
 %include "six/Utilities.h"
 %include "six/Options.h"
+%include "six/XMLControlFactory.h"
 
 %feature("shadow") six::Parameter::setValue(const std::string &)
 %{

--- a/six/modules/python/six/tests/runPythonScripts.py
+++ b/six/modules/python/six/tests/runPythonScripts.py
@@ -69,11 +69,22 @@ def testSixSICD(testsDir):
         return True
     return False
 
+def testReadSICDXML(testsDir):
+    print('Running test_read_sicd_xml.py')
+    scriptName = os.path.join(testsDir, 'test_read_sicd_xml.py')
+    sampleNITF = os.path.join(utils.findSixHome(), 'regression_files',
+            'six.sicd', 'sicd_1.0.0(RMA)RMAT.nitf')
+    result = call(['python', scriptName, sampleNITF],
+                  stdout = subprocess.PIPE)
+    if result == 0:
+        print('test_read_sicd_xml.py succeeded')
+        return True
+    return False
+
 def run():
     testsDir = os.path.join(utils.findSixHome(), 'six',
             'modules', 'python', 'six.sicd', 'tests')
 
     result = (sicdToSIO(testsDir) and testCreateSICDXML(testsDir) and
-            testSixSICD(testsDir))
+            testSixSICD(testsDir) and testReadSICDXML(testsDir))
     return result
-


### PR DESCRIPTION
Added C++ implementations which also make some of this simpler in Python

- `six::parseData()` overloading that took in a file renamed to `six::parseDataFromFile()`
- Added `six::parseDataFromString()`
- Added overloadings in six.sicd for these that return a `ComplexData` object to save some casting
- `pysix.six_sicd.getComplexData()` changed to `pysix.six_sicd.SixSicdUtilities.getComplexData()`
- Realized in Swig bindings that including Swig .i files like `#include <std_vector.i>` rather than `#include "std_vector.i"` will let Swig find these.  Now using `std_auto_ptr.i` which allows Swig to auto-generate some code that we had to do a combination of `%ignore` and adding non-auto_ptr overloadings previously... as a result, a few Python function names changed slightly