### PR TITLE
Add option to pass NITFWriteControl to ctor

### DIFF
--- a/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
@@ -197,6 +197,17 @@ public:
                      size_t maxProductSize = 0);
 
     /*!
+     * Constructor
+     * This option allows you to pass in an initialized writer,
+     * in case you need something specific in the header
+     *
+     * \param writer Initiailized NITFWriteControl
+     * \param schemaPaths Directories or files of schema locations
+     */
+    SICDByteProvider(const NITFWriteControl& writer,
+                     const std::vector<std::string>& schemaPaths);
+
+    /*!
      * \return The total number of bytes in the NITF
      */
     nitf::Off getFileNumBytes() const
@@ -262,6 +273,9 @@ public:
                   size_t numRows,
                   nitf::Off& fileOffset,
                   NITFBufferList& buffers) const;
+
+private:
+    size_t getNumBytesPerRow(const NITFWriteControl& writer) const;
 
 private:
     const size_t mNumBytesPerRow;

--- a/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
@@ -201,7 +201,7 @@ public:
      * This option allows you to pass in an initialized writer,
      * in case you need something specific in the header
      *
-     * \param writer Initiailized NITFWriteControl
+     * \param writer Initialized NITFWriteControl
      * \param schemaPaths Directories or files of schema locations
      */
     SICDByteProvider(const NITFWriteControl& writer,

--- a/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDByteProvider.h
@@ -275,7 +275,7 @@ public:
                   NITFBufferList& buffers) const;
 
 private:
-    size_t getNumBytesPerRow(const NITFWriteControl& writer) const;
+    static size_t getNumBytesPerRow(const NITFWriteControl& writer);
 
 private:
     const size_t mNumBytesPerRow;

--- a/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
+++ b/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
@@ -131,7 +131,7 @@ const void* SICDByteProvider::NITFBufferList::getBlock(
 }
 
 size_t SICDByteProvider::getNumBytesPerRow(
-        const NITFWriteControl& writer) const
+        const NITFWriteControl& writer)
 {
     const Data& data = *writer.getContainer()->getData(0);
     return data.getNumCols() * data.getNumBytesPerPixel();

--- a/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
+++ b/six/modules/c++/six.sicd/source/SICDByteProvider.cpp
@@ -130,6 +130,28 @@ const void* SICDByteProvider::NITFBufferList::getBlock(
     return NULL;
 }
 
+size_t SICDByteProvider::getNumBytesPerRow(
+        const NITFWriteControl& writer) const
+{
+    const Data& data = *writer.getContainer()->getData(0);
+    return data.getNumCols() * data.getNumBytesPerPixel();
+}
+
+SICDByteProvider::SICDByteProvider(
+        const NITFWriteControl& writer,
+        const std::vector<std::string>& schemaPaths) :
+    mNumBytesPerRow(getNumBytesPerRow(writer))
+{
+    writer.getFileLayout(schemaPaths,
+                         mFileHeader,
+                         mImageSubheaders,
+                         mDesSubheaderAndData,
+                         mImageSubheaderFileOffsets,
+                         mImageSegmentInfo,
+                         mDesSubheaderFileOffset,
+                         mFileNumBytes);
+}
+
 SICDByteProvider::SICDByteProvider(
         const ComplexData& data,
         const std::vector<std::string>& schemaPaths,


### PR DESCRIPTION
Need this so we can control what goes in the NITF header when writing with SICDByteProvider.