### PR TITLE
test_create_sicd_from_mem size_t bug

### DIFF
--- a/six/modules/c++/samples/test_create_sicd_from_mem.cpp
+++ b/six/modules/c++/samples/test_create_sicd_from_mem.cpp
@@ -20,16 +20,17 @@
  *
  */
 #include <iostream>
+#include <memory>
+#include <stdexcept>
 
-#include <import/cli.h>
-#include <import/six.h>
-#include <import/io.h>
+#include <sys/Path.h>
+#include <except/Exception.h>
 #include <logging/Setup.h>
-#include <scene/Utilities.h>
-#include "utils.h"
+#include <cli/ArgumentParser.h>
+#include <six/sicd/Utilities.h>
+#include <six/sicd/ComplexXMLControl.h>
 
-// For SICD implementation
-#include <import/six/sicd.h>
+#include "utils.h"
 
 int main(int argc, char** argv)
 {
@@ -38,11 +39,15 @@ int main(int argc, char** argv)
         // create a parser and add our options to it
         cli::ArgumentParser parser;
         parser.setDescription(
-                              "This program creates a sample SICD NITF file of all zeros.");
+                "This program creates a sample SICD NITF file of all zeros.");
         parser.addArgument("-r --rows", "Rows limit", cli::STORE, "maxRows",
-                           "ROWS")->setDefault(-1);
+                           "ROWS");
         parser.addArgument("-s --size", "Max product size", cli::STORE,
-                           "maxSize", "BYTES")->setDefault(-1);
+                           "maxSize", "BYTES");
+        parser.addArgument("--num-rows", "Number of rows", cli::STORE,
+                           "numRows", "ROWS")->setDefault(123);
+        parser.addArgument("--num-cols", "Number of columns", cli::STORE,
+                           "numCols", "COLS")->setDefault(456);
         parser.addArgument("--class", "Classification Level", cli::STORE,
                            "classLevel", "LEVEL")->setDefault("UNCLASSIFIED");
         parser.addArgument("--schema",
@@ -53,121 +58,31 @@ int main(int argc, char** argv)
 
         std::auto_ptr<cli::Results> options(parser.parse(argc, argv));
 
-        std::string outputName(options->get<std::string> ("output"));
-        size_t maxRows(options->get<size_t>("maxRows"));
-        size_t maxSize(options->get<size_t>("maxSize"));
-        std::string classLevel(options->get<std::string> ("classLevel"));
+        const types::RowCol<size_t> dims(options->get<size_t>("numRows"),
+                                         options->get<size_t>("numCols"));
+        const std::string outputName(options->get<std::string>("output"));
+        const std::string classLevel(options->get<std::string>("classLevel"));
         std::vector<std::string> schemaPaths;
         getSchemaPaths(*options, "--schema", "schema", schemaPaths);
 
         std::auto_ptr<logging::Logger> logger(
                 logging::setupLogger(sys::Path::basename(argv[0])));
 
-        // create an XML registry
-        // The reason to do this is to avoid adding XMLControlCreators to the
-        // XMLControlFactory singleton - this way has more fine-grained control
-        //        XMLControlRegistry xmlRegistry;
-        //        xmlRegistry.addCreator(DataType::COMPLEX, new XMLControlCreatorT<
-        //                six::sicd::ComplexXMLControl> ());
-
         six::XMLControlFactory::getInstance().addCreator(
                 six::DataType::COMPLEX,
                 new six::XMLControlCreatorT<six::sicd::ComplexXMLControl>());
 
-        // TODO: Allow this size to be overridden
-        const types::RowCol<size_t> dims(123, 456);
         std::vector<std::complex<float> > image(dims.row * dims.col);
 
-        // Create the Data
-        // TODO: Use a ComplexDataBuilder?
-        six::sicd::ComplexData* data(new six::sicd::ComplexData());
-        std::auto_ptr<six::Data> scopedData(data);
-        data->setPixelType(six::PixelType::RE32F_IM32F);
+        std::auto_ptr<six::Data> data(
+                six::sicd::Utilities::createFakeComplexData().release());
         data->setNumRows(dims.row);
         data->setNumCols(dims.col);
-        data->setName("corename");
-        data->setSource("sensorname");
-        data->collectionInformation->classification.level = classLevel;
-        data->setCreationTime(six::DateTime());
-        data->setImageCorners(makeUpCornersFromDMS());
-        data->collectionInformation->radarMode = six::RadarModeType::SPOTLIGHT;
-        data->scpcoa->sideOfTrack = six::SideOfTrackType::LEFT;
-        data->geoData->scp.llh = six::LatLonAlt(42.2708, -83.7264);
-        data->geoData->scp.ecf =
-                scene::Utilities::latLonToECEF(data->geoData->scp.llh);
-        data->grid->timeCOAPoly = six::Poly2D(0, 0);
-        data->grid->timeCOAPoly[0][0] = 15605743.142846;
-        data->position->arpPoly = six::PolyXYZ(0);
-        data->position->arpPoly[0] = 0.0;
-
-        data->radarCollection->txFrequencyMin = 0.0;
-        data->radarCollection->txFrequencyMax = 0.0;
-        data->radarCollection->txPolarization = six::PolarizationType::OTHER;
-        mem::ScopedCloneablePtr<six::sicd::ChannelParameters>
-                rcvChannel(new six::sicd::ChannelParameters());
-        rcvChannel->txRcvPolarization = six::DualPolarizationType::OTHER;
-        data->radarCollection->rcvChannels.push_back(rcvChannel);
-
-        data->grid->row->sign = six::FFTSign::POS;
-        data->grid->row->unitVector = 0.0;
-        data->grid->row->sampleSpacing = 0;
-        data->grid->row->impulseResponseWidth = 0;
-        data->grid->row->impulseResponseBandwidth = 0;
-        data->grid->row->kCenter = 0;
-        data->grid->row->deltaK1 = 0;
-        data->grid->row->deltaK2 = 0;
-        data->grid->col->sign = six::FFTSign::POS;
-        data->grid->col->unitVector = 0.0;
-        data->grid->col->sampleSpacing = 0;
-        data->grid->col->impulseResponseWidth = 0;
-        data->grid->col->impulseResponseBandwidth = 0;
-        data->grid->col->kCenter = 0;
-        data->grid->col->deltaK1 = 0;
-        data->grid->col->deltaK2 = 0;
-
-        data->imageFormation->rcvChannelProcessed->numChannelsProcessed = 1;
-        data->imageFormation->rcvChannelProcessed->channelIndex.push_back(0);
-
-        data->pfa.reset(new six::sicd::PFA());
-        data->pfa->spatialFrequencyScaleFactorPoly = six::Poly1D(0);
-        data->pfa->spatialFrequencyScaleFactorPoly[0] = 42;
-        data->pfa->polarAnglePoly = six::Poly1D(0);
-        data->pfa->polarAnglePoly[0] = 42;
-
-        data->timeline->collectDuration = 0;
-        data->imageFormation->txRcvPolarizationProc =
-                six::DualPolarizationType::OTHER;
-        data->imageFormation->tStartProc = 0;
-        data->imageFormation->tEndProc = 0;
-
-        data->scpcoa->scpTime = 15605743.142846;
-        data->scpcoa->slantRange = 0.0;
-        data->scpcoa->groundRange = 0.0;
-        data->scpcoa->dopplerConeAngle = 0.0;
-        data->scpcoa->grazeAngle = 0.0;
-        data->scpcoa->incidenceAngle = 0.0;
-        data->scpcoa->twistAngle = 0.0;
-        data->scpcoa->slopeAngle = 0.0;
-        data->scpcoa->azimAngle = 0.0;
-        data->scpcoa->layoverAngle = 0.0;
-        data->scpcoa->arpPos = 0.0;
-        data->scpcoa->arpVel = 0.0;
-        data->scpcoa->arpAcc = 0.0;
-
-        data->pfa->focusPlaneNormal = 0.0;
-        data->pfa->imagePlaneNormal = 0.0;
-        data->pfa->polarAngleRefTime = 0.0;
-        data->pfa->krg1 = 0;
-        data->pfa->krg2 = 0;
-        data->pfa->kaz1 = 0;
-        data->pfa->kaz2 = 0;
-
-        data->imageFormation->txFrequencyProcMin = 0;
-        data->imageFormation->txFrequencyProcMax = 0;
+        data->setPixelType(six::PixelType::RE32F_IM32F);
 
         mem::SharedPtr<six::Container> container(new six::Container(
                 six::DataType::COMPLEX));
-        container->addData(scopedData);
+        container->addData(data);
         six::NITFWriteControl writer;
         writer.setLogger(logger.get());
 
@@ -182,18 +97,21 @@ int main(int argc, char** argv)
          *  the algorithm to segment early.
          *
          */
-        if (maxRows > 0)
+
+        if (options->hasValue("maxRows"))
         {
             std::cout << "Overriding NITF max ILOC" << std::endl;
-            writer.getOptions().setParameter(six::NITFWriteControl::OPT_MAX_ILOC_ROWS,
-                                             maxRows);
-
+            writer.getOptions().setParameter(
+                    six::NITFWriteControl::OPT_MAX_ILOC_ROWS,
+                    options->get<size_t>("maxRows"));
         }
-        if (maxSize > 0)
+
+        if (options->hasValue("maxSize"))
         {
             std::cout << "Overriding NITF product size" << std::endl;
-            writer.getOptions().setParameter(six::NITFWriteControl::OPT_MAX_PRODUCT_SIZE,
-                                             maxSize);
+            writer.getOptions().setParameter(
+                    six::NITFWriteControl::OPT_MAX_PRODUCT_SIZE,
+                    options->get<size_t>("maxSize"));
         }
 
         writer.initialize(container);
@@ -207,17 +125,16 @@ int main(int argc, char** argv)
     catch (const std::exception& ex)
     {
         std::cerr << "Caught std::exception: " << ex.what() << std::endl;
-        return 1;
     }
     catch (const except::Exception& ex)
     {
         std::cerr << "Caught except::Exception: " << ex.getMessage()
                   << std::endl;
-        return 1;
     }
     catch (...)
     {
         std::cerr << "Caught unknown exception\n";
-        return 1;
     }
+
+    return 1;
 }


### PR DESCRIPTION
* At some point we must have changed maxRows and maxSize to be a `size_t`... we were reserving the value `-1` to indicate they hadn't been set, which meant that this got set to a high value and always looked like they should be overridden (and now they were set to too high of a value so NITRO would throw)
* Allowing NITF's number of rows and cols to be overridden.