### PR TITLE
Add utility for generate fake ComplexData

### DIFF
--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -329,6 +329,14 @@ public:
             const std::vector<std::string>& schemaPaths =
                     std::vector<std::string>(),
             logging::Logger* logger = NULL);
+
+    /*!
+     * Create a fake SICD that's populated enough for
+     * general testing code to run without throwing exceptions
+     *
+     * \return mock ComplexData object
+     */
+    static ComplexData createFakeComplexData();
 };
 }
 }

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -336,7 +336,7 @@ public:
      *
      * \return mock ComplexData object
      */
-    static ComplexData createFakeComplexData();
+    static std::auto_ptr<ComplexData> createFakeComplexData();
 };
 }
 }

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -624,63 +624,63 @@ std::string Utilities::toXMLString(const ComplexData& data,
                                    &xmlRegistry);
 }
 
-ComplexData Utilities::createFakeComplexData()
+std::auto_ptr<ComplexData> Utilities::createFakeComplexData()
 {
-    ComplexData data;
-    data.position->arpPoly = six::PolyXYZ(5);
-    data.position->arpPoly[0][0] = 4.45303008e6;
-    data.position->arpPoly[1][0] = 5.75153322e3;
-    data.position->arpPoly[2][0] = -2.7014602e0;
-    data.position->arpPoly[3][0] = -1.2323143e-3;
-    data.position->arpPoly[4][0] = 2.76797758e-7;
-    data.position->arpPoly[5][0] = 8.57355543e-11;
+    std::auto_ptr<ComplexData> data;
+    data->position->arpPoly = six::PolyXYZ(5);
+    data->position->arpPoly[0][0] = 4.45303008e6;
+    data->position->arpPoly[1][0] = 5.75153322e3;
+    data->position->arpPoly[2][0] = -2.7014602e0;
+    data->position->arpPoly[3][0] = -1.2323143e-3;
+    data->position->arpPoly[4][0] = 2.76797758e-7;
+    data->position->arpPoly[5][0] = 8.57355543e-11;
 
-    data.position->arpPoly[0][1] = 1.49876146e6;
-    data.position->arpPoly[1][1] = 4.95848815e1;
-    data.position->arpPoly[2][1] = -1.3299011e0;
-    data.position->arpPoly[3][1] = 1.20353768e-4;
-    data.position->arpPoly[4][1] = 1.79750748e-7;
-    data.position->arpPoly[5][1] = -1.8053533e-11;
+    data->position->arpPoly[0][1] = 1.49876146e6;
+    data->position->arpPoly[1][1] = 4.95848815e1;
+    data->position->arpPoly[2][1] = -1.3299011e0;
+    data->position->arpPoly[3][1] = 1.20353768e-4;
+    data->position->arpPoly[4][1] = 1.79750748e-7;
+    data->position->arpPoly[5][1] = -1.8053533e-11;
 
-    data.grid->timeCOAPoly = six::Poly2D(2, 2);
-    data.grid->timeCOAPoly[0][0] = 1.9789488e0;
-    data.grid->timeCOAPoly[0][1] = 2.6269628e-4;
-    data.grid->timeCOAPoly[0][2] = 6.1316813e-16;
+    data->grid->timeCOAPoly = six::Poly2D(2, 2);
+    data->grid->timeCOAPoly[0][0] = 1.9789488e0;
+    data->grid->timeCOAPoly[0][1] = 2.6269628e-4;
+    data->grid->timeCOAPoly[0][2] = 6.1316813e-16;
 
-    data.grid->timeCOAPoly[1][0] = -8.953947e-9;
-    data.grid->timeCOAPoly[1][1] = -9.8252154e-13;
-    data.grid->timeCOAPoly[1][2] = -9.6216278e-24;
+    data->grid->timeCOAPoly[1][0] = -8.953947e-9;
+    data->grid->timeCOAPoly[1][1] = -9.8252154e-13;
+    data->grid->timeCOAPoly[1][2] = -9.6216278e-24;
 
-    data.grid->timeCOAPoly[0][0] = 3.3500568e-17;
-    data.grid->timeCOAPoly[0][1] = 3.6743435e-21;
-    data.grid->timeCOAPoly[0][2] = -3.95088507e-28;
+    data->grid->timeCOAPoly[0][0] = 3.3500568e-17;
+    data->grid->timeCOAPoly[0][1] = 3.6743435e-21;
+    data->grid->timeCOAPoly[0][2] = -3.95088507e-28;
 
-    data.geoData->scp.llh.setLat(4.785840035e1);
-    data.geoData->scp.llh.setLon(1.213899391e1);
-    data.geoData->scp.llh.setAlt(4.880295281e2);
+    data->geoData->scp.llh.setLat(4.785840035e1);
+    data->geoData->scp.llh.setLon(1.213899391e1);
+    data->geoData->scp.llh.setAlt(4.880295281e2);
 
-    data.geoData->scp.ecf[0] = 4.19186033e6;
-    data.geoData->scp.ecf[1] = 9.01641404e5;
-    data.geoData->scp.ecf[2] = 4.70668874e6;
+    data->geoData->scp.ecf[0] = 4.19186033e6;
+    data->geoData->scp.ecf[1] = 9.01641404e5;
+    data->geoData->scp.ecf[2] = 4.70668874e6;
 
     // Don't have data for this. Just putting something in to prevent
     // a segfault.
     // Later, we can switch on ImageFormation type
-    data.pfa.reset(new six::sicd::PFA());
-    data.pfa->polarAnglePoly = six::Poly1D(1);
-    data.pfa->spatialFrequencyScaleFactorPoly = six::Poly1D(1);
+    data->pfa.reset(new six::sicd::PFA());
+    data->pfa->polarAnglePoly = six::Poly1D(1);
+    data->pfa->spatialFrequencyScaleFactorPoly = six::Poly1D(1);
 
-    data.collectionInformation->radarMode = six::RadarModeType::SPOTLIGHT;
+    data->collectionInformation->radarMode = six::RadarModeType::SPOTLIGHT;
 
-    data.imageData->validData = std::vector<six::RowColInt>(8);
-    data.imageData->validData[0] = six::RowColInt(0, 0);
-    data.imageData->validData[1] = six::RowColInt(0, 6163);
-    data.imageData->validData[2] = six::RowColInt(2760, 6163);
-    data.imageData->validData[3] = six::RowColInt(7902, 6163);
-    data.imageData->validData[4] = six::RowColInt(11623, 6163);
-    data.imageData->validData[5] = six::RowColInt(11790, 6163);
-    data.imageData->validData[6] = six::RowColInt(11790, 0);
-    data.imageData->validData[7] = six::RowColInt(1028, 0);
+    data->imageData->validData = std::vector<six::RowColInt>(8);
+    data->imageData->validData[0] = six::RowColInt(0, 0);
+    data->imageData->validData[1] = six::RowColInt(0, 6163);
+    data->imageData->validData[2] = six::RowColInt(2760, 6163);
+    data->imageData->validData[3] = six::RowColInt(7902, 6163);
+    data->imageData->validData[4] = six::RowColInt(11623, 6163);
+    data->imageData->validData[5] = six::RowColInt(11790, 6163);
+    data->imageData->validData[6] = six::RowColInt(11790, 0);
+    data->imageData->validData[7] = six::RowColInt(1028, 0);
 
     return data;
 }

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -623,5 +623,67 @@ std::string Utilities::toXMLString(const ComplexData& data,
                                    (logger == NULL) ? &nullLogger : logger,
                                    &xmlRegistry);
 }
+
+ComplexData Utilities::createFakeComplexData()
+{
+    ComplexData data;
+    data.position->arpPoly = six::PolyXYZ(5);
+    data.position->arpPoly[0][0] = 4.45303008e6;
+    data.position->arpPoly[1][0] = 5.75153322e3;
+    data.position->arpPoly[2][0] = -2.7014602e0;
+    data.position->arpPoly[3][0] = -1.2323143e-3;
+    data.position->arpPoly[4][0] = 2.76797758e-7;
+    data.position->arpPoly[5][0] = 8.57355543e-11;
+
+    data.position->arpPoly[0][1] = 1.49876146e6;
+    data.position->arpPoly[1][1] = 4.95848815e1;
+    data.position->arpPoly[2][1] = -1.3299011e0;
+    data.position->arpPoly[3][1] = 1.20353768e-4;
+    data.position->arpPoly[4][1] = 1.79750748e-7;
+    data.position->arpPoly[5][1] = -1.8053533e-11;
+
+    data.grid->timeCOAPoly = six::Poly2D(2, 2);
+    data.grid->timeCOAPoly[0][0] = 1.9789488e0;
+    data.grid->timeCOAPoly[0][1] = 2.6269628e-4;
+    data.grid->timeCOAPoly[0][2] = 6.1316813e-16;
+
+    data.grid->timeCOAPoly[1][0] = -8.953947e-9;
+    data.grid->timeCOAPoly[1][1] = -9.8252154e-13;
+    data.grid->timeCOAPoly[1][2] = -9.6216278e-24;
+
+    data.grid->timeCOAPoly[0][0] = 3.3500568e-17;
+    data.grid->timeCOAPoly[0][1] = 3.6743435e-21;
+    data.grid->timeCOAPoly[0][2] = -3.95088507e-28;
+
+    data.geoData->scp.llh.setLat(4.785840035e1);
+    data.geoData->scp.llh.setLon(1.213899391e1);
+    data.geoData->scp.llh.setAlt(4.880295281e2);
+
+    data.geoData->scp.ecf[0] = 4.19186033e6;
+    data.geoData->scp.ecf[1] = 9.01641404e5;
+    data.geoData->scp.ecf[2] = 4.70668874e6;
+
+    // Don't have data for this. Just putting something in to prevent
+    // a segfault.
+    // Later, we can switch on ImageFormation type
+    data.pfa.reset(new six::sicd::PFA());
+    data.pfa->polarAnglePoly = six::Poly1D(1);
+    data.pfa->spatialFrequencyScaleFactorPoly = six::Poly1D(1);
+
+    data.collectionInformation->radarMode = six::RadarModeType::SPOTLIGHT;
+
+    data.imageData->validData = std::vector<six::RowColInt>(8);
+    data.imageData->validData[0] = six::RowColInt(0, 0);
+    data.imageData->validData[1] = six::RowColInt(0, 6163);
+    data.imageData->validData[2] = six::RowColInt(2760, 6163);
+    data.imageData->validData[3] = six::RowColInt(7902, 6163);
+    data.imageData->validData[4] = six::RowColInt(11623, 6163);
+    data.imageData->validData[5] = six::RowColInt(11790, 6163);
+    data.imageData->validData[6] = six::RowColInt(11790, 0);
+    data.imageData->validData[7] = six::RowColInt(1028, 0);
+
+    return data;
 }
 }
+}
+

--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -3228,6 +3228,12 @@ class SixSicdUtilities(_object):
 
     toXMLString = staticmethod(toXMLString)
 
+    def createFakeComplexData():
+        """createFakeComplexData() -> std::auto_ptr< six::sicd::ComplexData >"""
+        return _six_sicd.SixSicdUtilities_createFakeComplexData()
+
+    createFakeComplexData = staticmethod(createFakeComplexData)
+
     def __init__(self):
         """__init__(six::sicd::Utilities self) -> SixSicdUtilities"""
         this = _six_sicd.new_SixSicdUtilities()
@@ -3308,6 +3314,10 @@ def SixSicdUtilities_toXMLString(*args):
     SixSicdUtilities_toXMLString(ComplexData data) -> std::string
     """
     return _six_sicd.SixSicdUtilities_toXMLString(*args)
+
+def SixSicdUtilities_createFakeComplexData():
+    """SixSicdUtilities_createFakeComplexData() -> std::auto_ptr< six::sicd::ComplexData >"""
+    return _six_sicd.SixSicdUtilities_createFakeComplexData()
 
 class StdAutoCollectionInformation(_object):
     """Proxy of C++ std::auto_ptr<(six::sicd::CollectionInformation)> class."""


### PR DESCRIPTION
I've run into several testing situations where I want to check that the right thing is happening with part of a `ComplexData` object, but something else I don't care about isn't initialized and I get errors. This method returns a partially-filled ComplexData so that the only thing I need to fill out in my tests is the part I actually care about, and nothing else will complain. I grabbed data from a sample SICD because some of the things in `scene` can throw if the fields don't make sense with each other.