### PR TITLE
Set J2K compression params with CompressedByteProvider

### DIFF
--- a/six/modules/c++/samples/test_create_sidd_with_compressed_byte_provider.cpp
+++ b/six/modules/c++/samples/test_create_sidd_with_compressed_byte_provider.cpp
@@ -1028,7 +1028,7 @@ void writeSIDD(const std::string& filename, bool shouldCompress)
     std::auto_ptr<six::sidd::DerivedData> data = createData(
             types::RowCol<size_t>(NITRO_IMAGE.height, NITRO_IMAGE.width));
     six::sidd::CompressedSIDDByteProvider byteProvider(*data, schemaPaths,
-            bytesPerBlock);
+            bytesPerBlock, 1);
     nitf::Off fileOffset;
     nitf::NITFBufferList buffers;
     byteProvider.getBytes(NITRO_IMAGE.data, 0, NITRO_IMAGE.height,

--- a/six/modules/c++/six.sidd/include/six/sidd/CompressedSIDDByteProvider.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/CompressedSIDDByteProvider.h
@@ -57,7 +57,7 @@ public:
      * \param bytesPerBlock A vector for each image segment. Each inner vector
      *        contains the compressed size for each block in the segment,
      *        in bytes.
-     * \param compressionRatio Ratio used for J2K compression
+     * \param isNumericallyLossless Flag whether compression was lossless
      * \param numRowsPerBlock The number of rows per block.  Defaults to no
      * blocking.
      * \param numColsPerBlock The number of columns per block.  Defaults to no
@@ -68,7 +68,7 @@ public:
     CompressedSIDDByteProvider(const DerivedData& data,
                                const std::vector<std::string>& schemaPaths,
                                const std::vector<std::vector<size_t> >& bytesPerBlock,
-                               size_t compressionRatio,
+                               bool isNumericallyLossless,
                                size_t numRowsPerBlock = 0,
                                size_t numColsPerBlock = 0,
                                size_t maxProductSize = 0);

--- a/six/modules/c++/six.sidd/include/six/sidd/CompressedSIDDByteProvider.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/CompressedSIDDByteProvider.h
@@ -67,6 +67,7 @@ public:
     CompressedSIDDByteProvider(const DerivedData& data,
                                const std::vector<std::string>& schemaPaths,
                                const std::vector<std::vector<size_t> >& bytesPerBlock,
+                               double compressionLevel = 1,
                                size_t numRowsPerBlock = 0,
                                size_t numColsPerBlock = 0,
                                size_t maxProductSize = 0);

--- a/six/modules/c++/six.sidd/include/six/sidd/CompressedSIDDByteProvider.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/CompressedSIDDByteProvider.h
@@ -57,6 +57,7 @@ public:
      * \param bytesPerBlock A vector for each image segment. Each inner vector
      *        contains the compressed size for each block in the segment,
      *        in bytes.
+     * \param compressionRatio Ratio used for J2K compression
      * \param numRowsPerBlock The number of rows per block.  Defaults to no
      * blocking.
      * \param numColsPerBlock The number of columns per block.  Defaults to no
@@ -67,7 +68,7 @@ public:
     CompressedSIDDByteProvider(const DerivedData& data,
                                const std::vector<std::string>& schemaPaths,
                                const std::vector<std::vector<size_t> >& bytesPerBlock,
-                               double compressionLevel = 1,
+                               size_t compressionRatio,
                                size_t numRowsPerBlock = 0,
                                size_t numColsPerBlock = 0,
                                size_t maxProductSize = 0);

--- a/six/modules/c++/six.sidd/source/CompressedSIDDByteProvider.cpp
+++ b/six/modules/c++/six.sidd/source/CompressedSIDDByteProvider.cpp
@@ -31,7 +31,7 @@ CompressedSIDDByteProvider::CompressedSIDDByteProvider(
         const DerivedData& data,
         const std::vector<std::string>& schemaPaths,
         const std::vector<std::vector<size_t> >& bytesPerBlock,
-        double compressionLevel,
+        size_t compressionRatio,
         size_t numRowsPerBlock,
         size_t numColsPerBlock,
         size_t maxProductSize)
@@ -48,8 +48,8 @@ CompressedSIDDByteProvider::CompressedSIDDByteProvider(
     container->addData(data.clone());
 
     initialize(container, xmlRegistry, schemaPaths, bytesPerBlock,
-               maxProductSize, compressionLevel, numRowsPerBlock,
-               numColsPerBlock);
+               compressionRatio, maxProductSize,
+               numRowsPerBlock, numColsPerBlock);
 }
 
 CompressedSIDDByteProvider::CompressedSIDDByteProvider(

--- a/six/modules/c++/six.sidd/source/CompressedSIDDByteProvider.cpp
+++ b/six/modules/c++/six.sidd/source/CompressedSIDDByteProvider.cpp
@@ -31,7 +31,7 @@ CompressedSIDDByteProvider::CompressedSIDDByteProvider(
         const DerivedData& data,
         const std::vector<std::string>& schemaPaths,
         const std::vector<std::vector<size_t> >& bytesPerBlock,
-        size_t compressionRatio,
+        bool isNumericallyLossless,
         size_t numRowsPerBlock,
         size_t numColsPerBlock,
         size_t maxProductSize)
@@ -48,7 +48,7 @@ CompressedSIDDByteProvider::CompressedSIDDByteProvider(
     container->addData(data.clone());
 
     initialize(container, xmlRegistry, schemaPaths, bytesPerBlock,
-               compressionRatio, maxProductSize,
+               isNumericallyLossless, maxProductSize,
                numRowsPerBlock, numColsPerBlock);
 }
 

--- a/six/modules/c++/six.sidd/source/CompressedSIDDByteProvider.cpp
+++ b/six/modules/c++/six.sidd/source/CompressedSIDDByteProvider.cpp
@@ -31,6 +31,7 @@ CompressedSIDDByteProvider::CompressedSIDDByteProvider(
         const DerivedData& data,
         const std::vector<std::string>& schemaPaths,
         const std::vector<std::vector<size_t> >& bytesPerBlock,
+        double compressionLevel,
         size_t numRowsPerBlock,
         size_t numColsPerBlock,
         size_t maxProductSize)
@@ -47,7 +48,8 @@ CompressedSIDDByteProvider::CompressedSIDDByteProvider(
     container->addData(data.clone());
 
     initialize(container, xmlRegistry, schemaPaths, bytesPerBlock,
-               maxProductSize, numRowsPerBlock, numColsPerBlock);
+               maxProductSize, compressionLevel, numRowsPerBlock,
+               numColsPerBlock);
 }
 
 CompressedSIDDByteProvider::CompressedSIDDByteProvider(

--- a/six/modules/c++/six/include/six/CompressedByteProvider.h
+++ b/six/modules/c++/six/include/six/CompressedByteProvider.h
@@ -61,7 +61,7 @@ protected:
      * \param bytesPerBlock A vector for each image segment. Each inner vector
      *        contains the compressed size for each block in the segment,
      *        in bytes.
-     * \param compressionRatio Ratio used for J2K compression
+     * \param isNumericallyLossless Flag whether compression was lossless
      * \param maxProductSize The max number of bytes in an image segment.
      * \param numRowsPerBlock The number of rows per block.  Only applies for
      * SIDD.  Defaults to no blocking.
@@ -72,7 +72,7 @@ protected:
                     const XMLControlRegistry& xmlRegistry,
                     const std::vector<std::string>& schemaPaths,
                     const std::vector<std::vector<size_t> >& bytesPerBlock,
-                    size_t compressionRatio,
+                    bool isNumericallyLossless,
                     size_t maxProductSize,
                     size_t numRowsPerBlock = 0,
                     size_t numColsPerBlock = 0);

--- a/six/modules/c++/six/include/six/CompressedByteProvider.h
+++ b/six/modules/c++/six/include/six/CompressedByteProvider.h
@@ -72,6 +72,7 @@ protected:
                     const std::vector<std::string>& schemaPaths,
                     const std::vector<std::vector<size_t> >& bytesPerBlock,
                     size_t maxProductSize,
+                    double compressionLevel = 1,
                     size_t numRowsPerBlock = 0,
                     size_t numColsPerBlock = 0);
 
@@ -90,6 +91,10 @@ protected:
     void initialize(const NITFWriteControl& writer,
                     const std::vector<std::string>& schemaPaths,
                     const std::vector<std::vector<size_t> >& bytesPerBlock);
+
+private:
+    void setCompression(int compressionLevel,
+                        nitf::Record& record);
 };
 }
 

--- a/six/modules/c++/six/include/six/CompressedByteProvider.h
+++ b/six/modules/c++/six/include/six/CompressedByteProvider.h
@@ -61,6 +61,7 @@ protected:
      * \param bytesPerBlock A vector for each image segment. Each inner vector
      *        contains the compressed size for each block in the segment,
      *        in bytes.
+     * \param compressionRatio Ratio used for J2K compression
      * \param maxProductSize The max number of bytes in an image segment.
      * \param numRowsPerBlock The number of rows per block.  Only applies for
      * SIDD.  Defaults to no blocking.
@@ -71,8 +72,8 @@ protected:
                     const XMLControlRegistry& xmlRegistry,
                     const std::vector<std::string>& schemaPaths,
                     const std::vector<std::vector<size_t> >& bytesPerBlock,
+                    size_t compressionRatio,
                     size_t maxProductSize,
-                    double compressionLevel = 1,
                     size_t numRowsPerBlock = 0,
                     size_t numColsPerBlock = 0);
 
@@ -91,10 +92,6 @@ protected:
     void initialize(const NITFWriteControl& writer,
                     const std::vector<std::string>& schemaPaths,
                     const std::vector<std::vector<size_t> >& bytesPerBlock);
-
-private:
-    void setCompression(int compressionLevel,
-                        nitf::Record& record);
 };
 }
 

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -60,7 +60,15 @@ public:
     //!  Keys that allow us to override the ILOC rules for tests
     static const char OPT_MAX_PRODUCT_SIZE[];
     static const char OPT_MAX_ILOC_ROWS[];
-    static const char OPT_J2K_COMPRESSION[];
+
+    // The following two options control how the `comrat` field is set
+
+    //! Bits/pixel/band for j2k compression
+    static const char OPT_J2K_COMPRESSION_BITRATE[];
+
+    //! True if numerically lossless, false for visually lossless
+    //! We assume visually lossy compression will not be used
+    static const char OPT_J2K_COMPRESSION_LOSSLESS[];
 
     //! These determine the NITF blocking
     //  They only pertain to SIDD

--- a/six/modules/c++/six/source/CompressedByteProvider.cpp
+++ b/six/modules/c++/six/source/CompressedByteProvider.cpp
@@ -33,9 +33,10 @@ size_t countCompresedBytes(
     size_t sum = 0;
     for (size_t ii = 0; ii < bytesPerBlock.size(); ++ii)
     {
-        for (size_t jj = 0; jj < bytesPerBlock[ii].size(); ++jj)
+        const std::vector<size_t>& bytesPerBlockInSegment = bytesPerBlock[ii];
+        for (size_t jj = 0; jj < bytesPerBlockInSegment.size(); ++jj)
         {
-            sum += bytesPerBlock[ii][jj];
+            sum += bytesPerBlockInSegment[jj];
         }
     }
     return sum;
@@ -53,7 +54,7 @@ void CompressedByteProvider::initialize(
         const XMLControlRegistry& xmlRegistry,
         const std::vector<std::string>& schemaPaths,
         const std::vector<std::vector<size_t> >& bytesPerBlock,
-        size_t compressionRatio,
+        bool isNumericallyLossless,
         size_t maxProductSize,
         size_t numRowsPerBlock,
         size_t numColsPerBlock)
@@ -66,7 +67,7 @@ void CompressedByteProvider::initialize(
             six::NITFWriteControl::OPT_J2K_COMPRESSION_BITRATE, bitrate);
     writer.getOptions().setParameter(
             six::NITFWriteControl::OPT_J2K_COMPRESSION_LOSSLESS,
-            compressionRatio == 1);
+            isNumericallyLossless);
     six::ByteProvider::populateWriter(container, xmlRegistry,
             maxProductSize, numRowsPerBlock, numColsPerBlock, writer);
 

--- a/six/modules/c++/six/source/CompressedByteProvider.cpp
+++ b/six/modules/c++/six/source/CompressedByteProvider.cpp
@@ -33,10 +33,13 @@ void CompressedByteProvider::initialize(
         const std::vector<std::string>& schemaPaths,
         const std::vector<std::vector<size_t> >& bytesPerBlock,
         size_t maxProductSize,
+        double compressionLevel,
         size_t numRowsPerBlock,
         size_t numColsPerBlock)
 {
     NITFWriteControl writer;
+    writer.getOptions().setParameter(
+            six::NITFWriteControl::OPT_J2K_COMPRESSION, compressionLevel);
     six::ByteProvider::populateWriter(container, xmlRegistry,
             maxProductSize, numRowsPerBlock, numColsPerBlock, writer);
 

--- a/six/modules/c++/six/source/NITFWriteControl.cpp
+++ b/six/modules/c++/six/source/NITFWriteControl.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include <iomanip>
 #include <sstream>
 
 #include <mem/ScopedArray.h>
@@ -305,15 +306,18 @@ void NITFWriteControl::initialize(mem::SharedPtr<Container> container)
                 subheader.getImageCompression().set("C8");
 
                 //calculate comrat
-                const int comratInt = (int)((j2kCompression * nbpp * 10.0) + 0.5);
-                const bool isNumericallyLossless = (bool)mOptions.getParameter(
-                        OPT_J2K_COMPRESSION_LOSSLESS, Parameter(false));
+                const int comratInt = static_cast<int>(
+                        (j2kCompression * nbpp * 10.0) + 0.5);
+                const bool isNumericallyLossless = static_cast<bool>(
+                        mOptions.getParameter(
+                        OPT_J2K_COMPRESSION_LOSSLESS, Parameter(false)));
                 // We are assuming the image is not compressed so heavily as
                 // to be visually lossy
                 const char comratChar = isNumericallyLossless ? 'N' : 'V';
+                std::stringstream comratStream;
+                comratStream << comratChar << std::setw(3) << comratInt;
+                subheader.getCompressionRate().set(comratStream.str());
 
-                const std::string comrat = FmtX("%c%03d", comratChar, comratInt);
-                subheader.getCompressionRate().set(comrat);
             }
         }
 

--- a/six/modules/c++/six/source/NITFWriteControl.cpp
+++ b/six/modules/c++/six/source/NITFWriteControl.cpp
@@ -23,6 +23,7 @@
 #include <iomanip>
 #include <sstream>
 
+#include <math/Round.h>
 #include <mem/ScopedArray.h>
 #include <io/ByteStream.h>
 #include <nitf/IOStreamWriter.hpp>
@@ -307,14 +308,14 @@ void NITFWriteControl::initialize(mem::SharedPtr<Container> container)
 
                 //calculate comrat
                 const int comratInt = static_cast<int>(
-                        (j2kCompression * nbpp * 10.0) + 0.5);
+                        math::round((j2kCompression * nbpp * 10.0)));
                 const bool isNumericallyLossless = static_cast<bool>(
                         mOptions.getParameter(
                         OPT_J2K_COMPRESSION_LOSSLESS, Parameter(false)));
                 // We are assuming the image is not compressed so heavily as
                 // to be visually lossy
                 const char comratChar = isNumericallyLossless ? 'N' : 'V';
-                std::stringstream comratStream;
+                std::ostringstream comratStream;
                 comratStream << comratChar << std::setw(3) << comratInt;
                 subheader.getCompressionRate().set(comratStream.str());
 


### PR DESCRIPTION
Before I write the Doxygen, I'm not really sure what the new compressionLevel param is setting. In NITFWriteControl.cpp:307 it's transformed to `int comratInt = (int)((j2kCompression * nbpp * 10.0) + 0.5);` It looks like the passed value is meant to be compression percentage. If the comrat field is meant to map to openjpeg's compression factor, it would be nice if there were some way to set it to 1 (which means lossless compression for openjpeg). If it's not mirroring the compression factor, then I'm not really sure how to populate it.