### PR TITLE
Fix arithmetic and formatting error

### DIFF
--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -63,8 +63,8 @@ public:
 
     // The following two options control how the `comrat` field is set
 
-    //! Bits/pixel/band for j2k compression
-    static const char OPT_J2K_COMPRESSION_BITRATE[];
+    //! Bytes/pixel/band for j2k compression
+    static const char OPT_J2K_COMPRESSION_BYTERATE[];
 
     //! True if numerically lossless, false for visually lossless
     //! We assume visually lossy compression will not be used

--- a/six/modules/c++/six/source/CompressedByteProvider.cpp
+++ b/six/modules/c++/six/source/CompressedByteProvider.cpp
@@ -27,7 +27,7 @@
 
 namespace
 {
-size_t countCompresedBytes(
+size_t countCompressedBytes(
         const std::vector<std::vector<size_t> >& bytesPerBlock)
 {
     size_t sum = 0;
@@ -60,11 +60,11 @@ void CompressedByteProvider::initialize(
         size_t numColsPerBlock)
 {
     NITFWriteControl writer;
-    const double bitrate =
-            (countCompresedBytes(bytesPerBlock) * 8 /
-             countUncompressedPixels(*container->getData(0)));
+    const double byterate =
+            static_cast<double>(countCompressedBytes(bytesPerBlock)) /
+             countUncompressedPixels(*container->getData(0));
     writer.getOptions().setParameter(
-            six::NITFWriteControl::OPT_J2K_COMPRESSION_BITRATE, bitrate);
+            six::NITFWriteControl::OPT_J2K_COMPRESSION_BYTERATE, byterate);
     writer.getOptions().setParameter(
             six::NITFWriteControl::OPT_J2K_COMPRESSION_LOSSLESS,
             isNumericallyLossless);

--- a/six/modules/c++/six/source/NITFWriteControl.cpp
+++ b/six/modules/c++/six/source/NITFWriteControl.cpp
@@ -91,7 +91,7 @@ namespace six
 {
 const char NITFWriteControl::OPT_MAX_PRODUCT_SIZE[] = "MaxProductSize";
 const char NITFWriteControl::OPT_MAX_ILOC_ROWS[] = "MaxILOCRows";
-const char NITFWriteControl::OPT_J2K_COMPRESSION_BITRATE[] = "J2KCompressionBitrate";
+const char NITFWriteControl::OPT_J2K_COMPRESSION_BYTERATE[] = "J2KCompressionByterate";
 const char NITFWriteControl::OPT_J2K_COMPRESSION_LOSSLESS[] = "J2KCompressionLossless";
 const char NITFWriteControl::OPT_NUM_ROWS_PER_BLOCK[] = "NumRowsPerBlock";
 const char NITFWriteControl::OPT_NUM_COLS_PER_BLOCK[] = "NumColsPerBlock";
@@ -146,7 +146,7 @@ void NITFWriteControl::initialize(mem::SharedPtr<Container> container)
     {
         // J2K only available for derived data
         j2kCompression = (double)mOptions.getParameter(
-                OPT_J2K_COMPRESSION_BITRATE, Parameter(0));
+                OPT_J2K_COMPRESSION_BYTERATE, Parameter(0));
         enableJ2K = (j2kCompression <= 1.0) && j2kCompression > 0.0001;
 
         // get row blocking parameters
@@ -316,7 +316,8 @@ void NITFWriteControl::initialize(mem::SharedPtr<Container> container)
                 // to be visually lossy
                 const char comratChar = isNumericallyLossless ? 'N' : 'V';
                 std::ostringstream comratStream;
-                comratStream << comratChar << std::setw(3) << comratInt;
+                comratStream << comratChar;
+                comratStream << std::setw(3) << std::setfill('0') << comratInt;
                 subheader.getCompressionRate().set(comratStream.str());
 
             }
@@ -858,7 +859,7 @@ void NITFWriteControl::save(
 
     // check to see if J2K compression is enabled
     double j2kCompression = (double)mOptions.getParameter(
-            OPT_J2K_COMPRESSION_BITRATE, Parameter(0));
+            OPT_J2K_COMPRESSION_BYTERATE, Parameter(0));
 
     bool enableJ2K = (mContainer->getDataType() != DataType::COMPLEX) &&
             (j2kCompression <= 1.0) && j2kCompression > 0.0001;


### PR DESCRIPTION
Previously, bytes/pixel/band was getting multiplied by 8 in CompressedByteProvider, then again in NITFWriteControl. Also need to 0-pad for comrat.