### PR TITLE
Allow '1' as a valid FFT sign since it will pass schema validation

### DIFF
--- a/six/modules/c++/six/source/Utilities.cpp
+++ b/six/modules/c++/six/source/Utilities.cpp
@@ -879,13 +879,25 @@ template<> FFTSign six::toType<FFTSign>(const std::string& s)
     std::string type(s);
     str::trim(type);
     if (type == "-1")
+    {
         return FFTSign::NEG;
-    else if (type == "+1")
+    }
+    else if (type == "+1" || type == "1")
+    {
+        // NOTE: The SICD Volume 1 spec says only "+1" and "-1" are allowed,
+        //       and while the schema uses those same strings, it sets the
+        //       type to xs:int so that "1" will pass schema validation.  Some
+        //       producers do use "1" so for simplicity just support it here.
         return FFTSign::POS;
+    }
     else if (type == "0")
+    {
         return FFTSign::NOT_SET;
+    }
     else
+    {
         throw except::Exception(Ctxt("Unsupported fft sign '" + s + "'"));
+    }
 }
 
 template<> std::string six::toString(const FFTSign& value)

--- a/six/modules/c++/six/unittests/test_fft_sign_conversions.cpp
+++ b/six/modules/c++/six/unittests/test_fft_sign_conversions.cpp
@@ -1,0 +1,19 @@
+#include "TestCase.h"
+
+#include <six/Utilities.h>
+
+namespace
+{
+TEST_CASE(testToType)
+{
+    TEST_ASSERT_EQ(six::toType<six::FFTSign>("+1"), six::FFTSign::POS);
+    TEST_ASSERT_EQ(six::toType<six::FFTSign>("1"), six::FFTSign::POS);
+    TEST_ASSERT_EQ(six::toType<six::FFTSign>("-1"), six::FFTSign::NEG);
+}
+}
+
+int main(int , char** )
+{
+    TEST_CHECK(testToType);
+    return 0;
+}


### PR DESCRIPTION
See notes in the code... the spec seems to intend only "+1" but "1" will pass schema validation and some producers populate this way, so it's easy enough for us to add another conditional and handle it.

FYI @JonathanMeans 