### PR TITLE
Fix CSM parsing of file ISDs

### DIFF
--- a/six/projects/csm/source/SICDSensorModel.cpp
+++ b/six/projects/csm/source/SICDSensorModel.cpp
@@ -99,12 +99,12 @@ void SICDSensorModel::initializeFromFile(const std::string& pathname)
                                "SICDSensorModel::initializeFromFile");
         }
 
+        // Cast it and grab a copy
         mData.reset(reinterpret_cast<six::sicd::ComplexData*>(
-                container->getData(0)));
-        container->removeData(mData.get());
+                container->getData(0)->clone()));
 
         // get xml as string for sensor model state
-        std::string xmlStr = six::toXMLString(mData.get(), &xmlRegistry);
+        const std::string xmlStr = six::toXMLString(mData.get(), &xmlRegistry);
         mSensorModelState = NAME + std::string(" ") + xmlStr;
         reinitialize();
     }

--- a/six/projects/csm/source/SIDDSensorModel.cpp
+++ b/six/projects/csm/source/SIDDSensorModel.cpp
@@ -133,12 +133,11 @@ void SIDDSensorModel::initializeFromFile(const std::string& pathname,
                                "SIDDSensorModel::initializeFromFile");
         }
 
-        // Cast it and take ownership
-        mData.reset(reinterpret_cast<six::sidd::DerivedData*>(data));
-        container->removeData(mData.get());
+        // Cast it and grab a copy
+        mData.reset(reinterpret_cast<six::sidd::DerivedData*>(data->clone()));
 
         // get xml as string for sensor model state
-        std::string xmlStr = six::toXMLString(mData.get(), &xmlRegistry);
+        const std::string xmlStr = six::toXMLString(mData.get(), &xmlRegistry);
         mSensorModelState = NAME + std::string(" ") + xmlStr;
         reinitialize();
     }


### PR DESCRIPTION
How the underlying Container manages its memory had changed - since it holds onto a smart pointer now, and `removeData()` actually deleted the smart pointer, if we want to preserve a copy then we need to clone it ourselves.

Prior to this fix, trying to use the CSM plugin with an ISD constructed from a filename would seg fault.

@JonathanMeans 