### PR TITLE
Add SICD byte provider

### DIFF
--- a/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
@@ -1,0 +1,125 @@
+/* =========================================================================
+ * This file is part of six.sicd-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * six.sicd-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __SIX_SICD_BYTE_PROVIDER_H__
+#define __SIX_SICD_BYTE_PROVIDER_H__
+
+#include <vector>
+
+#include <six/sicd/ComplexData.h>
+
+namespace six
+{
+namespace sicd
+{
+/*!
+ * \class SICDByteProvider
+ * \brief Used to provide corresponding raw NITF bytes (including NITF headers)
+ * when provided with some AOI of the pixel data.  The idea is that if
+ * getBytes() is called multiple times, eventually for the entire image, the
+ * raw bytes provided back will be the entire NITF file.  This abstraction is
+ * useful if separate threads, processes, or even machines have only portions of
+ * the SICD pixel data and are all trying to write out a single file; in that
+ * scenario, this class provides a contiguous chunk of memory corresponding to
+ * the caller's AOI, including NITF headers if necessary.  The caller does not
+ * need to understand anything about the NITF file layout in order to write out
+ * the file.
+ */
+class SICDByteProvider
+{
+public:
+    /*!
+     * Constructor
+     *
+     * \param data Representation of the complex data
+     * \param schemPaths Directories or files of schema locations
+     */
+    SICDByteProvider(const ComplexData& data,
+                     const std::vector<std::string>& schemaPaths);
+
+    /*!
+     * \return The total number of bytes in the NITF
+     */
+    nitf::Off getFileNumBytes() const
+    {
+        return mFileNumBytes;
+    }
+
+    /*!
+     * The caller provides an AOI of the pixel data.  This method provides back
+     * a contiguous buffer corresponding to the raw NITF bytes for this portion
+     * of the file.  If this AOI is in the middle of an image segment, the
+     * input pointer is simply returned (no copy occurs).  Otherwise, various
+     * headers (file header, image subheader(s), DES subheader and data) will
+     * be copied before, in the middle, and/or after the image data in the
+     * returned pointer.  If this method is called multiple times with AOIs that
+     * eventually consist of the entire image, and the raw bytes are written
+     * out to disk in order with respect to the start pixel rows this method is
+     * called with, it will form a valid NITF.
+     *
+     * \note This method does not perform byte swapping on the pixel data for
+     * efficiency reasons, but NITFs are written out in big endian order.  This
+     * means that on a little endian system, you must byte swap the pixel data
+     * prior to calling this method.
+     *
+     * \note This method is not thread-safe (due to reusing an internal buffer
+     * to avoid repeated memory allocations).  However, this method can be
+     * called any number of times in any order with respect to the start row.
+     *
+     * \param imageData The image data pixels to write.  The underlying type
+     * will be complex short or complex float based on the complex data sent
+     * in during initialize.  Must be in big endian order.
+     * \param startRow The global start row in pixels as to where these pixels
+     * are in the image.  If this is a multi-segment NITF, this is still simply
+     * the global pixel location.
+     * \param numRows The number of rows in the provided 'imageData'
+     * \param[out] numBytes The number of bytes associated with the returned
+     * pointer (this may be more than the size of the imagery as NITF headers
+     * may be added)
+     *
+     * \return A pointer to a contiguous memory location which will include
+     * the pixel data and, if required, one or more NITF headers.  This pointer
+     * is only guaranteed to remain valid until the next call to getBytes() and
+     * must also not be used once this class goes out of scope.
+     */
+    const void* getBytes(const void* imageData,
+                         size_t startRow,
+                         size_t numRows,
+                         size_t& numBytes) const;
+
+private:
+    const size_t mNumBytesPerRow;
+
+    std::vector<sys::byte> mFileHeader;
+    std::vector<std::vector<sys::byte> > mImageSubheaders;
+    std::vector<sys::byte> mDesSubheaderAndData;
+    std::vector<nitf::Off> mImageSubheaderFileOffsets;
+    std::vector<NITFSegmentInfo> mImageSegmentInfo;
+    nitf::Off mDesSubheaderFileOffset;
+    nitf::Off mFileNumBytes;
+
+    mutable std::vector<sys::byte> mBuffer;
+};
+}
+}
+
+#endif

--- a/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
@@ -129,6 +129,44 @@ public:
             pushBack(data.empty() ? NULL : &data[0],
                      data.size() * sizeof(DataT));
         }
+
+        /*!
+         * Get the number of blocks of data of size 'blockSize'.  In cases
+         * where the block size is not an even multiple of the total number of
+         * bytes, the last block will be larger than the block size (rather
+         * than there being one more block which is smaller than the block
+         * size).  This is intentional in order to make this easily usable with
+         * Amazon's S3 storage with multipart uploads where there is a minimum
+         * part size (there may be multiple machines, all with their portion
+         * of the SICD, performing a multipart upload of their parts, and
+         * only the last overall part of the object can be less than the
+         * minimum part size).
+         *
+         * \param blockSize The desired block size
+         *
+         * \return The associated number of blocks
+         */
+        size_t getNumBlocks(size_t blockSize) const;
+
+        /*!
+         * Returns a pointer to contiguous memory associated with the desired
+         * block.  If this block lies entirely within a NITFBuffer, no copy
+         * is performed.  Otherwise, the scratch buffer is resized, the bytes
+         * are copied into this, and a pointer to the scratch buffer is
+         * returned.
+         *
+         * \param blockSize The desired block size.  See getNumBlocks() for a
+         * description on the behavior of the last block.
+         * \param blockIdx The 0-based block index
+         * \param[out] scratch Scratch buffer.  This will be resized and used
+         * if the underlying memory for this block is not contiguous (i.e. it
+         * spans NITFBuffers).
+         *
+         * \return A pointer to contiguous memory associated with this block
+         */
+        const void* getBlock(size_t blockSize,
+                             size_t blockIdx,
+                             std::vector<sys::byte>& scratch) const;
     };
 
     /*!

--- a/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
@@ -149,6 +149,18 @@ public:
         size_t getNumBlocks(size_t blockSize) const;
 
         /*!
+         * Get the number of bytes in the specified block.  All blocks will be
+         * the same size except for the last block (see getNumBlocks() for
+         * details).
+         *
+         * \param blockSize The desired block size
+         * \param blockIdx The 0-based block index
+         *
+         * \return The number of bytes in this block
+         */
+        size_t getNumBytesInBlock(size_t blockSize, size_t blockIdx) const;
+
+        /*!
          * Returns a pointer to contiguous memory associated with the desired
          * block.  If this block lies entirely within a NITFBuffer, no copy
          * is performed.  Otherwise, the scratch buffer is resized, the bytes
@@ -161,12 +173,14 @@ public:
          * \param[out] scratch Scratch buffer.  This will be resized and used
          * if the underlying memory for this block is not contiguous (i.e. it
          * spans NITFBuffers).
+         * \param[out] numBytes The number of bytes in this block
          *
          * \return A pointer to contiguous memory associated with this block
          */
         const void* getBlock(size_t blockSize,
                              size_t blockIdx,
-                             std::vector<sys::byte>& scratch) const;
+                             std::vector<sys::byte>& scratch,
+                             size_t& numBytes) const;
     };
 
     /*!

--- a/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
@@ -50,15 +50,15 @@ class SICDByteProvider
 {
 public:
     /*!
-     * \class Buffer
-     * \brief Represents a pointer to raw bytes and its length
+     * \class NITFBuffer
+     * \brief Represents a pointer to raw NITF bytes and its length
      */
-    struct Buffer
+    struct NITFBuffer
     {
         /*!
          * Initializes to an empty buffer
          */
-        Buffer();
+        NITFBuffer();
 
         /*!
          * Initializes to the specified pointer and size.  No copy is made and
@@ -68,21 +68,21 @@ public:
          * \param numBytes The number of bytes of contiguous data this
          * represents
          */
-        Buffer(const void* data, size_t numBytes);
+        NITFBuffer(const void* data, size_t numBytes);
 
         const void* mData;
         size_t mNumBytes;
     };
 
     /*!
-     * \class BufferList
+     * \class NITFBufferList
      * \brief Represents a sequence of buffers which appear in contiguous order
      * in the NITF (the underlying pointers are not contiguous)
      */
-    struct BufferList
+    struct NITFBufferList
     {
         //! The buffers
-        std::vector<Buffer> mBuffers;
+        std::vector<NITFBuffer> mBuffers;
 
         /*!
          * \return The total number of bytes across all the buffers
@@ -113,7 +113,7 @@ public:
          */
         void pushBack(const void* data, size_t numBytes)
         {
-            mBuffers.push_back(Buffer(data, numBytes));
+            mBuffers.push_back(NITFBuffer(data, numBytes));
         }
 
         /*!
@@ -208,7 +208,7 @@ public:
                   size_t startRow,
                   size_t numRows,
                   nitf::Off& fileOffset,
-                  BufferList& buffers) const;
+                  NITFBufferList& buffers) const;
 
 private:
     const size_t mNumBytesPerRow;

--- a/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
@@ -152,6 +152,22 @@ public:
     }
 
     /*!
+     * Given a range of rows from [startRow, startRow + numRows), provide the
+     * number of bytes that will appear in the NITF on disk (including NITF
+     * file header, image subheader(s), and DES subheader and data).  Calling
+     * this method repeatedly, eventually providing the entire range of the
+     * image, will produce the total number of bytes in the full NITF.
+     *
+     * \param startRow The global start row in pixels as to where these pixels
+     * are in the image.  If this is a multi-segment NITF, this is still simply
+     * the global pixel location.
+     * \param numRows The number of rows
+     *
+     * \return The associated number of bytes in the NITF
+     */
+    nitf::Off getNumBytes(size_t startRow, size_t numRows) const;
+
+    /*!
      * The caller provides an AOI of the pixel data.  This method provides back
      * a list of contiguous buffers corresponding to the raw NITF bytes for
      * this portion of the file.  If this AOI is in the middle of an image

--- a/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
@@ -52,9 +52,12 @@ public:
      *
      * \param data Representation of the complex data
      * \param schemPaths Directories or files of schema locations
+     * \param maxProductSize The max number of bytes in an image segment.
+     * By default this is set automatically for you based on NITF file rules.
      */
     SICDByteProvider(const ComplexData& data,
-                     const std::vector<std::string>& schemaPaths);
+                     const std::vector<std::string>& schemaPaths,
+                     size_t maxProductSize = 0);
 
     /*!
      * \return The total number of bytes in the NITF

--- a/six/modules/c++/six.sicd/include/six/sicd/SICDWriteControl.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDWriteControl.h
@@ -115,6 +115,7 @@ private:
     const std::vector<std::string> mSchemaPaths;
 
     std::vector<nitf::Off> mImageDataStart;
+    std::vector<NITFSegmentInfo> mImageSegmentInfo;
     bool mHaveWrittenHeaders;
 };
 }

--- a/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
+++ b/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
@@ -11,7 +11,8 @@ namespace sicd
 {
 SICDByteProvider::SICDByteProvider(
         const ComplexData& data,
-        const std::vector<std::string>& schemaPaths) :
+        const std::vector<std::string>& schemaPaths,
+        size_t maxProductSize) :
     mNumBytesPerRow(data.getNumCols() * data.getNumBytesPerPixel())
 {
     XMLControlRegistry xmlRegistry;
@@ -28,6 +29,14 @@ SICDByteProvider::SICDByteProvider(
 
     NITFWriteControl writer;
     writer.setXMLControlRegistry(&xmlRegistry);
+
+    if (maxProductSize != 0)
+    {
+        writer.getOptions().setParameter(
+                six::NITFWriteControl::OPT_MAX_PRODUCT_SIZE,
+                maxProductSize);
+    }
+
     writer.initialize(container);
 
     // Now we can get the file headers and offsets we want

--- a/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
+++ b/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
@@ -9,19 +9,19 @@ namespace six
 {
 namespace sicd
 {
-SICDByteProvider::Buffer::Buffer() :
+SICDByteProvider::NITFBuffer::NITFBuffer() :
     mData(NULL),
     mNumBytes(0)
 {
 }
 
-SICDByteProvider::Buffer::Buffer(const void* data, size_t numBytes) :
+SICDByteProvider::NITFBuffer::NITFBuffer(const void* data, size_t numBytes) :
     mData(data),
     mNumBytes(numBytes)
 {
 }
 
-size_t SICDByteProvider::BufferList::getTotalNumBytes() const
+size_t SICDByteProvider::NITFBufferList::getTotalNumBytes() const
 {
     size_t numBytes(0);
 
@@ -126,7 +126,7 @@ void SICDByteProvider::getBytes(const void* imageData,
                                 size_t startRow,
                                 size_t numRows,
                                 nitf::Off& fileOffset,
-                                BufferList& buffers) const
+                                NITFBufferList& buffers) const
 {
     fileOffset = std::numeric_limits<nitf::Off>::max();
     buffers.clear();

--- a/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
+++ b/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
@@ -1,0 +1,128 @@
+#include <utility>
+
+#include <six/NITFWriteControl.h>
+#include <six/XMLControlFactory.h>
+#include <six/sicd/ComplexXMLControl.h>
+#include <six/sicd/SICDByteProvider.h>
+
+namespace six
+{
+namespace sicd
+{
+SICDByteProvider::SICDByteProvider(
+        const ComplexData& data,
+        const std::vector<std::string>& schemaPaths) :
+    mNumBytesPerRow(data.getNumCols() * data.getNumBytesPerPixel())
+{
+    XMLControlRegistry xmlRegistry;
+    xmlRegistry.addCreator(six::DataType::COMPLEX,
+                           new six::XMLControlCreatorT<
+                                   six::sicd::ComplexXMLControl>());
+
+    mem::SharedPtr<Container> container(new Container(
+            DataType::COMPLEX));
+
+    // The container wants to take ownership of the data
+    // To avoid memory problems, we'll just clone it
+    container->addData(data.clone());
+
+    NITFWriteControl writer;
+    writer.setXMLControlRegistry(&xmlRegistry);
+    writer.initialize(container);
+
+    // Now we can get the file headers and offsets we want
+    writer.getFileLayout(schemaPaths,
+                         mFileHeader,
+                         mImageSubheaders,
+                         mDesSubheaderAndData,
+                         mImageSubheaderFileOffsets,
+                         mImageSegmentInfo,
+                         mDesSubheaderFileOffset,
+                         mFileNumBytes);
+}
+
+const void* SICDByteProvider::getBytes(const void* imageData,
+                                       size_t startRow,
+                                       size_t numRows,
+                                       size_t& numBytes) const
+{
+    std::vector<std::pair<const sys::byte*, size_t> > data;
+
+    const size_t imageDataEndRow = startRow + numRows;
+
+    for (size_t seg = 0; seg < mImageSegmentInfo.size(); ++seg)
+    {
+        // See if we're in this segment
+        const size_t segStartRow = mImageSegmentInfo[seg].firstRow;
+        const size_t segEndRow = mImageSegmentInfo[seg].endRow();
+
+        const size_t startGlobalRowToWrite = std::max(segStartRow, startRow);
+        const size_t endGlobalRowToWrite = std::min(segEndRow, imageDataEndRow);
+
+        if (endGlobalRowToWrite > startGlobalRowToWrite)
+        {
+            const size_t numRowsToWrite =
+                    endGlobalRowToWrite - startGlobalRowToWrite;
+
+            if (startRow <= segStartRow)
+            {
+                // We have the first row of this image segment, so we're
+                // responsible for the image subheader
+                if (seg == 0)
+                {
+                    // For the very first image segment, we're responsible for
+                    // the file header too
+                    data.push_back(std::make_pair(&mFileHeader[0],
+                                                  mFileHeader.size()));
+                }
+
+                data.push_back(std::make_pair(&mImageSubheaders[seg][0],
+                                              mImageSubheaders[seg].size()));
+            }
+
+            // Figure out what offset of 'imageData' we're writing from
+            const size_t startLocalRowToWrite =
+                    startGlobalRowToWrite - startRow;
+            const sys::byte* imageDataPtr =
+                    static_cast<const sys::byte*>(imageData) +
+                    startLocalRowToWrite * mNumBytesPerRow;
+
+            data.push_back(std::make_pair(imageDataPtr,
+                                          numRowsToWrite * mNumBytesPerRow));
+
+            if (seg == mImageSegmentInfo.size() - 1 &&
+                segEndRow == imageDataEndRow)
+            {
+                // When we write out the last row of the last image segment, we
+                // tack on the DES
+                data.push_back(std::make_pair(&mDesSubheaderAndData[0],
+                                              mDesSubheaderAndData.size()));
+            }
+        }
+    }
+
+    if (data.size() == 1)
+    {
+        // We must not have any headers - we can simply return the input
+        // pointer
+        numBytes = numRows * mNumBytesPerRow;
+        return imageData;
+    }
+    else
+    {
+        // Need to copy these to the internal buffer
+        mBuffer.clear();
+
+        for (size_t ii = 0; ii < data.size(); ++ii)
+        {
+            mBuffer.insert(mBuffer.end(),
+                           data[ii].first,
+                           data[ii].first + data[ii].second);
+        }
+
+        numBytes = mBuffer.size();
+        return &mBuffer[0];
+    }
+}
+}
+}

--- a/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
+++ b/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
@@ -44,10 +44,9 @@ size_t SICDByteProvider::NITFBufferList::getNumBlocks(size_t blockSize) const
     return getTotalNumBytes() / blockSize;
 }
 
-const void* SICDByteProvider::NITFBufferList::getBlock(
+size_t SICDByteProvider::NITFBufferList::getNumBytesInBlock(
         size_t blockSize,
-        size_t blockIdx,
-        std::vector<sys::byte>& scratch) const
+        size_t blockIdx) const
 {
     const size_t numBlocks(getNumBlocks(blockSize));
     if (blockIdx >= numBlocks)
@@ -58,10 +57,21 @@ const void* SICDByteProvider::NITFBufferList::getBlock(
         throw except::Exception(Ctxt(ostr.str()));
     }
 
-    const size_t startByte = blockIdx * blockSize;
     const size_t numBytes = (blockIdx == numBlocks - 1) ?
             getTotalNumBytes() - (numBlocks - 1) * blockSize :
             blockSize;
+
+    return numBytes;
+}
+
+const void* SICDByteProvider::NITFBufferList::getBlock(
+        size_t blockSize,
+        size_t blockIdx,
+        std::vector<sys::byte>& scratch,
+        size_t& numBytes) const
+{
+    const size_t startByte = blockIdx * blockSize;
+    numBytes = getNumBytesInBlock(blockSize, blockIdx);
 
     size_t byteCount(0);
     for (size_t ii = 0; ii < mBuffers.size(); ++ii)

--- a/six/modules/c++/six.sicd/source/SICDWriteControl.cpp
+++ b/six/modules/c++/six.sicd/source/SICDWriteControl.cpp
@@ -122,7 +122,6 @@ void SICDWriteControl::save(void* imageData,
     }
 
     const size_t globalNumCols = data->getNumCols();
-    const size_t imageDataEndRow = offset.row + dims.row;
 
     for (size_t seg = 0; seg < mImageSegmentInfo.size(); ++seg)
     {

--- a/six/modules/c++/six.sicd/source/SICDWriteControl.cpp
+++ b/six/modules/c++/six.sicd/source/SICDWriteControl.cpp
@@ -68,6 +68,7 @@ void SICDWriteControl::writeHeaders()
                   imageSubheaders,
                   desSubheaderAndData,
                   imageSubheaderFileOffsets,
+                  mImageSegmentInfo,
                   desSubheaderFileOffset,
                   fileNumBytes);
 
@@ -120,17 +121,14 @@ void SICDWriteControl::save(void* imageData,
                       numPixelsTotal);
     }
 
-    const std::vector <NITFSegmentInfo> imageSegments
-                    = mInfos[0]->getImageSegments();
-
     const size_t globalNumCols = data->getNumCols();
     const size_t imageDataEndRow = offset.row + dims.row;
 
-    for (size_t seg = 0; seg < imageSegments.size(); ++seg)
+    for (size_t seg = 0; seg < mImageSegmentInfo.size(); ++seg)
     {
         // See if we're in this segment
-        const size_t segStartRow = imageSegments[seg].firstRow;
-        const size_t segEndRow = segStartRow + imageSegments[seg].numRows;
+        const size_t segStartRow = mImageSegmentInfo[seg].firstRow;
+        const size_t segEndRow = mImageSegmentInfo[seg].endRow();
 
         const size_t startGlobalRowToWrite = std::max(segStartRow, offset.row);
         const size_t endGlobalRowToWrite = std::min(segEndRow, imageDataEndRow);

--- a/six/modules/c++/six.sicd/source/SICDWriteControl.cpp
+++ b/six/modules/c++/six.sicd/source/SICDWriteControl.cpp
@@ -127,17 +127,13 @@ void SICDWriteControl::save(void* imageData,
     for (size_t seg = 0; seg < mImageSegmentInfo.size(); ++seg)
     {
         // See if we're in this segment
-        const size_t segStartRow = mImageSegmentInfo[seg].firstRow;
-        const size_t segEndRow = mImageSegmentInfo[seg].endRow();
-
-        const size_t startGlobalRowToWrite = std::max(segStartRow, offset.row);
-        const size_t endGlobalRowToWrite = std::min(segEndRow, imageDataEndRow);
-
-        if (endGlobalRowToWrite > startGlobalRowToWrite)
+        const NITFSegmentInfo& imageSegmentInfo(mImageSegmentInfo[seg]);
+        size_t startGlobalRowToWrite;
+        size_t numRowsToWrite;
+        if (imageSegmentInfo.isInRange(offset.row, dims.row,
+                                       startGlobalRowToWrite,
+                                       numRowsToWrite))
         {
-            const size_t numRowsToWrite =
-                    endGlobalRowToWrite - startGlobalRowToWrite;
-
             // Figure out what offset of 'imageData' we're writing from
             const size_t startLocalRowToWrite =
                     startGlobalRowToWrite - offset.row;
@@ -147,6 +143,7 @@ void SICDWriteControl::save(void* imageData,
                     startLocalRowToWrite * numBytesPerRow;
 
             // Now figure out our offset into the segment
+            const size_t segStartRow = imageSegmentInfo.firstRow;
             const size_t startRowInSegToWrite =
                     startGlobalRowToWrite - segStartRow;
             const size_t pixelOffset =

--- a/six/modules/c++/six.sicd/tests/TestUtilities.h
+++ b/six/modules/c++/six.sicd/tests/TestUtilities.h
@@ -1,0 +1,172 @@
+/* =========================================================================
+ * This file is part of six.sicd-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * six.sicd-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __SIX_SICD_TEST_UTILITIES_H__
+#define __SIX_SICD_TEST_UTILITIES_H__
+
+#include <iostream>
+#include <vector>
+
+#include <sys/OS.h>
+#include <io/FileInputStream.h>
+#include <six/sicd/Utilities.h>
+
+// Template specialization to get appropriate pixel type
+template <typename DataTypeT>
+struct GetPixelType
+{
+};
+
+template <>
+struct GetPixelType<float>
+{
+    static six::PixelType getPixelType()
+    {
+        return six::PixelType::RE32F_IM32F;
+    }
+};
+
+template <>
+struct GetPixelType<sys::Int16_T>
+{
+    static six::PixelType getPixelType()
+    {
+        return six::PixelType::RE16I_IM16I;
+    }
+};
+
+// Create dummy SICD data
+template <typename DataTypeT>
+std::auto_ptr<six::sicd::ComplexData>
+createData(const types::RowCol<size_t>& dims)
+{
+    std::auto_ptr<six::sicd::ComplexData> data =
+            six::sicd::Utilities::createFakeComplexData();
+    data->setNumRows(dims.row);
+    data->setNumCols(dims.col);
+    data->setPixelType(GetPixelType<DataTypeT>::getPixelType());
+    return data;
+}
+
+// Read in the entire contents of a file into 'contents'
+inline
+void readFile(const std::string& pathname,
+              std::vector<sys::byte>& contents)
+{
+    io::FileInputStream inStream(pathname);
+
+    contents.resize(inStream.available());
+
+    const size_t numRead = inStream.read(&contents[0], contents.size());
+    if (numRead != contents.size())
+    {
+        throw except::Exception(Ctxt("Short read"));
+    }
+}
+
+// Note that this will work because SIX is forcing the NITF date/time to match
+// what's in the SICD XML and we're writing the same SICD XML in all our files
+class CompareFiles
+{
+public:
+    CompareFiles(const std::string& lhsPathname)
+    {
+        readFile(lhsPathname, mLHS);
+    }
+
+    bool operator()(const std::string& prefix,
+                    const std::string& rhsPathname) const
+    {
+        readFile(rhsPathname, mRHS);
+
+        if (mLHS == mRHS)
+        {
+            std::cout << prefix << " matches" << std::endl;
+            return true;
+        }
+        else if (mLHS.size() != mRHS.size())
+        {
+            std::cerr << prefix << " DOES NOT MATCH: file sizes are "
+                      << mLHS.size() << " vs. " << mRHS.size() << " bytes"
+                      << std::endl;
+        }
+        else
+        {
+            size_t ii;
+            for (ii = 0; ii < mLHS.size(); ++ii)
+            {
+                if (mLHS[ii] != mRHS[ii])
+                {
+                    break;
+                }
+            }
+
+            std::cerr << prefix << " DOES NOT MATCH at byte " << ii
+                      << std::endl;
+        }
+
+        return false;
+    }
+
+private:
+    std::vector<sys::byte> mLHS;
+    mutable std::vector<sys::byte> mRHS;
+};
+
+// Makes sure a file gets removed
+// Both makes sure we start with a clean slate each time and that there are no
+// leftover files if an exception occurs
+class EnsureFileCleanup
+{
+public:
+    EnsureFileCleanup(const std::string& pathname) :
+        mPathname(pathname)
+    {
+        removeIfExists();
+    }
+
+    ~EnsureFileCleanup()
+    {
+        try
+        {
+            removeIfExists();
+        }
+        catch (...)
+        {
+        }
+    }
+
+private:
+    void removeIfExists()
+    {
+        sys::OS os;
+        if (os.exists(mPathname))
+        {
+            os.remove(mPathname);
+        }
+    }
+
+private:
+    const std::string mPathname;
+};
+
+#endif

--- a/six/modules/c++/six.sicd/tests/test_sicd_byte_provider.cpp
+++ b/six/modules/c++/six.sicd/tests/test_sicd_byte_provider.cpp
@@ -113,7 +113,7 @@ private:
     }
 
     void write(nitf::Off fileOffset,
-               const six::sicd::SICDByteProvider::BufferList& buffers,
+               const six::sicd::SICDByteProvider::NITFBufferList& buffers,
                nitf::Off computedNumBytes,
                io::FileOutputStream& outStream)
     {
@@ -191,7 +191,7 @@ void Tester<DataTypeT>::testSingleWrite()
             mSchemaPaths,
             mSetMaxProductSize ? mMaxProductSize : 0);
 
-    six::sicd::SICDByteProvider::BufferList buffers;
+    six::sicd::SICDByteProvider::NITFBufferList buffers;
     nitf::Off fileOffset;
     sicdByteProvider.getBytes(&mBigEndianImage[0], 0, mDims.row,
                               fileOffset, buffers);
@@ -216,7 +216,7 @@ void Tester<DataTypeT>::testMultipleWrites()
 
     // Rows [40, 60)
     nitf::Off fileOffset;
-    six::sicd::SICDByteProvider::BufferList buffers;
+    six::sicd::SICDByteProvider::NITFBufferList buffers;
     size_t startRow = 40;
     size_t numRows = 20;
     sicdByteProvider.getBytes(&mBigEndianImage[startRow * mDims.col],
@@ -306,7 +306,7 @@ void Tester<DataTypeT>::testOneWritePerRow()
         const size_t startRow = mDims.row - 1 - row;
 
         nitf::Off fileOffset;
-        six::sicd::SICDByteProvider::BufferList buffers;
+        six::sicd::SICDByteProvider::NITFBufferList buffers;
         sicdByteProvider.getBytes(&mBigEndianImage[startRow * mDims.col],
                                   startRow,
                                   1,

--- a/six/modules/c++/six.sicd/tests/test_sicd_byte_provider.cpp
+++ b/six/modules/c++/six.sicd/tests/test_sicd_byte_provider.cpp
@@ -1,0 +1,387 @@
+/* =========================================================================
+ * This file is part of six.sicd-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * six-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Test program for SICDByteProvider
+// Demonstrates that the raw bytes provided by this class result in equivalent
+// SICDs to the normal writes via NITFWriteControl
+
+#include <iostream>
+
+#include "TestUtilities.h"
+
+#include <six/NITFWriteControl.h>
+#include <six/XMLControlFactory.h>
+#include <six/sicd/ComplexXMLControl.h>
+#include <six/sicd/SICDByteProvider.h>
+
+namespace
+{
+// Main test class
+template <typename DataTypeT>
+class Tester
+{
+public:
+    Tester(const std::vector<std::string>& schemaPaths,
+           bool setMaxProductSize,
+           size_t maxProductSize = 0) :
+        mNormalPathname("normal_write.nitf"),
+        mNormalFileCleanup(mNormalPathname),
+        mDims(123, 456),
+        mData(createData<DataTypeT>(mDims)),
+        mImage(mDims.area()),
+        mTestPathname("streaming_write.nitf"),
+        mSchemaPaths(schemaPaths),
+        mSetMaxProductSize(setMaxProductSize),
+        mMaxProductSize(maxProductSize),
+        mSuccess(true)
+    {
+        for (size_t ii = 0; ii < mImage.size(); ++ii)
+        {
+            mImage[ii] = std::complex<DataTypeT>(
+                    static_cast<DataTypeT>(ii),
+                    static_cast<DataTypeT>(ii * 10));
+        }
+
+        mBigEndianImage = mImage;
+        if (!sys::isBigEndianSystem())
+        {
+            sys::byteSwap(&mBigEndianImage[0],
+                          sizeof(DataTypeT),
+                          mBigEndianImage.size() * 2);
+        }
+
+        normalWrite();
+    }
+
+    bool success() const
+    {
+        return mSuccess;
+    }
+
+    // Write the file out with a SICDByteProvider in one shot
+    void testSingleWrite();
+
+    void testMultipleWrites();
+
+    void testOneWritePerRow();
+
+private:
+    void normalWrite();
+
+private:
+    void compare(const std::string& prefix)
+    {
+        std::string fullPrefix = prefix;
+        if (mSetMaxProductSize)
+        {
+            fullPrefix += " (max product size " +
+                    str::toString(mMaxProductSize) + ")";
+        }
+
+        if (!(*mCompareFiles)(fullPrefix, mTestPathname))
+        {
+            mSuccess = false;
+        }
+    }
+
+    void setMaxProductSize(six::NITFWriteControl& writer)
+    {
+        if (mSetMaxProductSize)
+        {
+            writer.getOptions().setParameter(
+                    six::NITFWriteControl::OPT_MAX_PRODUCT_SIZE, mMaxProductSize);
+        }
+    }
+
+private:
+    const std::string mNormalPathname;
+    const EnsureFileCleanup mNormalFileCleanup;
+
+    const types::RowCol<size_t> mDims;
+    std::auto_ptr<six::sicd::ComplexData> mData;
+    std::vector<std::complex<DataTypeT> > mImage;
+    std::vector<std::complex<DataTypeT> > mBigEndianImage;
+
+    std::auto_ptr<const CompareFiles> mCompareFiles;
+    const std::string mTestPathname;
+    const std::vector<std::string> mSchemaPaths;
+
+    bool mSetMaxProductSize;
+    size_t mMaxProductSize;
+
+    bool mSuccess;
+};
+
+template <typename DataTypeT>
+void Tester<DataTypeT>::normalWrite()
+{
+    mem::SharedPtr<six::Container> container(
+            new six::Container(six::DataType::COMPLEX));
+    container->addData(mData->clone());
+
+    six::XMLControlRegistry xmlRegistry;
+    xmlRegistry.addCreator(six::DataType::COMPLEX,
+                           new six::XMLControlCreatorT<
+                                   six::sicd::ComplexXMLControl>());
+
+    six::NITFWriteControl writer;
+    writer.setXMLControlRegistry(&xmlRegistry);
+    setMaxProductSize(writer);
+    writer.initialize(container);
+
+    six::BufferList buffers;
+    buffers.push_back(reinterpret_cast<six::UByte*>(&mImage[0]));
+    writer.save(buffers, mNormalPathname, mSchemaPaths);
+
+    mCompareFiles.reset(new CompareFiles(mNormalPathname));
+}
+
+template <typename DataTypeT>
+void Tester<DataTypeT>::testSingleWrite()
+{
+    const EnsureFileCleanup ensureFileCleanup(mTestPathname);
+
+    six::sicd::SICDByteProvider sicdByteProvider(
+            *mData,
+            mSchemaPaths,
+            mSetMaxProductSize ? mMaxProductSize : 0);
+
+    size_t numBytes;
+    const sys::byte* const rawBytes = static_cast<const sys::byte*>(
+            sicdByteProvider.getBytes(&mBigEndianImage[0], 0, mDims.row,
+                                      numBytes));
+
+    io::FileOutputStream outStream(mTestPathname);
+    outStream.write(rawBytes, numBytes);
+    outStream.close();
+
+    compare("Single write");
+}
+
+template <typename DataTypeT>
+void Tester<DataTypeT>::testMultipleWrites()
+{
+    const EnsureFileCleanup ensureFileCleanup(mTestPathname);
+
+    six::sicd::SICDByteProvider sicdByteProvider(
+            *mData,
+            mSchemaPaths,
+            mSetMaxProductSize ? mMaxProductSize : 0);
+
+    // Rows [0, 5)
+    size_t numBytes;
+    size_t startRow = 0;
+    const sys::byte* rawBytes = static_cast<const sys::byte*>(
+            sicdByteProvider.getBytes(&mBigEndianImage[startRow * mDims.col],
+                                       startRow,
+                                       5,
+                                       numBytes));
+
+    io::FileOutputStream outStream(mTestPathname);
+    outStream.write(rawBytes, numBytes);
+
+    // Rows [5, 25)
+    startRow = 5;
+    rawBytes = static_cast<const sys::byte*>(
+            sicdByteProvider.getBytes(&mBigEndianImage[startRow * mDims.col],
+                                       startRow,
+                                       20,
+                                       numBytes));
+
+    outStream.write(rawBytes, numBytes);
+
+    // Rows [25, 40)
+    startRow = 25;
+    rawBytes = static_cast<const sys::byte*>(
+            sicdByteProvider.getBytes(&mBigEndianImage[startRow * mDims.col],
+                                       startRow,
+                                       15,
+                                       numBytes));
+
+    outStream.write(rawBytes, numBytes);
+
+    // Rows [40, 60)
+    startRow = 40;
+    rawBytes = static_cast<const sys::byte*>(
+            sicdByteProvider.getBytes(&mBigEndianImage[startRow * mDims.col],
+                                       startRow,
+                                       20,
+                                       numBytes));
+
+    outStream.write(rawBytes, numBytes);
+
+    // Rows [60, 100)
+    startRow = 60;
+    rawBytes = static_cast<const sys::byte*>(
+            sicdByteProvider.getBytes(&mBigEndianImage[startRow * mDims.col],
+                                       startRow,
+                                       40,
+                                       numBytes));
+
+    outStream.write(rawBytes, numBytes);
+
+    // Rows [100, 123)
+    startRow = 100;
+    rawBytes = static_cast<const sys::byte*>(
+            sicdByteProvider.getBytes(&mBigEndianImage[startRow * mDims.col],
+                                       startRow,
+                                       23,
+                                       numBytes));
+
+    outStream.write(rawBytes, numBytes);
+
+    outStream.close();
+
+    compare("Multiple writes");
+}
+
+template <typename DataTypeT>
+void Tester<DataTypeT>::testOneWritePerRow()
+{
+    const EnsureFileCleanup ensureFileCleanup(mTestPathname);
+
+    six::sicd::SICDByteProvider sicdByteProvider(
+            *mData,
+            mSchemaPaths,
+            mSetMaxProductSize ? mMaxProductSize : 0);
+
+    io::FileOutputStream outStream(mTestPathname);
+    for (size_t row = 0; row < mDims.row; ++row)
+    {
+        size_t numBytes;
+        const sys::byte* const rawBytes = static_cast<const sys::byte*>(
+                sicdByteProvider.getBytes(&mBigEndianImage[row * mDims.col],
+                                           row,
+                                           1,
+                                           numBytes));
+
+        outStream.write(rawBytes, numBytes);
+    }
+
+    outStream.close();
+
+    compare("One write per row");
+}
+
+template <typename DataTypeT>
+bool doTests(const std::vector<std::string>& schemaPaths,
+             bool setMaxProductSize,
+             size_t numRowsPerSeg)
+{
+    // TODO: This math isn't quite right
+    //       We also end up with a different number of segments for the
+    //       complex float than the complex short case sometimes
+    //       It would be better to get the logic fixed that forces
+    //       segmentation on the number of rows via OPT_MAX_ILOC_ROWS
+    static const size_t APPROX_HEADER_SIZE = 2 * 1024;
+    const size_t numBytesPerRow = 456 * sizeof(std::complex<DataTypeT>);
+    const size_t maxProductSize = numRowsPerSeg * numBytesPerRow +
+            APPROX_HEADER_SIZE;
+
+    Tester<DataTypeT> tester(schemaPaths, setMaxProductSize, maxProductSize);
+    tester.testSingleWrite();
+    tester.testMultipleWrites();
+    tester.testOneWritePerRow();
+
+    return tester.success();
+}
+
+bool doTestsBothDataTypes(const std::vector<std::string>& schemaPaths,
+                          bool setMaxProductSize,
+                          size_t numRowsPerSeg = 0)
+{
+    bool success = true;
+    if (!doTests<float>(schemaPaths, setMaxProductSize, numRowsPerSeg))
+    {
+        success = false;
+    }
+
+    if (!doTests<sys::Int16_T>(schemaPaths, setMaxProductSize, numRowsPerSeg))
+    {
+        success = false;
+    }
+
+    return success;
+}
+}
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    try
+    {
+        // TODO: Take these in optionally
+        const std::vector<std::string> schemaPaths;
+
+        // Run tests with no funky segmentation
+        bool success = true;
+        if (!doTestsBothDataTypes(schemaPaths, false))
+        {
+            success = false;
+        }
+
+        // Run tests forcing various numbers of segments
+        std::vector<size_t> numRows;
+        numRows.push_back(80);
+        numRows.push_back(30);
+        numRows.push_back(15);
+        numRows.push_back(7);
+        numRows.push_back(3);
+        numRows.push_back(2);
+        numRows.push_back(1);
+
+        for (size_t ii = 0; ii < numRows.size(); ++ii)
+        {
+            if (!doTestsBothDataTypes(schemaPaths, true, numRows[ii]))
+            {
+                success = false;
+            }
+        }
+
+        // With any luck we passed
+        if (success)
+        {
+            std::cout << "All tests pass!\n";
+        }
+        else
+        {
+            std::cerr << "Some tests FAIL!\n";
+        }
+
+        return (success ? 0 : 1);
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << "Caught std::exception: " << ex.what() << std::endl;
+        return 1;
+    }
+    catch (const except::Exception& ex)
+    {
+        std::cerr << "Caught except::Exception: " << ex.getMessage()
+                  << std::endl;
+        return 1;
+    }
+    catch (...)
+    {
+        std::cerr << "Caught unknown exception\n";
+        return 1;
+    }
+}

--- a/six/modules/c++/six.sicd/tests/test_streaming_write.cpp
+++ b/six/modules/c++/six.sicd/tests/test_streaming_write.cpp
@@ -151,12 +151,11 @@ private:
 template <typename DataTypeT>
 void Tester<DataTypeT>::normalWrite()
 {
-    mContainer->addData(createData<DataTypeT>(mDims));
+    mContainer->addData(createData<DataTypeT>(mDims).release());
 
     six::NITFWriteControl writer;
     setMaxProductSize(writer);
     writer.initialize(mContainer);
-
 
     six::BufferList buffers;
     buffers.push_back(reinterpret_cast<six::UByte*>(mImagePtr));

--- a/six/modules/c++/six/include/six/NITFSegmentInfo.h
+++ b/six/modules/c++/six/include/six/NITFSegmentInfo.h
@@ -22,7 +22,9 @@
 #ifndef __SIX_NITF_SEGMENT_INFO_H__
 #define __SIX_NITF_SEGMENT_INFO_H__
 
-#include "six/Types.h"
+#include <algorithm>
+
+#include <six/Types.h>
 
 namespace six
 {
@@ -56,8 +58,31 @@ struct NITFSegmentInfo
     {
         return firstRow + numRows;
     }
-};
 
+    /*!
+     * Given a global pixel range of
+     * [rangeStartRow, rangeStartRow + rangeNumRows), determines if this range
+     * overlaps with this segment and, if so, what rows overlap with it
+     *
+     * \param rangeStartRow The inclusive global start row of the range of
+     * interest
+     * \param rangeNumRows The number of rows in the range of interest
+     * \param[out] firstGlobalRowInThisSegment If the range does appear in this
+     * segment, the first global row of the range that's in the segment (if the
+     * range starts prior to this segment, it'll be the first row of the
+     * segment.  If the range starts inside the segment, it'll be the first row
+     * of the range).  If the range does not appear in this segment, this is
+     * set to numeric_limits<size_t>::max().
+     * \param[out] numRowsInThisSegment The number of rows of the range which
+     * appear in this segment
+     *
+     * \return True if the range overlaps with this segment, false otherwise
+     */
+    bool isInRange(size_t rangeStartRow,
+                   size_t rangeNumRows,
+                   size_t& firstGlobalRowInThisSegment,
+                   size_t& numRowsInThisSegment) const;
+};
 }
 
 #endif

--- a/six/modules/c++/six/include/six/NITFSegmentInfo.h
+++ b/six/modules/c++/six/include/six/NITFSegmentInfo.h
@@ -48,6 +48,14 @@ struct NITFSegmentInfo
 
     //! The image segment corner points
     LatLonCorners corners;
+
+    /*!
+     * \return The end row (exclusive) of the image segment
+     */
+    size_t endRow() const
+    {
+        return firstRow + numRows;
+    }
 };
 
 }

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -253,6 +253,8 @@ public:
      * and data (i.e. XML string)
      * \param[out] imageSubheaderFileOffsets Offsets in the NITF where each
      * image subheader should be written
+     * \param[out] imageSegmentInfo The starting row and number of rows for each
+     * image segment
      * \param[out] desSubheaderFileOffset Offset in the NITF where the DES
      * subheader should be written
      * \param[out] fileNumBytes The total number of bytes the NITF will be
@@ -266,6 +268,7 @@ public:
                        std::vector<std::vector<sys::byte> >& imageSubheaders,
                        std::vector<sys::byte>& desSubheaderAndData,
                        std::vector<nitf::Off>& imageSubheaderFileOffsets,
+                       std::vector<NITFSegmentInfo>& imageSegmentInfo,
                        nitf::Off& desSubheaderFileOffset,
                        nitf::Off& fileNumBytes) const;
 

--- a/six/modules/c++/six/source/NITFSegmentInfo.cpp
+++ b/six/modules/c++/six/source/NITFSegmentInfo.cpp
@@ -1,0 +1,52 @@
+/* =========================================================================
+ * This file is part of six-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * six-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <limits>
+#include <algorithm>
+
+#include <six/NITFSegmentInfo.h>
+
+namespace six
+{
+bool NITFSegmentInfo::isInRange(size_t rangeStartRow,
+                                size_t rangeNumRows,
+                                size_t& firstGlobalRowInThisSegment,
+                                size_t& numRowsInThisSegment) const
+{
+    const size_t startGlobalRow = std::max(firstRow, rangeStartRow);
+    const size_t endGlobalRow =
+            std::min(endRow(), rangeStartRow + rangeNumRows);
+
+    if (endGlobalRow > startGlobalRow)
+    {
+        firstGlobalRowInThisSegment = startGlobalRow;
+        numRowsInThisSegment = endGlobalRow - startGlobalRow;
+        return true;
+    }
+    else
+    {
+        firstGlobalRowInThisSegment = std::numeric_limits<size_t>::max();
+        numRowsInThisSegment = 0;
+        return false;
+    }
+}
+}

--- a/six/modules/c++/six/source/NITFWriteControl.cpp
+++ b/six/modules/c++/six/source/NITFWriteControl.cpp
@@ -1177,6 +1177,7 @@ void NITFWriteControl::getFileLayout(
         std::vector<std::vector<sys::byte> >& imageSubheaders,
         std::vector<sys::byte>& desSubheaderAndData,
         std::vector<nitf::Off>& imageSubheaderFileOffsets,
+        std::vector<NITFSegmentInfo>& imageSegmentInfo,
         nitf::Off& desSubheaderFileOffset,
         nitf::Off& fileNumBytes) const
 {
@@ -1309,5 +1310,7 @@ void NITFWriteControl::getFileLayout(
 
     // DES is right after that
     desSubheaderFileOffset = offset;
+
+    imageSegmentInfo = mInfos[0]->getImageSegments();
 }
 }

--- a/six/modules/python/six/tests/runTests.py
+++ b/six/modules/python/six/tests/runTests.py
@@ -131,6 +131,9 @@ def run(sourceDir):
         if not sicdTestRunner.run('test_streaming_write'):
             return False
 
+        if not sicdTestRunner.run('test_sicd_byte_provider'):
+            return False
+
         if not runCsmTests():
             return False
 


### PR DESCRIPTION
This adds functionality that allows the caller to provide an AOI of SICD pixel data and get back corresponding raw NITF file bytes in a contiguous block of memory such that, if it's called eventually with the entire image, the caller will get the entire raw NITF file (including NITF headers).  The idea is to make it simple for callers to write out a SICD NITF piecemeal without needing to understand the underlying complexities of the NITF file structure.