### PR TITLE
Fix checking whether measurement->arpFlag is set. Template overloads …

### DIFF
--- a/six/modules/c++/six.sidd/source/DerivedXMLParser110.cpp
+++ b/six/modules/c++/six.sidd/source/DerivedXMLParser110.cpp
@@ -1491,7 +1491,7 @@ XMLElem DerivedXMLParser110::convertMeasurementToXML(const Measurement* measurem
 {
     XMLElem measurementElem = DerivedXMLParser::convertMeasurementToXML(measurement, parent);
 
-    if (six::Init::isDefined(measurement->arpFlag))
+    if (measurement->arpFlag != AppliedType::NOT_SET)
     {
         createStringFromEnum("ARPFlag", measurement->arpFlag, measurementElem);
     }


### PR DESCRIPTION
…in Init don't handle it as was desired