### PR TITLE
Added SixSicdUtilities to the getComplexData call.

### DIFF
--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -9482,7 +9482,7 @@ def read(inputPathname, schemaPaths = VectorString()):
     return widebandData, complexData
 
 def readRegion(inputPathname, startRow, numRows, startCol, numCols, schemaPaths = VectorString()):
-    complexData = getComplexData(inputPathname, schemaPaths)
+    complexData = SixSicdUtilities.getComplexData(inputPathname, schemaPaths)
 
     widebandData = np.empty(shape = (numRows, numCols), dtype = "complex64")
     widebandBuffer, ro = widebandData.__array_interface__["data"]

--- a/six/modules/python/six.sicd/source/six_sicd.i
+++ b/six/modules/python/six.sicd/source/six_sicd.i
@@ -280,7 +280,7 @@ def read(inputPathname, schemaPaths = VectorString()):
     return widebandData, complexData
 
 def readRegion(inputPathname, startRow, numRows, startCol, numCols, schemaPaths = VectorString()):
-    complexData = getComplexData(inputPathname, schemaPaths)
+    complexData = SixSicdUtilities.getComplexData(inputPathname, schemaPaths)
 
     widebandData = np.empty(shape = (numRows, numCols), dtype = "complex64")
     widebandBuffer, ro = widebandData.__array_interface__["data"]


### PR DESCRIPTION
Added SixSicdUtilities to getComplexData in readRegion. This now matches the call made in "read". Before this update you get a runtime error saying that getComplexData is not defined.