### PR TITLE
No longer require NITF_PLUGIN_PATH

### DIFF
--- a/six/modules/c++/samples/crop_sicd.cpp
+++ b/six/modules/c++/samples/crop_sicd.cpp
@@ -119,11 +119,6 @@ int main(int argc, char** argv)
                            "latDegrees,lonDegrees[,altMeters] tuples",
                            cli::STORE,
                            "latlon", "#,#,#", 4, 4);
-        parser.addArgument("--nitro",
-                           "Specify a path to the NITRO plugins.  To use "
-                           "NITF_PLUGIN_PATH environment variable instead, "
-                           "use \"\".",
-                           cli::STORE)->setDefault(nitroDir);
         parser.addArgument("--schema",
                            "Specify a schema or directory of schemas "
                            "(or set SIX_SCHEMA_PATH). Use \"\" as value to "
@@ -148,12 +143,6 @@ int main(int argc, char** argv)
         const std::string outPathname(options->get<std::string> ("output"));
         const bool trimCornersIfNeeded =
                 !options->get<bool>("requireAoiInBounds");
-
-        const std::string nitroStr(options->get<std::string>("nitro"));
-        if (!nitroStr.empty())
-        {
-            six::loadPluginDir(nitroStr);
-        }
 
         std::vector<std::string> schemaPaths;
         const std::string schemaPath(options->get<std::string>("schema"));

--- a/six/modules/c++/six/include/six/NITFImageInfo.h
+++ b/six/modules/c++/six/include/six/NITFImageInfo.h
@@ -58,7 +58,7 @@ public:
             compute();
     }
 
-    unsigned int getNumBitsPerPixel() const
+    size_t getNumBitsPerPixel() const
     {
         return data->getNumBytesPerPixel() / data->getNumChannels() * 8;
     }

--- a/six/modules/c++/six/include/six/NITFReadControl.h
+++ b/six/modules/c++/six/include/six/NITFReadControl.h
@@ -51,9 +51,7 @@ class NITFReadControl : public ReadControl
 public:
 
     //!  Constructor
-    NITFReadControl()
-    {
-    }
+    NITFReadControl();
 
     //!  Destructor
     virtual ~NITFReadControl()

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -49,9 +49,7 @@ class NITFWriteControl : public WriteControl
 public:
 
     //!  Constructor
-    NITFWriteControl()
-    {
-    }
+    NITFWriteControl();
 
     //!  We are a 'NITF'
     std::string getFileType() const

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -168,7 +168,15 @@ template<> std::string toString(const six::FrameType& value);
 template<> std::string toString(const six::LatLonCorners& corners);
 
 // Load the TRE plugins in the given directory
+// In most cases this is not needed as XML_DATA_CONTENT is linked statically
 void loadPluginDir(const std::string& pluginDir);
+
+/*
+ * Used to ensure the PluginRegistry singleton has loaded the XML_DATA_CONTENT
+ * handler.  This is used internally by NITFReadControl and NITFWriteControl
+ * and should not need to be called directly.
+ */
+void loadXmlDataContentHandler();
 
 /*
  * Parses the XML in 'xmlStream' and converts it into a Data object

--- a/six/modules/c++/six/source/NITFReadControl.cpp
+++ b/six/modules/c++/six/source/NITFReadControl.cpp
@@ -81,6 +81,13 @@ six::PixelType getPixelType(nitf::ImageSubheader& subheader)
 
 namespace six
 {
+NITFReadControl::NITFReadControl()
+{
+    // Make sure that if we use XML_DATA_CONTENT that we've loaded it into the
+    // singleton PluginRegistry
+    loadXmlDataContentHandler();
+}
+
 DataType NITFReadControl::getDataType(nitf::Record& record)
 {
     nitf::List des = record.getDataExtensions();
@@ -140,24 +147,8 @@ DataType NITFReadControl::getDataType(nitf::DESegment& segment)
             return DataType::NOT_SET;
         }
 
-        std::string field;
-        if (tre.exists("DESSHSI"))
-        {
-            field = tre.getField("DESSHSI").toString();
-            str::trim(field);
-        }
-        else
-        {
-            // We've already checked that it's XML_DATA_CONTENT
-            // with length 773, so the DESSHSI field ought to be
-            // present if the plugins are loaded.
-            throw except::NoSuchKeyException(Ctxt(
-                "Must have '" +
-                std::string(Constants::DES_USER_DEFINED_SUBHEADER_TAG) +
-                "' plugin on the plugin path.  Either set the "
-                "NITF_PLUGIN_PATH environment variable or use "
-                "six::loadPluginDir()"));
-        }
+        std::string field = tre.getField("DESSHSI").toString();
+        str::trim(field);
 
         if (field == Constants::SICD_DESSHSI)
         {

--- a/six/modules/c++/six/source/NITFWriteControl.cpp
+++ b/six/modules/c++/six/source/NITFWriteControl.cpp
@@ -91,6 +91,13 @@ const char NITFWriteControl::OPT_J2K_COMPRESSION[] = "J2KCompression";
 const char NITFWriteControl::OPT_NUM_ROWS_PER_BLOCK[] = "NumRowsPerBlock";
 const char NITFWriteControl::OPT_NUM_COLS_PER_BLOCK[] = "NumColsPerBlock";
 
+NITFWriteControl::NITFWriteControl()
+{
+    // Make sure that if we use XML_DATA_CONTENT that we've loaded it into the
+    // singleton PluginRegistry
+    loadXmlDataContentHandler();
+}
+
 void NITFWriteControl::initialize(Container* container)
 {
     // Clean up
@@ -1012,99 +1019,83 @@ void NITFWriteControl::addUserDefinedSubheader(
         const six::Data& data,
         nitf::DESubheader& subheader) const
 {
-    // If NITRO doesn't know this TRE (because our plugin path isn't set),
-    // we won't actually get an exception in the TRE constructor because it'll
-    // use a default handler for the TRE.  Instead, we'll get a no such key
-    // exception when it doesn't know what the fields below are.  try/catch
-    // this so we can supply a more obvious error message.
     nitf::TRE tre(Constants::DES_USER_DEFINED_SUBHEADER_TAG,
                   Constants::DES_USER_DEFINED_SUBHEADER_ID);
 
-    try
+    tre["DESCRC"] = "99999";
+    tre["DESSHFT"] = "XML";
+    tre["DESSHDT"] = data.getCreationTime().format("%Y-%m-%dT%H:%M:%SZ");
+    setField("DESSHRP", mOrganizationId, tre);
+
+    const std::string dataType =
+            (data.getDataType() == DataType::COMPLEX) ? "SICD" : "SIDD";
+
+    if (dataType == "SICD")
     {
-        tre["DESCRC"] = "99999";
-        tre["DESSHFT"] = "XML";
-        tre["DESSHDT"] = data.getCreationTime().format("%Y-%m-%dT%H:%M:%SZ");
-        setField("DESSHRP", mOrganizationId, tre);
-
-        const std::string dataType =
-                (data.getDataType() == DataType::COMPLEX) ? "SICD" : "SIDD";
-        
-        if (dataType == "SICD")
-        {
-            tre["DESSHSI"] = Constants::SICD_DESSHSI;
-        }
-        else
-        {
-            tre["DESSHSI"] = Constants::SIDD_DESSHSI;
-        }
-
-        // This is the publication date and version of the
-        // Design and Implementation Description Document 
-        // for the specification -- Add to this list as more
-        // versions are published
-        const std::string version(data.getVersion());
-        std::string specVers;
-        std::string specDT;
-        if (dataType == "SICD")
-        {    
-            if (version == "1.0.0" || version == "1.0.1")
-            {
-                specVers = "1.0";
-                specDT = "2011-09-28T00:00:00Z";
-            }
-            else if (version == "1.1.0")
-            {
-                specVers = "1.1";
-                specDT = "2014-07-08T00:00:00Z";
-            }
-        }
-        else if (dataType == "SIDD")
-        {
-            if (version == "1.0.0")
-            {
-                specVers = "1.0";
-                specDT = "2011-08-01T00:00:00Z";
-            }
-        }
-
-        // spec version
-        if (specVers.empty())
-        {
-            throw except::Exception(Ctxt(
-                "DESSHSV Failure - Unsupported in " + dataType +
-                " version: " + version));
-        }
-        tre["DESSHSV"] = specVers;
-
-        // spec publication Date/Time
-        if (specDT.empty())
-        {
-            throw except::Exception(Ctxt(
-                "DESSHSD Failure - Unsupported in " + dataType +
-                " version: " + version));
-        }
-        tre["DESSHSD"] = specDT;
-
-        tre["DESSHTN"] = "urn:" + dataType + ":" + version;
-        tre["DESSHLPG"] = toString(data.getImageCorners());
-
-        // Spec specifies leaving this blank
-        tre["DESSHLPT"] = "";
-
-        setField("DESSHLI", mLocationId, tre);
-        setField("DESSHLIN", mLocationIdNamespace, tre);
-        setField("DESSHABS", mAbstract, tre);
+        tre["DESSHSI"] = Constants::SICD_DESSHSI;
     }
-    catch (const except::NoSuchKeyException& )
+    else
     {
-        throw except::NoSuchKeyException(Ctxt(
-                "Must have '" +
-                std::string(Constants::DES_USER_DEFINED_SUBHEADER_TAG) +
-                "' plugin on the plugin path.  Either set the "
-                "NITF_PLUGIN_PATH environment variable or use "
-                "six::loadPluginDir()"));
+        tre["DESSHSI"] = Constants::SIDD_DESSHSI;
     }
+
+    // This is the publication date and version of the
+    // Design and Implementation Description Document
+    // for the specification -- Add to this list as more
+    // versions are published
+    const std::string version(data.getVersion());
+    std::string specVers;
+    std::string specDT;
+    if (dataType == "SICD")
+    {
+        if (version == "1.0.0" || version == "1.0.1")
+        {
+            specVers = "1.0";
+            specDT = "2011-09-28T00:00:00Z";
+        }
+        else if (version == "1.1.0")
+        {
+            specVers = "1.1";
+            specDT = "2014-07-08T00:00:00Z";
+        }
+    }
+    else if (dataType == "SIDD")
+    {
+        if (version == "1.0.0")
+        {
+            specVers = "1.0";
+            specDT = "2011-08-01T00:00:00Z";
+        }
+    }
+
+    // spec version
+    if (specVers.empty())
+    {
+        throw except::Exception(Ctxt(
+            "DESSHSV Failure - Unsupported in " + dataType +
+            " version: " + version));
+    }
+    tre["DESSHSV"] = specVers;
+
+    // spec publication Date/Time
+    if (specDT.empty())
+    {
+        throw except::Exception(Ctxt(
+            "DESSHSD Failure - Unsupported in " + dataType +
+            " version: " + version));
+    }
+    tre["DESSHSD"] = specDT;
+
+    tre["DESSHTN"] = "urn:" + dataType + ":" + version;
+    tre["DESSHLPG"] = toString(data.getImageCorners());
+
+    // Spec specifies leaving this blank
+    tre["DESSHLPT"] = "";
+
+    setField("DESSHLI", mLocationId, tre);
+    setField("DESSHLIN", mLocationIdNamespace, tre);
+    setField("DESSHABS", mAbstract, tre);
+
     subheader.setSubheaderFields(tre);
 }
 

--- a/six/modules/c++/six/source/Utilities.cpp
+++ b/six/modules/c++/six/source/Utilities.cpp
@@ -30,6 +30,8 @@
 
 namespace
 {
+NITF_TRE_STATIC_HANDLER_REF(XML_DATA_CONTENT);
+
 inline
 double square(double val)
 {
@@ -1026,6 +1028,15 @@ template<> std::string six::toString(const six::LatLonCorners& corners)
 void six::loadPluginDir(const std::string& pluginDir)
 {
     nitf::PluginRegistry::loadDir(pluginDir);
+}
+
+void six::loadXmlDataContentHandler()
+{
+    if (!nitf::PluginRegistry::treHandlerExists("XML_DATA_CONTENT"))
+    {
+        nitf::PluginRegistry::registerTREHandler(XML_DATA_CONTENT_init,
+                                                 XML_DATA_CONTENT_handler);
+    }
 }
 
 std::auto_ptr<Data> six::parseData(const XMLControlRegistry& xmlReg, 

--- a/six/modules/c++/six/wscript
+++ b/six/modules/c++/six/wscript
@@ -1,7 +1,7 @@
 NAME            = 'six'
 MAINTAINER      = 'adam.sylvester@mdaus.com'
 MODULE_DEPS     = 'scene nitf xml.lite logging math.poly mem'
-TARGETS_TO_ADD  = 'XML_DATA_CONTENT'
+USE             = 'XML_DATA_CONTENT-static-c'
 
 options = configure = distclean = lambda p: None
 

--- a/six/modules/python/six/tests/checkNITFs.py
+++ b/six/modules/python/six/tests/checkNITFs.py
@@ -28,6 +28,7 @@ import utils
 
 from subprocess import call
 
+print utils.installPath()
 binDir = os.path.join(utils.installPath(), 'bin')
 
 def roundTrippedName(pathname):

--- a/six/modules/python/six/tests/runMiscTests.py
+++ b/six/modules/python/six/tests/runMiscTests.py
@@ -49,19 +49,24 @@ def runTests(testDir, testName, *args):
 
 def runSICDTests():
     # Make sure plugins installed properly
-    nitfPluginPath = os.environ['NITF_PLUGIN_PATH']
-    # I'm not sure how this happens, but during a prior test, one .dll does
-    # get copied over, so we can't just check that the directory's empty.
-    if len(os.listdir(nitfPluginPath)) <= 1:
+    nitfPluginPath = os.environ['NITF_PLUGIN_PATH_REAL']
+
+    if not any(plugin.startswith('PIAIMB') for plugin in os.listdir(nitfPluginPath)): 
         print('Could not find NITF plugins. Please re-install with '
                 'the following command.')
-        print('python waf install --target=nitro-plugins')
+        print('python waf install --target=PIAIMB')
         sys.exit(1)
     testDir = os.path.join(utils.installPath(), 'tests', 'six.sicd')
-    return (runTests(testDir, 'test_add_additional_des', getSampleSicdXML())
-            and runTests(testDir, 'test_read_sicd_with_extra_des',
-            getSampleSicdXML()))
 
+    success = runTests(testDir, 'test_add_additional_des', getSampleSicdXML())
+
+    # Need it for just this test
+    os.environ['NITF_PLUGIN_PATH'] = os.environ['NITF_PLUGIN_PATH_REAL']
+    success = success and runTests(testDir, 'test_read_sicd_with_extra_des',
+            getSampleSicdXML())
+    del os.environ['NITF_PLUGIN_PATH']
+
+    return success
 
 def run():
     return runSICDTests()

--- a/six/modules/python/six/tests/utils.py
+++ b/six/modules/python/six/tests/utils.py
@@ -101,5 +101,5 @@ def executableName(pathname):
             return pathname
         return pathname + '.exe'
     if pathname.startswith('/'):
-        return '.' + pathname
+        return pathname
     return './' + pathname

--- a/six/modules/python/six/tests/utils.py
+++ b/six/modules/python/six/tests/utils.py
@@ -50,10 +50,11 @@ def installPath():
                 'docs', 'waf', '.gitignore', 'LICENSE']
 
     for child in os.listdir(home):
-        if child not in children and os.path.isdir(child):
-            subdirs = os.listdir(child)
+        fullChildPath = os.path.join(home, child)
+        if child not in children and os.path.isdir(fullChildPath):
+            subdirs = os.listdir(fullChildPath)
             if 'tests' in subdirs and 'bin' in subdirs:
-                return child
+                return fullChildPath
 def findPythonPath():
     if platform.system() == 'Linux':
         return glob(os.path.join(installPath(), 'lib', 'python*',
@@ -76,7 +77,10 @@ def setPaths():
     sixSchemaPath = os.path.join(installPath(), 'conf', 'schema',
                                  'six')
 
-    os.environ['NITF_PLUGIN_PATH'] = nitfPluginPath
+    # Want to save this value off but only actually want it set for one test
+    # For the rest of them, want to make sure we don't need NITF_PLUGIN_PATH
+    # set since we're linking XML_DATA_CONTENT in statically
+    os.environ['NITF_PLUGIN_PATH_REAL'] = nitfPluginPath
     os.environ['SIX_SCHEMA_PATH'] = sixSchemaPath
 
     pythonPath = findPythonPath()

--- a/six/modules/wscript
+++ b/six/modules/wscript
@@ -3,6 +3,11 @@ def options(opt):
 
 def configure(conf):
     conf.env['VERSION'] = '2.2.1-alpha'
+
+    # This allows us to build XML_DATA_CONTENT statically so that users don't
+    # have to set NITF_PLUGIN_PATH    
+    conf.env['enable_static_tres'] = True
+
     conf.recurse()
 
 def build(bld):


### PR DESCRIPTION
Changed code to link in XML_DATA_CONTENT statically.  The underlying NITFReadControl and NITFWriteControl check the singleton `PluginRegistry` to ensure the handler has been added.

The net effect of this is that you don't need to set NITF_PLUGIN_PATH or call `six::loadPluginDir()` to read or write SICDs or SIDDs.  The only reason you'd still need to do this is if you're handling files that contain additional TREs.