### PR TITLE
Add edge blocking / segmentation check for when single block doesn't fit

### DIFF
--- a/six/modules/c++/samples/test_create_sidd_legend.cpp
+++ b/six/modules/c++/samples/test_create_sidd_legend.cpp
@@ -221,7 +221,7 @@ int main(int argc, char** argv)
                     six::NITFWriteControl::OPT_MAX_PRODUCT_SIZE,
                     str::toString(maxSize));
 
-            const std::string blockSize("1024");
+            const std::string blockSize("23");
             writer.getOptions().setParameter(
                     six::NITFWriteControl::OPT_NUM_ROWS_PER_BLOCK,
                     blockSize);


### PR DESCRIPTION
When this occurs, we should throw... this also exposed an issue where test_create_sidd_legend wasn't actually blocking like it thought it was...

FYI @JonathanMeans 