### PR TITLE
Osx macports gcc5

### DIFF
--- a/externals/coda-oss/build/build.py
+++ b/externals/coda-oss/build/build.py
@@ -801,6 +801,7 @@ def configureCompilerOptions(self):
     linuxRegex = r'.*-.*-linux-.*|i686-pc-.*|linux'
     solarisRegex = r'sparc-sun.*|i.86-pc-solaris.*|sunos'
     winRegex = r'win32'
+    osxRegex = r'darwin'
 
     cxxCompiler = self.env['COMPILER_CXX']
     ccCompiler = self.env['COMPILER_CC']
@@ -848,7 +849,8 @@ def configureCompilerOptions(self):
     elif ccCompiler == 'gcc' or ccCompiler == 'icc':
         if not re.match(winRegex, sys_platform):
             self.env.append_value('LIB_DL', 'dl')
-            self.env.append_value('LIB_NSL', 'nsl')
+            if not re.match(osxRegex, sys_platform):
+                self.env.append_value('LIB_NSL', 'nsl')
         self.env.append_value('LIB_MATH', 'm')
         self.env.append_value('LINKFLAGS_THREAD', '-pthread')
         self.check_cc(lib='pthread', mandatory=True)
@@ -897,7 +899,8 @@ def configureCompilerOptions(self):
             #       Is there an equivalent to get the same functionality or
             #       is this an OS limitation?
             linkFlags = '-fPIC'
-            if not re.match(solarisRegex, sys_platform):
+            
+            if (not re.match(osxRegex, sys_platform)) and (not re.match(solarisRegex, sys_platform)):
                 linkFlags += ' -Wl,-E'
 
             self.env.append_value('LINKFLAGS', linkFlags.split())
@@ -1311,6 +1314,7 @@ def process_swig_linkage(tsk):
 
     solarisRegex = r'sparc-sun.*|i.86-pc-solaris.*|sunos'
     darwinRegex = r'i.86-apple-.*'
+    osxRegex = r'darwin'
 
     platform = getPlatform(default=Options.platform)
     compiler = tsk.env['COMPILER_CXX']
@@ -1338,7 +1342,7 @@ def process_swig_linkage(tsk):
         rpath_pattern = '-Rpath%s'
 
     # overrides for osx
-    if re.match(darwinRegex,platform):
+    if re.match(darwinRegex,platform) or re.match(osxRegex,platform):
         while '-bundle' in tsk.env.LINKFLAGS:
             tsk.env.LINKFLAGS.remove('-bundle')
         tsk.env.LINKFLAGS.append('-dynamiclib')

--- a/six/modules/c++/six.sicd/source/SICDWriteControl.cpp
+++ b/six/modules/c++/six.sicd/source/SICDWriteControl.cpp
@@ -103,10 +103,10 @@ void SICDWriteControl::writeHeaders()
         //       SIDD as you will have some pad
         // TODO: Would be nice if ImageSubheader had a method to compute this
         //       for you
-        const size_t numRows(subheader.getNumRows());
-        const size_t numCols(subheader.getNumCols());
-        numBands = subheader.getNumImageBands();
-        const size_t numBitsPerPixel(subheader.getNumBitsPerPixel());
+        const size_t numRows(static_cast<nitf::Uint64>(subheader.getNumRows()));
+        const size_t numCols(static_cast<nitf::Uint64>(subheader.getNumCols()));
+        numBands = static_cast<nitf::Uint64>(subheader.getNumImageBands());
+        const size_t numBitsPerPixel(static_cast<nitf::Uint64>(subheader.getNumBitsPerPixel()));
         numBytesPerPixel = NITF_NBPP_TO_BYTES(numBitsPerPixel);
         const size_t numBytes = numRows * numCols * numBands * numBytesPerPixel;
         imageDataLens[ii] = numBytes;

--- a/six/modules/c++/six/source/NITFWriteControl.cpp
+++ b/six/modules/c++/six/source/NITFWriteControl.cpp
@@ -452,7 +452,7 @@ void NITFWriteControl::setBlocking(const std::string& imode,
             throw except::Exception(Ctxt("SICDs do not support blocking"));
         }
 
-        const size_t optNumRowsPerBlock = static_cast<size_t>(
+        const size_t optNumRowsPerBlock = static_cast<nitf::Uint64>(
                 mOptions.getParameter(OPT_NUM_ROWS_PER_BLOCK));
 
         numRowsPerBlock = static_cast<sys::Uint32_T>(
@@ -473,7 +473,7 @@ void NITFWriteControl::setBlocking(const std::string& imode,
             throw except::Exception(Ctxt("SICDs do not support blocking"));
         }
 
-        const size_t optNumColsPerBlock = static_cast<size_t>(
+        const size_t optNumColsPerBlock = static_cast<nitf::Uint64>(
                 mOptions.getParameter(OPT_NUM_COLS_PER_BLOCK));
 
         numColsPerBlock = static_cast<sys::Uint32_T>(
@@ -729,9 +729,9 @@ void NITFWriteControl::save(const SourceList& imageData,
                             const std::string& outputFile,
                             const std::vector<std::string>& schemaPaths)
 {
-    const size_t bufferSize =
+    const size_t bufferSize = static_cast<nitf::Uint64>(
             mOptions.getParameter(OPT_BUFFER_SIZE,
-                                  Parameter(DEFAULT_BUFFER_SIZE));
+                                  Parameter(DEFAULT_BUFFER_SIZE)));
 
     nitf::BufferedWriter bufferedIO(outputFile, bufferSize);
 
@@ -816,9 +816,9 @@ void NITFWriteControl::save(const BufferList& imageData,
                             const std::string& outputFile,
                             const std::vector<std::string>& schemaPaths)
 {
-    const size_t bufferSize =
+    const size_t bufferSize = static_cast<nitf::Uint64>(
             mOptions.getParameter(OPT_BUFFER_SIZE,
-                                  Parameter(DEFAULT_BUFFER_SIZE));
+                                  Parameter(DEFAULT_BUFFER_SIZE)));
     nitf::BufferedWriter bufferedIO(outputFile, bufferSize);
 
     save(imageData, bufferedIO, schemaPaths);


### PR DESCRIPTION
This pull request addressed two issues. Tested on OS-X 10.11.4 with gcc5 from macports. All the other libraries like pcre, xerces, fftw3 are from macports.

The line used for configuration:
```bash
PYTHON=/opt/local/bin/python3 PYTHON_CONFIG=/opt/local/bin/python3.5-config python3 waf configure --prefix=/Users/agram/packages/MDA/install --with-cxxflags="-I /opt/local/include" --with-cflags="-I /opt/local/include" --with-linkflags="-L/opt/local/lib" --disable-swig
```

csm still breaks on OS-X and explicit changes are needed to VTS to get this to work.

1) Changes to build/build.py need to build six:
   - sys_platform returns "darwin"
   - libnsl is not needed for darwin
   - -Wl,-E option for ld is not supported on darwin

2) Fixes a bunch of ambiguous casts to size_t in "six.sicd/source/SICDWriteControl.cpp" and "six/source/NITFWriteControl.cpp" for size_t. Use nitf::Uint64 instead.