### PR TITLE
Add CPHDWriter to Python layer

### DIFF
--- a/six/modules/c++/cphd/include/cphd/CPHDWriter.h
+++ b/six/modules/c++/cphd/include/cphd/CPHDWriter.h
@@ -157,8 +157,6 @@ private:
     void writeCPHDDataImpl(const sys::ubyte* data,
                            size_t size);
 
-    static size_t initNumThreads(size_t numThreads);
-
     class DataWriter
     {
     public:

--- a/six/modules/c++/cphd/include/cphd/CPHDWriter.h
+++ b/six/modules/c++/cphd/include/cphd/CPHDWriter.h
@@ -31,6 +31,7 @@
 #include <types/RowCol.h>
 #include <io/FileOutputStream.h>
 #include <cphd/VBM.h>
+#include <sys/OS.h>
 
 namespace cphd
 {
@@ -46,6 +47,11 @@ public:
      *  \func Constructor
      *  \brief Sets up the internal structure of the CPHDWriter
      *
+     *  The default argument for numThreads should be sys::OS().getNumCPUs().
+     *  However, SWIG doesn't seem to like that.
+     *  As a workaround, we pass in 0 for the default, and the ctor sets the
+     *  number of threads to the number of CPUs if this happens.
+     *
      *  \param metadata A filled out metadata struct for the file that will be
      *         written. The data.arraySize and data.numCPHDChannels will be
      *         filled in internally. All other data must be provided.
@@ -55,7 +61,7 @@ public:
      *         Default is 4 MB
      */
     CPHDWriter(const Metadata& metadata,
-               size_t numThreads = sys::OS().getNumCPUs(),
+               size_t numThreads = 0,
                size_t scratchSpaceSize = 4 * 1024 * 1024);
 
     /*
@@ -150,6 +156,8 @@ private:
 
     void writeCPHDDataImpl(const sys::ubyte* data,
                            size_t size);
+
+    static size_t initNumThreads(size_t numThreads);
 
     class DataWriter
     {

--- a/six/modules/c++/cphd/source/CPHDWriter.cpp
+++ b/six/modules/c++/cphd/source/CPHDWriter.cpp
@@ -32,13 +32,19 @@ namespace cphd
 CPHDWriter::DataWriter::DataWriter(io::FileOutputStream& stream,
             size_t numThreads) :
     mStream(stream),
-    mNumThreads(numThreads)
+    mNumThreads(initNumThreads(numThreads))
 {
 }
 
 CPHDWriter::DataWriter::~DataWriter()
 {
 }
+
+size_t CPHDWriter::initNumThreads(size_t numThreads)
+{
+    return numThreads == 0 ? sys::OS().getNumCPUs() : numThreads;
+}
+
 
 CPHDWriter::DataWriterLittleEndian::DataWriterLittleEndian(
         io::FileOutputStream& stream,

--- a/six/modules/c++/cphd/source/CPHDWriter.cpp
+++ b/six/modules/c++/cphd/source/CPHDWriter.cpp
@@ -32,19 +32,13 @@ namespace cphd
 CPHDWriter::DataWriter::DataWriter(io::FileOutputStream& stream,
             size_t numThreads) :
     mStream(stream),
-    mNumThreads(initNumThreads(numThreads))
+    mNumThreads(numThreads == 0 ? sys::OS().getNumCPUs() : numThreads)
 {
 }
 
 CPHDWriter::DataWriter::~DataWriter()
 {
 }
-
-size_t CPHDWriter::initNumThreads(size_t numThreads)
-{
-    return numThreads == 0 ? sys::OS().getNumCPUs() : numThreads;
-}
-
 
 CPHDWriter::DataWriterLittleEndian::DataWriterLittleEndian(
         io::FileOutputStream& stream,

--- a/six/modules/python/cphd/source/cphd.i
+++ b/six/modules/python/cphd/source/cphd.i
@@ -1,8 +1,8 @@
 /*
  * =========================================================================
- * This file is part of cphd-python 
+ * This file is part of cphd-python
  * =========================================================================
- * 
+ *
  * (C) Copyright 2004 - 2015, MDA Information Systems LLC
  *
  * cphd-python is free software; you can redistribute it and/or modify
@@ -15,8 +15,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
  * see <http://www.gnu.org/licenses/>.
  */
 
@@ -37,15 +37,18 @@
 %import "scene.i"
 
 %{
+#include "import/types.h"
 #include "import/cphd.h"
 #include "import/six.h"
 #include "import/six/sicd.h"
+#include "import/sys.h"
 using six::Vector3;
 %}
 %ignore cphd::CPHDXMLControl::toXML(const Metadata& metadata);
 %ignore cphd::CPHDXMLControl::fromXML(const xml::lite::Document* doc);
 %ignore cphd::CPHDXMLControl::fromXML(const std::string& xmlString);
 %rename(CphdAntenna) cphd::Antenna;
+
 
 %include "cphd/Types.h"
 %include "cphd/Enums.h"
@@ -62,6 +65,13 @@ using six::Vector3;
 
 %include "cphd/Wideband.h"
 %include "cphd/CPHDReader.h"
+%include "cphd/CPHDWriter.h"
+
+%ignore CPHDWriter::writeCPHDData;
+%ignore CPHDWriter::close;
+%ignore CPHDWriter::writeMetadata;
+%ignore CPHDWriter::addImage;
+%ignore CPHDWriter::write;
 
 %extend cphd::FileHeader
 {
@@ -114,6 +124,18 @@ using six::Vector3;
 //       send NumPy arrays to/from C++ when you allocate an
 //       array > 4 GB.  It seems like Swig should be smarter
 //       in what it auto-generates to avoid this.
+%extend cphd::CPHDWriter
+{
+    void addImageImpl(long long image,
+            const types::RowCol<size_t>& dims,
+            long long vbm)
+    {
+        $self->addImage(reinterpret_cast<std::complex<float>*>(image),
+                dims,
+                reinterpret_cast<sys::ubyte*>(vbm));
+    }
+}
+
 %extend cphd::Wideband
 {
     // We need to expose a way to read into a raw buffer
@@ -140,23 +162,32 @@ using six::Vector3;
 %pythoncode
 %{
 import numpy
-
-def toBuffer(self, channel = 0):
-    
-    numpyArray = numpy.empty(shape = ((self.getVBMsize(channel) / 8)), dtype = 'double')
-    pointer, ro = numpyArray.__array_interface__['data']
-    
-    self.getVBMdata(channel, pointer)
-    return numpyArray
-    
-VBM.toBuffer = toBuffer
-%}
-
-%pythoncode
-%{
-import numpy
 import multiprocessing
 from coda.coda_types import RowColSizeT
+
+def toBuffer(self, channel = 0):
+
+    numpyArray = numpy.empty(shape = ((self.getVBMsize(channel) / 8)), dtype = 'double')
+    pointer, ro = numpyArray.__array_interface__['data']
+
+    self.getVBMdata(channel, pointer)
+    return numpyArray
+
+VBM.toBuffer = toBuffer
+
+def write(self, pathname, data, dims, vbm):
+    imagePointer, _ = data.__array_interface__['data']
+    vbmPointer, _ = vbm.__array_interface__['data']
+    if data.dtype != numpy.dtype('complex64'):
+        raise TypeError('Python CPHDWriter only supports complex float data')
+    self.addImageImpl(imagePointer, dims, vbmPointer)
+    self.write(pathname)
+
+def __del__(self):
+    self.close()
+
+CPHDWriter.writeCPHD = write
+CPHDWriter.__del__ = __del__
 
 def read(self,
          channel = 0,
@@ -165,22 +196,22 @@ def read(self,
          firstSample = 0,
          lastSample = Wideband.ALL,
          numThreads = multiprocessing.cpu_count()):
-    
+
     dims = self.getBufferDims(channel, firstVector, lastVector, firstSample, lastSample)
     sampleType = self.getSampleType()
-    
+
     # RF32F_IM32F
     if sampleType == 1:
         dtype = 'complex64'
     else:
         raise Exception('Unknown element type')
-        
-    
+
+
     numpyArray = numpy.empty(shape = (dims.row, dims.col), dtype = dtype)
     pointer, ro = numpyArray.__array_interface__['data']
     self.readImpl(channel, firstVector, lastVector, firstSample, lastSample, numThreads, dims, pointer)
     return numpyArray
-    
+
 Wideband.read = read
 %}
 
@@ -204,3 +235,4 @@ SCOPED_COPYABLE(cphd,AreaPlane);
 SCOPED_COPYABLE(cphd,FxParameters);
 SCOPED_COPYABLE(cphd,TOAParameters);
 SCOPED_COPYABLE_RENAME(cphd,Antenna,CphdAntenna);
+

--- a/six/modules/python/cphd/source/generated/cphd.py
+++ b/six/modules/python/cphd/source/generated/cphd.py
@@ -1970,8 +1970,63 @@ class CPHDReader(_object):
 CPHDReader_swigregister = _cphd.CPHDReader_swigregister
 CPHDReader_swigregister(CPHDReader)
 
+class CPHDWriter(_object):
+    """Proxy of C++ cphd::CPHDWriter class."""
+
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, CPHDWriter, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, CPHDWriter, name)
+    __repr__ = _swig_repr
+
+    def __init__(self, metadata, numThreads=0, scratchSpaceSize=4):
+        """
+        __init__(cphd::CPHDWriter self, Metadata metadata, size_t numThreads=0, size_t scratchSpaceSize=4) -> CPHDWriter
+        __init__(cphd::CPHDWriter self, Metadata metadata, size_t numThreads=0) -> CPHDWriter
+        __init__(cphd::CPHDWriter self, Metadata metadata) -> CPHDWriter
+        """
+        this = _cphd.new_CPHDWriter(metadata, numThreads, scratchSpaceSize)
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+
+    def writeMetadata(self, *args):
+        """
+        writeMetadata(CPHDWriter self, std::string const & pathname, VBM vbm, std::string const & classification, std::string const & releaseInfo)
+        writeMetadata(CPHDWriter self, std::string const & pathname, VBM vbm, std::string const & classification)
+        writeMetadata(CPHDWriter self, std::string const & pathname, VBM vbm)
+        """
+        return _cphd.CPHDWriter_writeMetadata(self, *args)
+
+
+    def write(self, *args):
+        """
+        write(CPHDWriter self, std::string const & pathname, std::string const & classification, std::string const & releaseInfo)
+        write(CPHDWriter self, std::string const & pathname, std::string const & classification)
+        write(CPHDWriter self, std::string const & pathname)
+        """
+        return _cphd.CPHDWriter_write(self, *args)
+
+
+    def close(self):
+        """close(CPHDWriter self)"""
+        return _cphd.CPHDWriter_close(self)
+
+
+    def addImageImpl(self, image, dims, vbm):
+        """addImageImpl(CPHDWriter self, long long image, RowColSizeT dims, long long vbm)"""
+        return _cphd.CPHDWriter_addImageImpl(self, image, dims, vbm)
+
+    __swig_destroy__ = _cphd.delete_CPHDWriter
+    __del__ = lambda self: None
+CPHDWriter_swigregister = _cphd.CPHDWriter_swigregister
+CPHDWriter_swigregister(CPHDWriter)
+
 
 import numpy
+import multiprocessing
+from coda.coda_types import RowColSizeT
 
 def toBuffer(self, channel = 0):
 
@@ -1983,10 +2038,19 @@ def toBuffer(self, channel = 0):
 
 VBM.toBuffer = toBuffer
 
+def write(self, pathname, data, dims, vbm):
+    imagePointer, _ = data.__array_interface__['data']
+    vbmPointer, _ = vbm.__array_interface__['data']
+    if data.dtype != numpy.dtype('complex64'):
+        raise TypeError('Python CPHDWriter only supports complex float data')
+    self.addImageImpl(imagePointer, dims, vbmPointer)
+    self.write(pathname)
 
-import numpy
-import multiprocessing
-from coda.coda_types import RowColSizeT
+def __del__(self):
+    self.close()
+
+CPHDWriter.writeCPHD = write
+CPHDWriter.__del__ = __del__
 
 def read(self,
          channel = 0,

--- a/six/modules/python/cphd/source/generated/cphd_wrap.cxx
+++ b/six/modules/python/cphd/source/generated/cphd_wrap.cxx
@@ -3019,113 +3019,114 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_cphd__AreaPlane swig_types[8]
 #define SWIGTYPE_p_cphd__ArraySize swig_types[9]
 #define SWIGTYPE_p_cphd__CPHDReader swig_types[10]
-#define SWIGTYPE_p_cphd__CPHDXMLControl swig_types[11]
-#define SWIGTYPE_p_cphd__Channel swig_types[12]
-#define SWIGTYPE_p_cphd__ChannelParameters swig_types[13]
-#define SWIGTYPE_p_cphd__Data swig_types[14]
-#define SWIGTYPE_p_cphd__DomainType swig_types[15]
-#define SWIGTYPE_p_cphd__DwellTimeParameters swig_types[16]
-#define SWIGTYPE_p_cphd__FileHeader swig_types[17]
-#define SWIGTYPE_p_cphd__FxParameters swig_types[18]
-#define SWIGTYPE_p_cphd__Global swig_types[19]
-#define SWIGTYPE_p_cphd__ImageArea swig_types[20]
-#define SWIGTYPE_p_cphd__Metadata swig_types[21]
-#define SWIGTYPE_p_cphd__PhaseSGN swig_types[22]
-#define SWIGTYPE_p_cphd__SRP swig_types[23]
-#define SWIGTYPE_p_cphd__SRPType swig_types[24]
-#define SWIGTYPE_p_cphd__SampleType swig_types[25]
-#define SWIGTYPE_p_cphd__TOAParameters swig_types[26]
-#define SWIGTYPE_p_cphd__VBM swig_types[27]
-#define SWIGTYPE_p_cphd__VectorParameters swig_types[28]
-#define SWIGTYPE_p_cphd__Wideband swig_types[29]
-#define SWIGTYPE_p_difference_type swig_types[30]
-#define SWIGTYPE_p_except__Context swig_types[31]
-#define SWIGTYPE_p_except__NullPointerReferenceException swig_types[32]
-#define SWIGTYPE_p_int swig_types[33]
-#define SWIGTYPE_p_int16_t swig_types[34]
-#define SWIGTYPE_p_int32_t swig_types[35]
-#define SWIGTYPE_p_int64_t swig_types[36]
-#define SWIGTYPE_p_int8_t swig_types[37]
-#define SWIGTYPE_p_io__FileInputStreamOS swig_types[38]
-#define SWIGTYPE_p_io__SeekableInputStream swig_types[39]
-#define SWIGTYPE_p_logging__Logger swig_types[40]
-#define SWIGTYPE_p_math__linear__VectorNT_2_double_t swig_types[41]
-#define SWIGTYPE_p_math__linear__VectorNT_3_double_t swig_types[42]
-#define SWIGTYPE_p_math__linear__VectorT_double_t swig_types[43]
-#define SWIGTYPE_p_math__poly__OneDT_double_t swig_types[44]
-#define SWIGTYPE_p_math__poly__OneDT_math__linear__VectorNT_3_double_t_t swig_types[45]
-#define SWIGTYPE_p_math__poly__TwoDT_double_t swig_types[46]
-#define SWIGTYPE_p_mem__BufferViewT_std__complexT_float_t_t swig_types[47]
-#define SWIGTYPE_p_mem__BufferViewT_unsigned_char_t swig_types[48]
-#define SWIGTYPE_p_mem__ScopedArrayT_unsigned_char_t swig_types[49]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__Antenna_t swig_types[50]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__AreaPlane_t swig_types[51]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__DwellTimeParameters_t swig_types[52]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__FxParameters_t swig_types[53]
-#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__TOAParameters_t swig_types[54]
-#define SWIGTYPE_p_mem__SharedPtrT_io__SeekableInputStream_t swig_types[55]
-#define SWIGTYPE_p_mem__SharedPtrT_logging__Logger_t swig_types[56]
-#define SWIGTYPE_p_mt__SingletonT_six__XMLControlRegistry_true_t swig_types[57]
-#define SWIGTYPE_p_nitf__DateTime swig_types[58]
-#define SWIGTYPE_p_off_t swig_types[59]
-#define SWIGTYPE_p_p_PyObject swig_types[60]
-#define SWIGTYPE_p_pid_t swig_types[61]
-#define SWIGTYPE_p_scene__AngleMagnitude swig_types[62]
-#define SWIGTYPE_p_scene__FrameType swig_types[63]
-#define SWIGTYPE_p_scene__LatLon swig_types[64]
-#define SWIGTYPE_p_scene__LatLonAlt swig_types[65]
-#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[66]
-#define SWIGTYPE_p_six__BooleanType swig_types[67]
-#define SWIGTYPE_p_six__CollectType swig_types[68]
-#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[69]
-#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[70]
-#define SWIGTYPE_p_six__Data swig_types[71]
-#define SWIGTYPE_p_six__DataType swig_types[72]
-#define SWIGTYPE_p_six__FFTSign swig_types[73]
-#define SWIGTYPE_p_six__RadarModeType swig_types[74]
-#define SWIGTYPE_p_six__ReferencePoint swig_types[75]
-#define SWIGTYPE_p_six__XMLControlCreator swig_types[76]
-#define SWIGTYPE_p_six__sicd__AntennaParameters swig_types[77]
-#define SWIGTYPE_p_six__sicd__AreaDirectionParameters swig_types[78]
-#define SWIGTYPE_p_six__sicd__CollectionInformation swig_types[79]
-#define SWIGTYPE_p_six__sicd__ComplexData swig_types[80]
-#define SWIGTYPE_p_six__sicd__ElectricalBoresight swig_types[81]
-#define SWIGTYPE_p_six__sicd__GainAndPhasePolys swig_types[82]
-#define SWIGTYPE_p_six__sicd__HalfPowerBeamwidths swig_types[83]
-#define SWIGTYPE_p_size_t swig_types[84]
-#define SWIGTYPE_p_size_type swig_types[85]
-#define SWIGTYPE_p_ssize_t swig_types[86]
-#define SWIGTYPE_p_std__allocatorT_cphd__ArraySize_t swig_types[87]
-#define SWIGTYPE_p_std__allocatorT_cphd__ChannelParameters_t swig_types[88]
-#define SWIGTYPE_p_std__allocatorT_math__linear__VectorNT_3_double_t_t swig_types[89]
-#define SWIGTYPE_p_std__allocatorT_six__sicd__AntennaParameters_t swig_types[90]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__Antenna_t swig_types[91]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__DwellTimeParameters_t swig_types[92]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__FxParameters_t swig_types[93]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__TOAParameters_t swig_types[94]
-#define SWIGTYPE_p_std__invalid_argument swig_types[95]
-#define SWIGTYPE_p_std__ostream swig_types[96]
-#define SWIGTYPE_p_std__vectorT_cphd__ArraySize_std__allocatorT_cphd__ArraySize_t_t swig_types[97]
-#define SWIGTYPE_p_std__vectorT_cphd__ChannelParameters_std__allocatorT_cphd__ChannelParameters_t_t swig_types[98]
-#define SWIGTYPE_p_std__vectorT_math__linear__VectorNT_3_double_t_std__allocatorT_math__linear__VectorNT_3_double_t_t_t swig_types[99]
-#define SWIGTYPE_p_std__vectorT_math__poly__OneDT_Vector3_t_std__allocatorT_math__poly__OneDT_Vector3_t_t_t swig_types[100]
-#define SWIGTYPE_p_std__vectorT_six__sicd__AntennaParameters_std__allocatorT_six__sicd__AntennaParameters_t_t swig_types[101]
-#define SWIGTYPE_p_std__vectorT_unsigned_char_std__allocatorT_unsigned_char_t_t swig_types[102]
-#define SWIGTYPE_p_std__vectorT_void_const_p_std__allocatorT_void_const_p_t_t swig_types[103]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[104]
-#define SWIGTYPE_p_types__RowColT_double_t swig_types[105]
-#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[106]
-#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[107]
-#define SWIGTYPE_p_types__RowColT_size_t_t swig_types[108]
-#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[109]
-#define SWIGTYPE_p_uint16_t swig_types[110]
-#define SWIGTYPE_p_uint32_t swig_types[111]
-#define SWIGTYPE_p_uint64_t swig_types[112]
-#define SWIGTYPE_p_uint8_t swig_types[113]
-#define SWIGTYPE_p_unsigned_char swig_types[114]
-#define SWIGTYPE_p_value_type swig_types[115]
-static swig_type_info *swig_types[117];
-static swig_module_info swig_module = {swig_types, 116, 0, 0, 0, 0};
+#define SWIGTYPE_p_cphd__CPHDWriter swig_types[11]
+#define SWIGTYPE_p_cphd__CPHDXMLControl swig_types[12]
+#define SWIGTYPE_p_cphd__Channel swig_types[13]
+#define SWIGTYPE_p_cphd__ChannelParameters swig_types[14]
+#define SWIGTYPE_p_cphd__Data swig_types[15]
+#define SWIGTYPE_p_cphd__DomainType swig_types[16]
+#define SWIGTYPE_p_cphd__DwellTimeParameters swig_types[17]
+#define SWIGTYPE_p_cphd__FileHeader swig_types[18]
+#define SWIGTYPE_p_cphd__FxParameters swig_types[19]
+#define SWIGTYPE_p_cphd__Global swig_types[20]
+#define SWIGTYPE_p_cphd__ImageArea swig_types[21]
+#define SWIGTYPE_p_cphd__Metadata swig_types[22]
+#define SWIGTYPE_p_cphd__PhaseSGN swig_types[23]
+#define SWIGTYPE_p_cphd__SRP swig_types[24]
+#define SWIGTYPE_p_cphd__SRPType swig_types[25]
+#define SWIGTYPE_p_cphd__SampleType swig_types[26]
+#define SWIGTYPE_p_cphd__TOAParameters swig_types[27]
+#define SWIGTYPE_p_cphd__VBM swig_types[28]
+#define SWIGTYPE_p_cphd__VectorParameters swig_types[29]
+#define SWIGTYPE_p_cphd__Wideband swig_types[30]
+#define SWIGTYPE_p_difference_type swig_types[31]
+#define SWIGTYPE_p_except__Context swig_types[32]
+#define SWIGTYPE_p_except__NullPointerReferenceException swig_types[33]
+#define SWIGTYPE_p_int swig_types[34]
+#define SWIGTYPE_p_int16_t swig_types[35]
+#define SWIGTYPE_p_int32_t swig_types[36]
+#define SWIGTYPE_p_int64_t swig_types[37]
+#define SWIGTYPE_p_int8_t swig_types[38]
+#define SWIGTYPE_p_io__FileInputStreamOS swig_types[39]
+#define SWIGTYPE_p_io__SeekableInputStream swig_types[40]
+#define SWIGTYPE_p_logging__Logger swig_types[41]
+#define SWIGTYPE_p_math__linear__VectorNT_2_double_t swig_types[42]
+#define SWIGTYPE_p_math__linear__VectorNT_3_double_t swig_types[43]
+#define SWIGTYPE_p_math__linear__VectorT_double_t swig_types[44]
+#define SWIGTYPE_p_math__poly__OneDT_double_t swig_types[45]
+#define SWIGTYPE_p_math__poly__OneDT_math__linear__VectorNT_3_double_t_t swig_types[46]
+#define SWIGTYPE_p_math__poly__TwoDT_double_t swig_types[47]
+#define SWIGTYPE_p_mem__BufferViewT_std__complexT_float_t_t swig_types[48]
+#define SWIGTYPE_p_mem__BufferViewT_unsigned_char_t swig_types[49]
+#define SWIGTYPE_p_mem__ScopedArrayT_unsigned_char_t swig_types[50]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__Antenna_t swig_types[51]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__AreaPlane_t swig_types[52]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__DwellTimeParameters_t swig_types[53]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__FxParameters_t swig_types[54]
+#define SWIGTYPE_p_mem__ScopedCopyablePtrT_cphd__TOAParameters_t swig_types[55]
+#define SWIGTYPE_p_mem__SharedPtrT_io__SeekableInputStream_t swig_types[56]
+#define SWIGTYPE_p_mem__SharedPtrT_logging__Logger_t swig_types[57]
+#define SWIGTYPE_p_mt__SingletonT_six__XMLControlRegistry_true_t swig_types[58]
+#define SWIGTYPE_p_nitf__DateTime swig_types[59]
+#define SWIGTYPE_p_off_t swig_types[60]
+#define SWIGTYPE_p_p_PyObject swig_types[61]
+#define SWIGTYPE_p_pid_t swig_types[62]
+#define SWIGTYPE_p_scene__AngleMagnitude swig_types[63]
+#define SWIGTYPE_p_scene__FrameType swig_types[64]
+#define SWIGTYPE_p_scene__LatLon swig_types[65]
+#define SWIGTYPE_p_scene__LatLonAlt swig_types[66]
+#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[67]
+#define SWIGTYPE_p_six__BooleanType swig_types[68]
+#define SWIGTYPE_p_six__CollectType swig_types[69]
+#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[70]
+#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[71]
+#define SWIGTYPE_p_six__Data swig_types[72]
+#define SWIGTYPE_p_six__DataType swig_types[73]
+#define SWIGTYPE_p_six__FFTSign swig_types[74]
+#define SWIGTYPE_p_six__RadarModeType swig_types[75]
+#define SWIGTYPE_p_six__ReferencePoint swig_types[76]
+#define SWIGTYPE_p_six__XMLControlCreator swig_types[77]
+#define SWIGTYPE_p_six__sicd__AntennaParameters swig_types[78]
+#define SWIGTYPE_p_six__sicd__AreaDirectionParameters swig_types[79]
+#define SWIGTYPE_p_six__sicd__CollectionInformation swig_types[80]
+#define SWIGTYPE_p_six__sicd__ComplexData swig_types[81]
+#define SWIGTYPE_p_six__sicd__ElectricalBoresight swig_types[82]
+#define SWIGTYPE_p_six__sicd__GainAndPhasePolys swig_types[83]
+#define SWIGTYPE_p_six__sicd__HalfPowerBeamwidths swig_types[84]
+#define SWIGTYPE_p_size_t swig_types[85]
+#define SWIGTYPE_p_size_type swig_types[86]
+#define SWIGTYPE_p_ssize_t swig_types[87]
+#define SWIGTYPE_p_std__allocatorT_cphd__ArraySize_t swig_types[88]
+#define SWIGTYPE_p_std__allocatorT_cphd__ChannelParameters_t swig_types[89]
+#define SWIGTYPE_p_std__allocatorT_math__linear__VectorNT_3_double_t_t swig_types[90]
+#define SWIGTYPE_p_std__allocatorT_six__sicd__AntennaParameters_t swig_types[91]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__Antenna_t swig_types[92]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__DwellTimeParameters_t swig_types[93]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__FxParameters_t swig_types[94]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__TOAParameters_t swig_types[95]
+#define SWIGTYPE_p_std__invalid_argument swig_types[96]
+#define SWIGTYPE_p_std__ostream swig_types[97]
+#define SWIGTYPE_p_std__vectorT_cphd__ArraySize_std__allocatorT_cphd__ArraySize_t_t swig_types[98]
+#define SWIGTYPE_p_std__vectorT_cphd__ChannelParameters_std__allocatorT_cphd__ChannelParameters_t_t swig_types[99]
+#define SWIGTYPE_p_std__vectorT_math__linear__VectorNT_3_double_t_std__allocatorT_math__linear__VectorNT_3_double_t_t_t swig_types[100]
+#define SWIGTYPE_p_std__vectorT_math__poly__OneDT_Vector3_t_std__allocatorT_math__poly__OneDT_Vector3_t_t_t swig_types[101]
+#define SWIGTYPE_p_std__vectorT_six__sicd__AntennaParameters_std__allocatorT_six__sicd__AntennaParameters_t_t swig_types[102]
+#define SWIGTYPE_p_std__vectorT_unsigned_char_std__allocatorT_unsigned_char_t_t swig_types[103]
+#define SWIGTYPE_p_std__vectorT_void_const_p_std__allocatorT_void_const_p_t_t swig_types[104]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[105]
+#define SWIGTYPE_p_types__RowColT_double_t swig_types[106]
+#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[107]
+#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[108]
+#define SWIGTYPE_p_types__RowColT_size_t_t swig_types[109]
+#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[110]
+#define SWIGTYPE_p_uint16_t swig_types[111]
+#define SWIGTYPE_p_uint32_t swig_types[112]
+#define SWIGTYPE_p_uint64_t swig_types[113]
+#define SWIGTYPE_p_uint8_t swig_types[114]
+#define SWIGTYPE_p_unsigned_char swig_types[115]
+#define SWIGTYPE_p_value_type swig_types[116]
+static swig_type_info *swig_types[118];
+static swig_module_info swig_module = {swig_types, 117, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -4749,9 +4750,11 @@ namespace swig
 }
 
 
+#include "import/types.h"
 #include "import/cphd.h"
 #include "import/six.h"
 #include "import/six/sicd.h"
+#include "import/sys.h"
 using six::Vector3;
 
 
@@ -5262,6 +5265,11 @@ SWIGINTERN void cphd_Wideband_readImpl(cphd::Wideband *self,size_t channel,size_
                     numThreads,
                     dims,
                     reinterpret_cast<void*>(data));
+    }
+SWIGINTERN void cphd_CPHDWriter_addImageImpl(cphd::CPHDWriter *self,long long image,types::RowCol< size_t > const &dims,long long vbm){
+        self->addImage(reinterpret_cast<std::complex<float>*>(image),
+                dims,
+                reinterpret_cast<sys::ubyte*>(vbm));
     }
 
   namespace swig {
@@ -32966,6 +32974,1147 @@ SWIGINTERN PyObject *CPHDReader_swigregister(PyObject *SWIGUNUSEDPARM(self), PyO
   return SWIG_Py_Void();
 }
 
+SWIGINTERN PyObject *_wrap_new_CPHDWriter__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::Metadata *arg1 = 0 ;
+  size_t arg2 ;
+  size_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  cphd::CPHDWriter *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:new_CPHDWriter",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_cphd__Metadata,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_CPHDWriter" "', argument " "1"" of type '" "cphd::Metadata const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_CPHDWriter" "', argument " "1"" of type '" "cphd::Metadata const &""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::Metadata * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_CPHDWriter" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_CPHDWriter" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  {
+    try
+    {
+      result = (cphd::CPHDWriter *)new cphd::CPHDWriter((cphd::Metadata const &)*arg1,arg2,arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_cphd__CPHDWriter, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_CPHDWriter__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::Metadata *arg1 = 0 ;
+  size_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  size_t val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  cphd::CPHDWriter *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:new_CPHDWriter",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_cphd__Metadata,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_CPHDWriter" "', argument " "1"" of type '" "cphd::Metadata const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_CPHDWriter" "', argument " "1"" of type '" "cphd::Metadata const &""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::Metadata * >(argp1);
+  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_CPHDWriter" "', argument " "2"" of type '" "size_t""'");
+  } 
+  arg2 = static_cast< size_t >(val2);
+  {
+    try
+    {
+      result = (cphd::CPHDWriter *)new cphd::CPHDWriter((cphd::Metadata const &)*arg1,arg2);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_cphd__CPHDWriter, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_CPHDWriter__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::Metadata *arg1 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  cphd::CPHDWriter *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:new_CPHDWriter",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1, SWIGTYPE_p_cphd__Metadata,  0  | 0);
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_CPHDWriter" "', argument " "1"" of type '" "cphd::Metadata const &""'"); 
+  }
+  if (!argp1) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_CPHDWriter" "', argument " "1"" of type '" "cphd::Metadata const &""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::Metadata * >(argp1);
+  {
+    try
+    {
+      result = (cphd::CPHDWriter *)new cphd::CPHDWriter((cphd::Metadata const &)*arg1);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_cphd__CPHDWriter, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_CPHDWriter(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[4] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 3) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 1) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_cphd__Metadata, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      return _wrap_new_CPHDWriter__SWIG_2(self, args);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_cphd__Metadata, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_size_t(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_new_CPHDWriter__SWIG_1(self, args);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    int res = SWIG_ConvertPtr(argv[0], 0, SWIGTYPE_p_cphd__Metadata, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      {
+        int res = SWIG_AsVal_size_t(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_new_CPHDWriter__SWIG_0(self, args);
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_CPHDWriter'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    cphd::CPHDWriter::CPHDWriter(cphd::Metadata const &,size_t,size_t)\n"
+    "    cphd::CPHDWriter::CPHDWriter(cphd::Metadata const &,size_t)\n"
+    "    cphd::CPHDWriter::CPHDWriter(cphd::Metadata const &)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_writeMetadata__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::CPHDWriter *arg1 = (cphd::CPHDWriter *) 0 ;
+  std::string *arg2 = 0 ;
+  cphd::VBM *arg3 = 0 ;
+  std::string *arg4 = 0 ;
+  std::string *arg5 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  int res4 = SWIG_OLDOBJ ;
+  int res5 = SWIG_OLDOBJ ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:CPHDWriter_writeMetadata",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_cphd__CPHDWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CPHDWriter_writeMetadata" "', argument " "1"" of type '" "cphd::CPHDWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::CPHDWriter * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CPHDWriter_writeMetadata" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_writeMetadata" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_cphd__VBM,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "CPHDWriter_writeMetadata" "', argument " "3"" of type '" "cphd::VBM const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_writeMetadata" "', argument " "3"" of type '" "cphd::VBM const &""'"); 
+  }
+  arg3 = reinterpret_cast< cphd::VBM * >(argp3);
+  {
+    std::string *ptr = (std::string *)0;
+    res4 = SWIG_AsPtr_std_string(obj3, &ptr);
+    if (!SWIG_IsOK(res4)) {
+      SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "CPHDWriter_writeMetadata" "', argument " "4"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_writeMetadata" "', argument " "4"" of type '" "std::string const &""'"); 
+    }
+    arg4 = ptr;
+  }
+  {
+    std::string *ptr = (std::string *)0;
+    res5 = SWIG_AsPtr_std_string(obj4, &ptr);
+    if (!SWIG_IsOK(res5)) {
+      SWIG_exception_fail(SWIG_ArgError(res5), "in method '" "CPHDWriter_writeMetadata" "', argument " "5"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_writeMetadata" "', argument " "5"" of type '" "std::string const &""'"); 
+    }
+    arg5 = ptr;
+  }
+  {
+    try
+    {
+      (arg1)->writeMetadata((std::string const &)*arg2,(cphd::VBM const &)*arg3,(std::string const &)*arg4,(std::string const &)*arg5);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  if (SWIG_IsNewObj(res5)) delete arg5;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  if (SWIG_IsNewObj(res5)) delete arg5;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_writeMetadata__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::CPHDWriter *arg1 = (cphd::CPHDWriter *) 0 ;
+  std::string *arg2 = 0 ;
+  cphd::VBM *arg3 = 0 ;
+  std::string *arg4 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  int res4 = SWIG_OLDOBJ ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:CPHDWriter_writeMetadata",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_cphd__CPHDWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CPHDWriter_writeMetadata" "', argument " "1"" of type '" "cphd::CPHDWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::CPHDWriter * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CPHDWriter_writeMetadata" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_writeMetadata" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_cphd__VBM,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "CPHDWriter_writeMetadata" "', argument " "3"" of type '" "cphd::VBM const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_writeMetadata" "', argument " "3"" of type '" "cphd::VBM const &""'"); 
+  }
+  arg3 = reinterpret_cast< cphd::VBM * >(argp3);
+  {
+    std::string *ptr = (std::string *)0;
+    res4 = SWIG_AsPtr_std_string(obj3, &ptr);
+    if (!SWIG_IsOK(res4)) {
+      SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "CPHDWriter_writeMetadata" "', argument " "4"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_writeMetadata" "', argument " "4"" of type '" "std::string const &""'"); 
+    }
+    arg4 = ptr;
+  }
+  {
+    try
+    {
+      (arg1)->writeMetadata((std::string const &)*arg2,(cphd::VBM const &)*arg3,(std::string const &)*arg4);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_writeMetadata__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::CPHDWriter *arg1 = (cphd::CPHDWriter *) 0 ;
+  std::string *arg2 = 0 ;
+  cphd::VBM *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:CPHDWriter_writeMetadata",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_cphd__CPHDWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CPHDWriter_writeMetadata" "', argument " "1"" of type '" "cphd::CPHDWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::CPHDWriter * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CPHDWriter_writeMetadata" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_writeMetadata" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_cphd__VBM,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "CPHDWriter_writeMetadata" "', argument " "3"" of type '" "cphd::VBM const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_writeMetadata" "', argument " "3"" of type '" "cphd::VBM const &""'"); 
+  }
+  arg3 = reinterpret_cast< cphd::VBM * >(argp3);
+  {
+    try
+    {
+      (arg1)->writeMetadata((std::string const &)*arg2,(cphd::VBM const &)*arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_writeMetadata(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[6] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 5) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_cphd__CPHDWriter, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_cphd__VBM, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_CPHDWriter_writeMetadata__SWIG_2(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_cphd__CPHDWriter, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_cphd__VBM, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          int res = SWIG_AsPtr_std_string(argv[3], (std::string**)(0));
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_CPHDWriter_writeMetadata__SWIG_1(self, args);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 5) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_cphd__CPHDWriter, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_cphd__VBM, 0);
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          int res = SWIG_AsPtr_std_string(argv[3], (std::string**)(0));
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            int res = SWIG_AsPtr_std_string(argv[4], (std::string**)(0));
+            _v = SWIG_CheckState(res);
+            if (_v) {
+              return _wrap_CPHDWriter_writeMetadata__SWIG_0(self, args);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'CPHDWriter_writeMetadata'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    cphd::CPHDWriter::writeMetadata(std::string const &,cphd::VBM const &,std::string const &,std::string const &)\n"
+    "    cphd::CPHDWriter::writeMetadata(std::string const &,cphd::VBM const &,std::string const &)\n"
+    "    cphd::CPHDWriter::writeMetadata(std::string const &,cphd::VBM const &)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_write__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::CPHDWriter *arg1 = (cphd::CPHDWriter *) 0 ;
+  std::string *arg2 = 0 ;
+  std::string *arg3 = 0 ;
+  std::string *arg4 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  int res3 = SWIG_OLDOBJ ;
+  int res4 = SWIG_OLDOBJ ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:CPHDWriter_write",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_cphd__CPHDWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CPHDWriter_write" "', argument " "1"" of type '" "cphd::CPHDWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::CPHDWriter * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CPHDWriter_write" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_write" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  {
+    std::string *ptr = (std::string *)0;
+    res3 = SWIG_AsPtr_std_string(obj2, &ptr);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "CPHDWriter_write" "', argument " "3"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_write" "', argument " "3"" of type '" "std::string const &""'"); 
+    }
+    arg3 = ptr;
+  }
+  {
+    std::string *ptr = (std::string *)0;
+    res4 = SWIG_AsPtr_std_string(obj3, &ptr);
+    if (!SWIG_IsOK(res4)) {
+      SWIG_exception_fail(SWIG_ArgError(res4), "in method '" "CPHDWriter_write" "', argument " "4"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_write" "', argument " "4"" of type '" "std::string const &""'"); 
+    }
+    arg4 = ptr;
+  }
+  {
+    try
+    {
+      (arg1)->write((std::string const &)*arg2,(std::string const &)*arg3,(std::string const &)*arg4);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res3)) delete arg3;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res3)) delete arg3;
+  if (SWIG_IsNewObj(res4)) delete arg4;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_write__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::CPHDWriter *arg1 = (cphd::CPHDWriter *) 0 ;
+  std::string *arg2 = 0 ;
+  std::string *arg3 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  int res3 = SWIG_OLDOBJ ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:CPHDWriter_write",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_cphd__CPHDWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CPHDWriter_write" "', argument " "1"" of type '" "cphd::CPHDWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::CPHDWriter * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CPHDWriter_write" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_write" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  {
+    std::string *ptr = (std::string *)0;
+    res3 = SWIG_AsPtr_std_string(obj2, &ptr);
+    if (!SWIG_IsOK(res3)) {
+      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "CPHDWriter_write" "', argument " "3"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_write" "', argument " "3"" of type '" "std::string const &""'"); 
+    }
+    arg3 = ptr;
+  }
+  {
+    try
+    {
+      (arg1)->write((std::string const &)*arg2,(std::string const &)*arg3);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res3)) delete arg3;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  if (SWIG_IsNewObj(res3)) delete arg3;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_write__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::CPHDWriter *arg1 = (cphd::CPHDWriter *) 0 ;
+  std::string *arg2 = 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:CPHDWriter_write",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_cphd__CPHDWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CPHDWriter_write" "', argument " "1"" of type '" "cphd::CPHDWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::CPHDWriter * >(argp1);
+  {
+    std::string *ptr = (std::string *)0;
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "CPHDWriter_write" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_write" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
+  }
+  {
+    try
+    {
+      (arg1)->write((std::string const &)*arg2);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return resultobj;
+fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_write(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 4) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 2) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_cphd__CPHDWriter, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_CPHDWriter_write__SWIG_2(self, args);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_cphd__CPHDWriter, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_AsPtr_std_string(argv[2], (std::string**)(0));
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          return _wrap_CPHDWriter_write__SWIG_1(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_cphd__CPHDWriter, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      int res = SWIG_AsPtr_std_string(argv[1], (std::string**)(0));
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        int res = SWIG_AsPtr_std_string(argv[2], (std::string**)(0));
+        _v = SWIG_CheckState(res);
+        if (_v) {
+          int res = SWIG_AsPtr_std_string(argv[3], (std::string**)(0));
+          _v = SWIG_CheckState(res);
+          if (_v) {
+            return _wrap_CPHDWriter_write__SWIG_0(self, args);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'CPHDWriter_write'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    cphd::CPHDWriter::write(std::string const &,std::string const &,std::string const &)\n"
+    "    cphd::CPHDWriter::write(std::string const &,std::string const &)\n"
+    "    cphd::CPHDWriter::write(std::string const &)\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_close(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::CPHDWriter *arg1 = (cphd::CPHDWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:CPHDWriter_close",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_cphd__CPHDWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CPHDWriter_close" "', argument " "1"" of type '" "cphd::CPHDWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::CPHDWriter * >(argp1);
+  {
+    try
+    {
+      (arg1)->close();
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_CPHDWriter_addImageImpl(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::CPHDWriter *arg1 = (cphd::CPHDWriter *) 0 ;
+  long long arg2 ;
+  types::RowCol< size_t > *arg3 = 0 ;
+  long long arg4 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  long long val2 ;
+  int ecode2 = 0 ;
+  void *argp3 = 0 ;
+  int res3 = 0 ;
+  long long val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:CPHDWriter_addImageImpl",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_cphd__CPHDWriter, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "CPHDWriter_addImageImpl" "', argument " "1"" of type '" "cphd::CPHDWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::CPHDWriter * >(argp1);
+  ecode2 = SWIG_AsVal_long_SS_long(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "CPHDWriter_addImageImpl" "', argument " "2"" of type '" "long long""'");
+  } 
+  arg2 = static_cast< long long >(val2);
+  res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_types__RowColT_size_t_t,  0  | 0);
+  if (!SWIG_IsOK(res3)) {
+    SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "CPHDWriter_addImageImpl" "', argument " "3"" of type '" "types::RowCol< size_t > const &""'"); 
+  }
+  if (!argp3) {
+    SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "CPHDWriter_addImageImpl" "', argument " "3"" of type '" "types::RowCol< size_t > const &""'"); 
+  }
+  arg3 = reinterpret_cast< types::RowCol< size_t > * >(argp3);
+  ecode4 = SWIG_AsVal_long_SS_long(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "CPHDWriter_addImageImpl" "', argument " "4"" of type '" "long long""'");
+  } 
+  arg4 = static_cast< long long >(val4);
+  {
+    try
+    {
+      cphd_CPHDWriter_addImageImpl(arg1,arg2,(types::RowCol< size_t > const &)*arg3,arg4);
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_CPHDWriter(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  cphd::CPHDWriter *arg1 = (cphd::CPHDWriter *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_CPHDWriter",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_cphd__CPHDWriter, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_CPHDWriter" "', argument " "1"" of type '" "cphd::CPHDWriter *""'"); 
+  }
+  arg1 = reinterpret_cast< cphd::CPHDWriter * >(argp1);
+  {
+    try
+    {
+      delete arg1;
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *CPHDWriter_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char*)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_cphd__CPHDWriter, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
 SWIGINTERN PyObject *_wrap_VectorArraySize_iterator(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   std::vector< cphd::ArraySize > *arg1 = (std::vector< cphd::ArraySize > *) 0 ;
@@ -52499,6 +53648,25 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"CPHDReader_getWideband", _wrap_CPHDReader_getWideband, METH_VARARGS, (char *)"CPHDReader_getWideband(CPHDReader self) -> Wideband"},
 	 { (char *)"delete_CPHDReader", _wrap_delete_CPHDReader, METH_VARARGS, (char *)"delete_CPHDReader(CPHDReader self)"},
 	 { (char *)"CPHDReader_swigregister", CPHDReader_swigregister, METH_VARARGS, NULL},
+	 { (char *)"new_CPHDWriter", _wrap_new_CPHDWriter, METH_VARARGS, (char *)"\n"
+		"CPHDWriter(Metadata metadata, size_t numThreads=0, size_t scratchSpaceSize=4)\n"
+		"CPHDWriter(Metadata metadata, size_t numThreads=0)\n"
+		"new_CPHDWriter(Metadata metadata) -> CPHDWriter\n"
+		""},
+	 { (char *)"CPHDWriter_writeMetadata", _wrap_CPHDWriter_writeMetadata, METH_VARARGS, (char *)"\n"
+		"writeMetadata(std::string const & pathname, VBM vbm, std::string const & classification, std::string const & releaseInfo)\n"
+		"writeMetadata(std::string const & pathname, VBM vbm, std::string const & classification)\n"
+		"CPHDWriter_writeMetadata(CPHDWriter self, std::string const & pathname, VBM vbm)\n"
+		""},
+	 { (char *)"CPHDWriter_write", _wrap_CPHDWriter_write, METH_VARARGS, (char *)"\n"
+		"write(std::string const & pathname, std::string const & classification, std::string const & releaseInfo)\n"
+		"write(std::string const & pathname, std::string const & classification)\n"
+		"CPHDWriter_write(CPHDWriter self, std::string const & pathname)\n"
+		""},
+	 { (char *)"CPHDWriter_close", _wrap_CPHDWriter_close, METH_VARARGS, (char *)"CPHDWriter_close(CPHDWriter self)"},
+	 { (char *)"CPHDWriter_addImageImpl", _wrap_CPHDWriter_addImageImpl, METH_VARARGS, (char *)"CPHDWriter_addImageImpl(CPHDWriter self, long long image, RowColSizeT dims, long long vbm)"},
+	 { (char *)"delete_CPHDWriter", _wrap_delete_CPHDWriter, METH_VARARGS, (char *)"delete_CPHDWriter(CPHDWriter self)"},
+	 { (char *)"CPHDWriter_swigregister", CPHDWriter_swigregister, METH_VARARGS, NULL},
 	 { (char *)"VectorArraySize_iterator", _wrap_VectorArraySize_iterator, METH_VARARGS, (char *)"VectorArraySize_iterator(VectorArraySize self) -> SwigPyIterator"},
 	 { (char *)"VectorArraySize___nonzero__", _wrap_VectorArraySize___nonzero__, METH_VARARGS, (char *)"VectorArraySize___nonzero__(VectorArraySize self) -> bool"},
 	 { (char *)"VectorArraySize___bool__", _wrap_VectorArraySize___bool__, METH_VARARGS, (char *)"VectorArraySize___bool__(VectorArraySize self) -> bool"},
@@ -52902,6 +54070,7 @@ static swig_type_info _swigt__p_cphd__Antenna = {"_p_cphd__Antenna", "cphd::Ante
 static swig_type_info _swigt__p_cphd__AreaPlane = {"_p_cphd__AreaPlane", "cphd::AreaPlane *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_cphd__ArraySize = {"_p_cphd__ArraySize", "std::vector< cphd::ArraySize >::value_type *|cphd::ArraySize *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_cphd__CPHDReader = {"_p_cphd__CPHDReader", "cphd::CPHDReader *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_cphd__CPHDWriter = {"_p_cphd__CPHDWriter", "cphd::CPHDWriter *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_cphd__CPHDXMLControl = {"_p_cphd__CPHDXMLControl", "cphd::CPHDXMLControl *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_cphd__Channel = {"_p_cphd__Channel", "cphd::Channel *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_cphd__ChannelParameters = {"_p_cphd__ChannelParameters", "std::vector< cphd::ChannelParameters >::value_type *|cphd::ChannelParameters *", 0, 0, (void*)0, 0};
@@ -53020,6 +54189,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_cphd__AreaPlane,
   &_swigt__p_cphd__ArraySize,
   &_swigt__p_cphd__CPHDReader,
+  &_swigt__p_cphd__CPHDWriter,
   &_swigt__p_cphd__CPHDXMLControl,
   &_swigt__p_cphd__Channel,
   &_swigt__p_cphd__ChannelParameters,
@@ -53138,6 +54308,7 @@ static swig_cast_info _swigc__p_cphd__Antenna[] = {  {&_swigt__p_cphd__Antenna, 
 static swig_cast_info _swigc__p_cphd__AreaPlane[] = {  {&_swigt__p_cphd__AreaPlane, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_cphd__ArraySize[] = {  {&_swigt__p_cphd__ArraySize, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_cphd__CPHDReader[] = {  {&_swigt__p_cphd__CPHDReader, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_cphd__CPHDWriter[] = {  {&_swigt__p_cphd__CPHDWriter, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_cphd__CPHDXMLControl[] = {  {&_swigt__p_cphd__CPHDXMLControl, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_cphd__Channel[] = {  {&_swigt__p_cphd__Channel, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_cphd__ChannelParameters[] = {  {&_swigt__p_cphd__ChannelParameters, 0, 0, 0},{0, 0, 0, 0}};
@@ -53256,6 +54427,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_cphd__AreaPlane,
   _swigc__p_cphd__ArraySize,
   _swigc__p_cphd__CPHDReader,
+  _swigc__p_cphd__CPHDWriter,
   _swigc__p_cphd__CPHDXMLControl,
   _swigc__p_cphd__Channel,
   _swigc__p_cphd__ChannelParameters,

--- a/six/modules/python/cphd/tests/test_round_trip_cphd.py
+++ b/six/modules/python/cphd/tests/test_round_trip_cphd.py
@@ -49,5 +49,5 @@ if __name__ == '__main__':
     assert (roundTrippedReader.getFileHeader().toString() ==
             reader.getFileHeader().toString())
     assert roundTrippedReader.getMetadata() == reader.getMetadata()
-    return 0
+    sys.exit(0)
 

--- a/six/modules/python/cphd/tests/test_round_trip_cphd.py
+++ b/six/modules/python/cphd/tests/test_round_trip_cphd.py
@@ -49,4 +49,5 @@ if __name__ == '__main__':
     assert (roundTrippedReader.getFileHeader().toString() ==
             reader.getFileHeader().toString())
     assert roundTrippedReader.getMetadata() == reader.getMetadata()
+    return 0
 

--- a/six/modules/python/six/tests/makeRegressionFiles.py
+++ b/six/modules/python/six/tests/makeRegressionFiles.py
@@ -33,3 +33,4 @@ def run():
 
     makeSIDDRegressionFiles.run()
     makeSICDRegressionFiles.run()
+


### PR DESCRIPTION
This allows for writing `std::complex<float>` CPHD files. The Python-layer writer and reader are currently restricted to this overload, because numpy doesn't have a datatype corresponding to `complex<int16>` or `complex<int8>.` I'm assuming since the reader's been fine how it is, there's no immediate need to support the other two overloads.  If there is, that might take a bit of thinking.

#147 
@darkstar007