### PR TITLE
Allow for negative pixels in calculations

### DIFF
--- a/six/modules/c++/six.sicd/include/six/sicd/SlantPlanePixelTransformer.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SlantPlanePixelTransformer.h
@@ -65,21 +65,21 @@ public:
      *  \param pixel - Slant Plane pixel with (row,col) index
      *  \return      - Returns the ground plane location in ECEF
      */
-    scene::Vector3 toECEF(const types::RowCol<int>& pixel) const;
+    scene::Vector3 toECEF(const types::RowCol<double>& pixel) const;
 
     /*!
      *  \fn toLLA
      *  \param pixel - Slant Plane pixel with (row,col) index
      *  \return      - Returns the ground plane location in LLA
      */
-    scene::LatLonAlt toLLA(const types::RowCol<int>& pixel) const;
+    scene::LatLonAlt toLLA(const types::RowCol<double>& pixel) const;
 
     /*!
      *  \fn toLatLon
      *  \param pixel - Slant Plane pixel with (row,col) index
      *  \return      - Returns the ground plane location in LatLon
      */
-    scene::LatLon toLatLon(const types::RowCol<int>& pixel) const;
+    scene::LatLon toLatLon(const types::RowCol<double>& pixel) const;
 
 private:
     const scene::SceneGeometry mGeom;

--- a/six/modules/c++/six.sicd/include/six/sicd/SlantPlanePixelTransformer.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SlantPlanePixelTransformer.h
@@ -41,7 +41,7 @@ namespace sicd
  *  \class SlantPlanePixelTransformer
  *  \brief Projects a slant plane pixel into various ground plane coordinates
  *
- *  This class should be used to project coordinates between slant and 
+ *  This class should be used to project coordinates between slant and
  *  ground planes.
  */
 class SlantPlanePixelTransformer
@@ -65,21 +65,21 @@ public:
      *  \param pixel - Slant Plane pixel with (row,col) index
      *  \return      - Returns the ground plane location in ECEF
      */
-    scene::Vector3 toECEF(const types::RowCol<size_t>& pixel) const;
+    scene::Vector3 toECEF(const types::RowCol<int>& pixel) const;
 
     /*!
      *  \fn toLLA
      *  \param pixel - Slant Plane pixel with (row,col) index
      *  \return      - Returns the ground plane location in LLA
      */
-    scene::LatLonAlt toLLA(const types::RowCol<size_t>& pixel) const;
+    scene::LatLonAlt toLLA(const types::RowCol<int>& pixel) const;
 
     /*!
      *  \fn toLatLon
      *  \param pixel - Slant Plane pixel with (row,col) index
      *  \return      - Returns the ground plane location in LatLon
      */
-    scene::LatLon toLatLon(const types::RowCol<size_t>& pixel) const;
+    scene::LatLon toLatLon(const types::RowCol<int>& pixel) const;
 
 private:
     const scene::SceneGeometry mGeom;

--- a/six/modules/c++/six.sicd/source/SlantPlanePixelTransformer.cpp
+++ b/six/modules/c++/six.sicd/source/SlantPlanePixelTransformer.cpp
@@ -47,7 +47,7 @@ SlantPlanePixelTransformer::SlantPlanePixelTransformer(
 }
 
 scene::Vector3 SlantPlanePixelTransformer::toECEF(
-    const types::RowCol<int>& pixel) const
+    const types::RowCol<double>& pixel) const
 {
     //! convert slant pixel to meters from scene center
     const types::RowCol<double> imagePt(mSicdData.pixelToImagePoint(pixel));
@@ -61,14 +61,14 @@ scene::Vector3 SlantPlanePixelTransformer::toECEF(
 }
 
 scene::LatLonAlt SlantPlanePixelTransformer::toLLA(
-    const types::RowCol<int>& pixel) const
+    const types::RowCol<double>& pixel) const
 {
     //! project then convert ECEF to LLA
     return scene::Utilities::ecefToLatLon(toECEF(pixel));
 }
 
 scene::LatLon SlantPlanePixelTransformer::toLatLon(
-    const types::RowCol<int>& pixel) const
+    const types::RowCol<double>& pixel) const
 {
     //! project then convert LLA to LatLon
     scene::LatLonAlt lla = toLLA(pixel);

--- a/six/modules/c++/six.sicd/source/SlantPlanePixelTransformer.cpp
+++ b/six/modules/c++/six.sicd/source/SlantPlanePixelTransformer.cpp
@@ -47,7 +47,7 @@ SlantPlanePixelTransformer::SlantPlanePixelTransformer(
 }
 
 scene::Vector3 SlantPlanePixelTransformer::toECEF(
-    const types::RowCol<size_t>& pixel) const
+    const types::RowCol<int>& pixel) const
 {
     //! convert slant pixel to meters from scene center
     const types::RowCol<double> imagePt(mSicdData.pixelToImagePoint(pixel));
@@ -61,14 +61,14 @@ scene::Vector3 SlantPlanePixelTransformer::toECEF(
 }
 
 scene::LatLonAlt SlantPlanePixelTransformer::toLLA(
-    const types::RowCol<size_t>& pixel) const
+    const types::RowCol<int>& pixel) const
 {
     //! project then convert ECEF to LLA
     return scene::Utilities::ecefToLatLon(toECEF(pixel));
 }
 
 scene::LatLon SlantPlanePixelTransformer::toLatLon(
-    const types::RowCol<size_t>& pixel) const
+    const types::RowCol<int>& pixel) const
 {
     //! project then convert LLA to LatLon
     scene::LatLonAlt lla = toLLA(pixel);


### PR DESCRIPTION
Want to be able to do calculations for pixels off the edge of the image outside the library.