### PR TITLE
Need to tweak a line to fix Python bindings for SICDWriteControl

### DIFF
--- a/six/modules/c++/six.sicd/include/six/sicd/SICDWriteControl.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDWriteControl.h
@@ -57,6 +57,8 @@ public:
     SICDWriteControl(const std::string& outputPathname,
                      const std::vector<std::string>& schemaPaths);
 
+    using NITFWriteControl::initialize;
+
     /*!
      * Initializes the control.  Either this or the base class's initialize()
      * function must be called prior to any of the save() methods or doing
@@ -68,7 +70,6 @@ public:
      */
     void initialize(const ComplexData& data);
 
-    using NITFWriteControl::initialize;
     using NITFWriteControl::save;
 
     /*!

--- a/six/modules/c++/six.sicd/tests/test_streaming_write.cpp
+++ b/six/modules/c++/six.sicd/tests/test_streaming_write.cpp
@@ -329,9 +329,9 @@ public:
         mImagePtr(&mImage[0]),
         mTestPathname("streaming_write.nitf"),
         mSchemaPaths(schemaPaths),
-        mSuccess(true),
         mSetMaxProductSize(setMaxProductSize),
-        mMaxProductSize(maxProductSize)
+        mMaxProductSize(maxProductSize),
+        mSuccess(true)
     {
         for (size_t ii = 0; ii < mImage.size(); ++ii)
         {

--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -9646,6 +9646,14 @@ class SICDWriteControl(_object):
         except:
             self.this = this
 
+    def initialize(self, *args):
+        """
+        initialize(SICDWriteControl self)
+        initialize(SICDWriteControl self, ComplexData data)
+        """
+        return _six_sicd.SICDWriteControl_initialize(self, *args)
+
+
     def save(self, *args):
         """
         save(SICDWriteControl self)

--- a/six/modules/wscript
+++ b/six/modules/wscript
@@ -2,7 +2,7 @@ def options(opt):
     opt.recurse()
 
 def configure(conf):
-    conf.env['VERSION'] = '2.2.2-alpha'
+    conf.env['VERSION'] = '2.2.1'
 
     # This allows us to build XML_DATA_CONTENT statically so that users don't
     # have to set NITF_PLUGIN_PATH    


### PR DESCRIPTION
Needed to move a 'using' line earlier in order for Python bindings to generate properly.

Fixed compiler warning about initialization order in test_streaming_write.cpp