### PR TITLE
Handle the case where user requests more rows per block than allowed …

### DIFF
--- a/six/modules/c++/six/source/NITFImageInfo.cpp
+++ b/six/modules/c++/six/source/NITFImageInfo.cpp
@@ -120,8 +120,8 @@ NITFImageInfo::NITFImageInfo(Data* data,
 
     if (mNumRowsLimit < mNumRowsPerBlock)
     {
-        std::cout << "Requested rows per block incompatible with requested "
-                "max rows per segment. Reducting rows per block to fit.\n";
+        std::cerr << "Requested rows per block incompatible with requested "
+                "max rows per segment. Reducing rows per block to fit.\n";
         mNumRowsPerBlock = mNumRowsLimit;
     }
 
@@ -169,8 +169,8 @@ void NITFImageInfo::computeImageInfo()
 
     if (maxRows < mNumRowsPerBlock)
     {
-        std::cout << "Requested rows per block incompatible with requested "
-                "max product size. Reducting rows per block to fit.\n";
+        std::cerr << "Requested rows per block incompatible with requested "
+                "max product size. Reducing rows per block to fit.\n";
         mNumRowsPerBlock = maxRows;
     }
 

--- a/six/modules/c++/six/source/NITFWriteControl.cpp
+++ b/six/modules/c++/six/source/NITFWriteControl.cpp
@@ -105,9 +105,9 @@ void NITFWriteControl::initialize(mem::SharedPtr<Container> container)
     mInfos.clear();
     mContainer = container;
 
-    sys::Uint32_T ilocMax = Constants::ILOC_MAX;
-    sys::Uint32_T maxRows = mOptions.getParameter(OPT_MAX_ILOC_ROWS,
-                                                  Parameter(ilocMax));
+    const sys::Uint32_T ilocMax = Constants::ILOC_MAX;
+    const sys::Uint32_T maxRows = mOptions.getParameter(OPT_MAX_ILOC_ROWS,
+                                                        Parameter(ilocMax));
 
     sys::Uint64_T maxSize =
             (sys::Uint64_T) mOptions.getParameter(


### PR DESCRIPTION
…in a segment

(It feels odd for the `NITFImageInfo` ctor to take both `maxRows` and `maxSize` parameters. Doesn't one determine the other?) 