### PR TITLE
Add overload to getOutputPlaneOffsetAndExtent

### DIFF
--- a/six/modules/c++/six.sicd/include/six/sicd/ComplexData.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ComplexData.h
@@ -323,14 +323,14 @@ public:
 
     /*!
      * Overload that allows caller to pass in their own AreaPlane
+     * \param areaPlane areaPlane to use for data
      * \param offset Output plane offset
      * \param extent Output plane extent
-     * \param areaPlane areaPlane to use for data
      */
     void getOutputPlaneOffsetAndExtent(
+            const AreaPlane& areaPlane,
             types::RowCol<size_t>& offset,
-            types::RowCol<size_t>& extent,
-            const AreaPlane& areaPlane) const;
+            types::RowCol<size_t>& extent) const;
 
     /*
      * Convert the slant plane pixel location into meters from the SCP

--- a/six/modules/c++/six.sicd/include/six/sicd/ComplexData.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ComplexData.h
@@ -314,10 +314,23 @@ public:
      * by radarCollection->area->plane.  If this is a multiple segment SICD,
      * this is determined by the radarCollection->area->plane->segmentList
      * entry that corresponds to the imageFormation->segmentIdentifier.
+     * \param offset Output plane offset
+     * \param extent Output plane extent
      */
     void getOutputPlaneOffsetAndExtent(
             types::RowCol<size_t>& offset,
             types::RowCol<size_t>& extent) const;
+
+    /*!
+     * Overload that allows caller to pass in their own AreaPlane
+     * \param offset Output plane offset
+     * \param extent Output plane extent
+     * \param areaPlane areaPlane to use for data
+     */
+    void getOutputPlaneOffsetAndExtent(
+            types::RowCol<size_t>& offset,
+            types::RowCol<size_t>& extent,
+            const AreaPlane& areaPlane) const;
 
     /*
      * Convert the slant plane pixel location into meters from the SCP

--- a/six/modules/c++/six.sicd/source/ComplexData.cpp
+++ b/six/modules/c++/six.sicd/source/ComplexData.cpp
@@ -56,10 +56,17 @@ void ComplexData::getOutputPlaneOffsetAndExtent(
         types::RowCol<size_t>& offset,
         types::RowCol<size_t>& extent) const
 {
-    offset.row = offset.col = 0;
-
     const six::sicd::AreaPlane& areaPlane =
         *radarCollection->area->plane;
+    getOutputPlaneOffsetAndExtent(offset, extent, areaPlane);
+}
+
+void ComplexData::getOutputPlaneOffsetAndExtent(
+        types::RowCol<size_t>& offset,
+        types::RowCol<size_t>& extent,
+        const AreaPlane& areaPlane) const
+{
+    offset.row = offset.col = 0;
     extent.row = areaPlane.xDirection->elements;
     extent.col = areaPlane.yDirection->elements;
 
@@ -67,27 +74,24 @@ void ComplexData::getOutputPlaneOffsetAndExtent(
     {
         const std::string& segmentID =
                 imageFormation->segmentIdentifier;
-
-        const std::vector<mem::ScopedCloneablePtr<six::sicd::Segment> >&
-                segmentList = radarCollection->area->plane->segmentList;
-
-        for (size_t ii = 0; ii < segmentList.size(); ++ii)
+        try
         {
-            const six::sicd::Segment& segment(*(segmentList[ii]));
-            if (segment.identifier == segmentID)
-            {
-                // TODO: These should be offset by areaPlane.xDirection->first
-                //       and areaPlane.yDirection->first, but the problem is
-                //       that SICD producers are currently doing this
-                //       incorrectly - they're setting the
-                //       FirstLine/FirstSample values to 1 but then setting
-                //       startLine and startSample to 0.
-                offset.row = segment.startLine;
-                offset.col = segment.startSample;
-                extent.row = segment.getNumLines();
-                extent.col = segment.getNumSamples();
-                break;
-            }
+            const six::sicd::Segment& segment = areaPlane.getSegment(segmentID);
+
+            // TODO: These should be offset by areaPlane.xDirection->first
+            //       and areaPlane.yDirection->first, but the problem is
+            //       that SICD producers are currently doing this
+            //       incorrectly - they're setting the
+            //       FirstLine/FirstSample values to 1 but then setting
+            //       startLine and startSample to 0.
+            offset.row = segment.startLine;
+            offset.col = segment.startSample;
+            extent.row = segment.getNumLines();
+            extent.col = segment.getNumSamples();
+        }
+        catch (const except::Exception& /*ex*/)
+        {
+            // Do nothing
         }
     }
 }

--- a/six/modules/c++/six.sicd/source/ComplexData.cpp
+++ b/six/modules/c++/six.sicd/source/ComplexData.cpp
@@ -58,13 +58,13 @@ void ComplexData::getOutputPlaneOffsetAndExtent(
 {
     const six::sicd::AreaPlane& areaPlane =
         *radarCollection->area->plane;
-    getOutputPlaneOffsetAndExtent(offset, extent, areaPlane);
+    getOutputPlaneOffsetAndExtent(areaPlane, offset, extent);
 }
 
 void ComplexData::getOutputPlaneOffsetAndExtent(
+        const AreaPlane& areaPlane,
         types::RowCol<size_t>& offset,
-        types::RowCol<size_t>& extent,
-        const AreaPlane& areaPlane) const
+        types::RowCol<size_t>& extent) const
 {
     offset.row = offset.col = 0;
     extent.row = areaPlane.xDirection->elements;

--- a/six/modules/c++/six.sicd/source/ComplexData.cpp
+++ b/six/modules/c++/six.sicd/source/ComplexData.cpp
@@ -74,7 +74,7 @@ void ComplexData::getOutputPlaneOffsetAndExtent(
     {
         const std::string& segmentID =
                 imageFormation->segmentIdentifier;
-        try
+        if (!segmentID.empty())
         {
             const six::sicd::Segment& segment = areaPlane.getSegment(segmentID);
 
@@ -88,10 +88,6 @@ void ComplexData::getOutputPlaneOffsetAndExtent(
             offset.col = segment.startSample;
             extent.row = segment.getNumLines();
             extent.col = segment.getNumSamples();
-        }
-        catch (const except::Exception& /*ex*/)
-        {
-            // Do nothing
         }
     }
 }

--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -3060,9 +3060,12 @@ class ComplexData(pysix.six_base.Data):
         return _six_sicd.ComplexData_setVersion(self, version)
 
 
-    def getOutputPlaneOffsetAndExtent(self, offset, extent):
-        """getOutputPlaneOffsetAndExtent(ComplexData self, RowColSizeT offset, RowColSizeT extent)"""
-        return _six_sicd.ComplexData_getOutputPlaneOffsetAndExtent(self, offset, extent)
+    def getOutputPlaneOffsetAndExtent(self, *args):
+        """
+        getOutputPlaneOffsetAndExtent(ComplexData self, RowColSizeT offset, RowColSizeT extent)
+        getOutputPlaneOffsetAndExtent(ComplexData self, RowColSizeT offset, RowColSizeT extent, AreaPlane areaPlane)
+        """
+        return _six_sicd.ComplexData_getOutputPlaneOffsetAndExtent(self, *args)
 
 
     def pixelToImagePoint(self, pixelLoc):

--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -3063,7 +3063,7 @@ class ComplexData(pysix.six_base.Data):
     def getOutputPlaneOffsetAndExtent(self, *args):
         """
         getOutputPlaneOffsetAndExtent(ComplexData self, RowColSizeT offset, RowColSizeT extent)
-        getOutputPlaneOffsetAndExtent(ComplexData self, RowColSizeT offset, RowColSizeT extent, AreaPlane areaPlane)
+        getOutputPlaneOffsetAndExtent(ComplexData self, AreaPlane areaPlane, RowColSizeT offset, RowColSizeT extent)
         """
         return _six_sicd.ComplexData_getOutputPlaneOffsetAndExtent(self, *args)
 


### PR DESCRIPTION
There was a hiccough in merging in the derivedOutputPlane stuff. This will make more sense once that PR is in.