### PR TITLE
Fix bug for gcc 4.4.7

### DIFF
--- a/six/modules/c++/six/unittests/test_fft_sign_conversions.cpp
+++ b/six/modules/c++/six/unittests/test_fft_sign_conversions.cpp
@@ -1,14 +1,19 @@
 #include "TestCase.h"
 
 #include <six/Utilities.h>
+#include <six/Enums.h>
 
 namespace
 {
 TEST_CASE(testToType)
 {
-    TEST_ASSERT_EQ(six::toType<six::FFTSign>("+1"), six::FFTSign::POS);
-    TEST_ASSERT_EQ(six::toType<six::FFTSign>("1"), six::FFTSign::POS);
-    TEST_ASSERT_EQ(six::toType<six::FFTSign>("-1"), six::FFTSign::NEG);
+    TEST_ASSERT_EQ(six::toType<six::FFTSign>("+1"),
+            six::FFTSign(six::FFTSign::POS));
+    TEST_ASSERT_EQ(six::toType<six::FFTSign>("1"),
+            six::FFTSign(six::FFTSign::POS));
+    TEST_ASSERT_EQ(six::toType<six::FFTSign>("-1"),
+            six::FFTSign(six::FFTSign::NEG));
+
 }
 }
 


### PR DESCRIPTION
This is a workaround for this issue: https://stackoverflow.com/questions/5720359/no-matching-function-call-to-anonymous-enum