### PR TITLE
Define local output plane center pixel for multi-segment SICDs

### DIFF
--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -956,9 +956,14 @@ void Utilities::getProjectionPolys(NITFReadControl& reader,
         complexData->radarCollection->area->plane->xDirection->spacing,
         complexData->radarCollection->area->plane->yDirection->spacing);
 
+    types::RowCol<size_t> outputPlaneOffset;
+    types::RowCol<size_t> outputPlaneExtent;
+    complexData->getOutputPlaneOffsetAndExtent(
+        outputPlaneOffset, outputPlaneExtent);
+
     const types::RowCol<double> outputCenter(
-        complexData->radarCollection->area->plane->referencePoint.rowCol.row,
-        complexData->radarCollection->area->plane->referencePoint.rowCol.col);
+        0.5 * (static_cast<double>(outputPlaneExtent.row) - 1.0),
+        0.5 * (static_cast<double>(outputPlaneExtent.col) - 1.0));
 
     const types::RowCol<double> slantSampleSpacing(
         complexData->grid->row->sampleSpacing,


### PR DESCRIPTION
Adjusting the output plane center pixel based on the local output plane extent for a SICD segment. This shift ensures the (row,col) projection polynomials are consistent with the origination mesh. 