### PR TITLE
Header size now calculated correctly

### DIFF
--- a/six/modules/c++/cphd/source/CPHDWriter.cpp
+++ b/six/modules/c++/cphd/source/CPHDWriter.cpp
@@ -172,7 +172,6 @@ void CPHDWriter::writeMetadata(size_t vbmSize,
     const std::string xmlMetadata(CPHDXMLControl().toXMLString(mMetadata));
 
     FileHeader header;
-    header.set(xmlMetadata.size(), vbmSize, cphdSize);
     if (!classification.empty())
     {
         header.setClassification(classification);
@@ -182,6 +181,8 @@ void CPHDWriter::writeMetadata(size_t vbmSize,
         header.setReleaseInfo(releaseInfo);
     }
 
+    // set header size, final step before write
+    header.set(xmlMetadata.size(), vbmSize, cphdSize);
     mFile.write(header.toString().c_str(), header.size());
     mFile.write("\f\n", 2);
     mFile.write(xmlMetadata.c_str(), xmlMetadata.size());


### PR DESCRIPTION
Function CPHDWriter::writeMetadata() had a defect in which the header size was calculated prior to the addition of the Classification and Release Information strings. If either of these strings were added the header's offsets to the other sections of the CPHD file were incorrect, resulting in a garbled CPHD file.