### PR TITLE
Fix how NITFWriteControl is constructed to work with NITFHeaderCreato…

### DIFF
--- a/six/modules/c++/samples/round_trip_six.cpp
+++ b/six/modules/c++/samples/round_trip_six.cpp
@@ -364,37 +364,36 @@ int main(int argc, char** argv)
             }
         }
 
-        six::NITFWriteControl writer;
+        six::Options writerOptions;
         if (!maxILOC.empty())
         {
-            writer.getOptions().setParameter(
+            writerOptions.setParameter(
                     six::NITFHeaderCreator::OPT_MAX_ILOC_ROWS,
                     maxILOC);
         }
         if (!maxSize.empty())
         {
-            writer.getOptions().setParameter(
+            writerOptions.setParameter(
                     six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE,
                     maxSize);
         }
 
         if (!rowsPerBlock.empty())
         {
-            writer.getOptions().setParameter(
+            writerOptions.setParameter(
                     six::NITFHeaderCreator::OPT_NUM_ROWS_PER_BLOCK,
                     rowsPerBlock);
         }
 
         if (!colsPerBlock.empty())
         {
-            writer.getOptions().setParameter(
+            writerOptions.setParameter(
                     six::NITFHeaderCreator::OPT_NUM_COLS_PER_BLOCK,
                     colsPerBlock);
         }
 
+        six::NITFWriteControl writer(writerOptions, container, &xmlRegistry);
         writer.setLogger(&log);
-        writer.initialize(container);
-        writer.setXMLControlRegistry(&xmlRegistry);
         writer.save(buffers.get(), outputFile, schemaPaths);
     }
     catch (const std::exception& ex)

--- a/six/modules/c++/samples/test_create_sicd.cpp
+++ b/six/modules/c++/samples/test_create_sicd.cpp
@@ -237,9 +237,8 @@ int main(int argc, char** argv)
         mem::SharedPtr<six::Container> container(new six::Container(
                 six::DataType::COMPLEX));
         container->addData(scopedData);
-        six::NITFWriteControl writer;
-        writer.setLogger(logger.get());
 
+        six::Options writerOptions;
         /*
          *  Under normal circumstances, the library uses the
          *  segmentation algorithm in the SICD spec, and numRowsLimit
@@ -254,14 +253,14 @@ int main(int argc, char** argv)
         if (maxRows > 0)
         {
             std::cout << "Overriding NITF max ILOC" << std::endl;
-            writer.getOptions().setParameter(six::NITFHeaderCreator::OPT_MAX_ILOC_ROWS,
+            writerOptions.setParameter(six::NITFHeaderCreator::OPT_MAX_ILOC_ROWS,
                                              maxRows);
 
         }
         if (maxSize > 0)
         {
             std::cout << "Overriding NITF product size" << std::endl;
-            writer.getOptions().setParameter(six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE,
+            writerOptions.setParameter(six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE,
                                              maxSize);
         }
 
@@ -270,11 +269,12 @@ int main(int argc, char** argv)
             (sys::isBigEndianSystem() && fileHeader->isDifferentByteOrdering())
          || (!sys::isBigEndianSystem() && !fileHeader->isDifferentByteOrdering());
 
-        writer.getOptions().setParameter(
+        writerOptions.setParameter(
                 six::WriteControl::OPT_BYTE_SWAP,
                 six::Parameter((sys::Uint16_T) needsByteSwap));
 
-        writer.initialize(container);
+        six::NITFWriteControl writer(writerOptions, container);
+        writer.setLogger(logger.get());
         std::vector<io::InputStream*> sources;
         sources.push_back(&sioReader);
 

--- a/six/modules/c++/samples/test_create_sicd_from_mem.cpp
+++ b/six/modules/c++/samples/test_create_sicd_from_mem.cpp
@@ -84,8 +84,6 @@ int main(int argc, char** argv)
         mem::SharedPtr<six::Container> container(new six::Container(
                 six::DataType::COMPLEX));
         container->addData(data);
-        six::NITFWriteControl writer;
-        writer.setLogger(logger.get());
 
         /*
          *  Under normal circumstances, the library uses the
@@ -99,10 +97,11 @@ int main(int argc, char** argv)
          *
          */
 
+        six::Options writerOptions;
         if (options->hasValue("maxRows"))
         {
             std::cout << "Overriding NITF max ILOC" << std::endl;
-            writer.getOptions().setParameter(
+            writerOptions.setParameter(
                     six::NITFHeaderCreator::OPT_MAX_ILOC_ROWS,
                     options->get<size_t>("maxRows"));
         }
@@ -110,12 +109,14 @@ int main(int argc, char** argv)
         if (options->hasValue("maxSize"))
         {
             std::cout << "Overriding NITF product size" << std::endl;
-            writer.getOptions().setParameter(
+            writerOptions.setParameter(
                     six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE,
                     options->get<size_t>("maxSize"));
         }
 
-        writer.initialize(container);
+
+        six::NITFWriteControl writer(writerOptions, container);
+        writer.setLogger(logger.get());
 
         six::BufferList buffers;
         buffers.push_back(reinterpret_cast<six::UByte*>(&image[0]));

--- a/six/modules/c++/samples/test_create_sidd_legend.cpp
+++ b/six/modules/c++/samples/test_create_sidd_legend.cpp
@@ -202,38 +202,32 @@ int main(int argc, char** argv)
 
         // Write it out
         {
-            six::NITFWriteControl writer;
-
-            writer.getOptions().setParameter(
+            six::Options options;
+            options.setParameter(
                     six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE,
                     str::toString(maxSize));
 
-            writer.setXMLControlRegistry(&xmlRegistry);
-            writer.initialize(container);
-
+            six::NITFWriteControl writer(options, container, &xmlRegistry);
             writer.save(buffers, outPathnamePrefix + "_unblocked.nitf");
         }
 
         // Write it out with blocking
         {
-            six::NITFWriteControl writer;
-
-            writer.getOptions().setParameter(
+            six::Options options;
+            options.setParameter(
                     six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE,
                     str::toString(maxSize));
 
             const std::string blockSize("23");
-            writer.getOptions().setParameter(
+            options.setParameter(
                     six::NITFHeaderCreator::OPT_NUM_ROWS_PER_BLOCK,
                     blockSize);
 
-            writer.getOptions().setParameter(
+            options.setParameter(
                     six::NITFHeaderCreator::OPT_NUM_COLS_PER_BLOCK,
                     blockSize);
 
-            writer.setXMLControlRegistry(&xmlRegistry);
-            writer.initialize(container);
-
+            six::NITFWriteControl writer(options, container, &xmlRegistry);
             writer.save(buffers, outPathnamePrefix + "_blocked.nitf");
         }
 

--- a/six/modules/c++/six.sicd/tests/test_sicd_byte_provider.cpp
+++ b/six/modules/c++/six.sicd/tests/test_sicd_byte_provider.cpp
@@ -106,11 +106,11 @@ private:
         }
     }
 
-    void setMaxProductSize(six::NITFWriteControl& writer)
+    void setMaxProductSize(six::Options& options)
     {
         if (mSetMaxProductSize)
         {
-            writer.getOptions().setParameter(
+            options.setParameter(
                     six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE, mMaxProductSize);
         }
     }
@@ -172,10 +172,9 @@ void Tester<DataTypeT>::normalWrite()
                            new six::XMLControlCreatorT<
                                    six::sicd::ComplexXMLControl>());
 
-    six::NITFWriteControl writer;
-    writer.setXMLControlRegistry(&xmlRegistry);
-    setMaxProductSize(writer);
-    writer.initialize(container);
+    six::Options options;
+    setMaxProductSize(options);
+    six::NITFWriteControl writer(options, container, &xmlRegistry);
 
     six::BufferList buffers;
     buffers.push_back(reinterpret_cast<six::UByte*>(&mImage[0]));

--- a/six/modules/c++/six.sicd/tests/test_streaming_write.cpp
+++ b/six/modules/c++/six.sicd/tests/test_streaming_write.cpp
@@ -120,11 +120,11 @@ private:
         }
     }
 
-    void setMaxProductSize(six::NITFWriteControl& writer)
+    void setMaxProductSize(six::Options& options)
     {
         if (mSetMaxProductSize)
         {
-            writer.getOptions().setParameter(
+            options.setParameter(
                     six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE, mMaxProductSize);
         }
     }
@@ -153,9 +153,9 @@ void Tester<DataTypeT>::normalWrite()
 {
     mContainer->addData(createData<DataTypeT>(mDims).release());
 
-    six::NITFWriteControl writer;
-    setMaxProductSize(writer);
-    writer.initialize(mContainer);
+    six::Options options;
+    setMaxProductSize(options);
+    six::NITFWriteControl writer(options, mContainer);
 
     six::BufferList buffers;
     buffers.push_back(reinterpret_cast<six::UByte*>(mImagePtr));
@@ -169,9 +169,10 @@ void Tester<DataTypeT>::testSingleWrite()
 {
     const EnsureFileCleanup ensureFileCleanup(mTestPathname);
 
+    six::Options options;
+    setMaxProductSize(options);
     six::sicd::SICDWriteControl sicdWriter(mTestPathname, mSchemaPaths);
-    setMaxProductSize(sicdWriter);
-    sicdWriter.initialize(mContainer);
+    sicdWriter.initialize(options, mContainer);
 
     sicdWriter.save(mImagePtr, types::RowCol<size_t>(0, 0), mDims);
     sicdWriter.close();
@@ -184,9 +185,10 @@ void Tester<DataTypeT>::testMultipleWritesOfFullRows()
 {
     const EnsureFileCleanup ensureFileCleanup(mTestPathname);
 
+    six::Options options;
+    setMaxProductSize(options);
     six::sicd::SICDWriteControl sicdWriter(mTestPathname, mSchemaPaths);
-    setMaxProductSize(sicdWriter);
-    sicdWriter.initialize(mContainer);
+    sicdWriter.initialize(options, mContainer);
 
     // Rows [40, 60)
     types::RowCol<size_t> offset(40, 0);
@@ -234,9 +236,11 @@ void Tester<DataTypeT>::testMultipleWritesOfPartialRows()
 {
     const EnsureFileCleanup ensureFileCleanup(mTestPathname);
 
+    six::Options options;
+    setMaxProductSize(options);
+
     six::sicd::SICDWriteControl sicdWriter(mTestPathname, mSchemaPaths);
-    setMaxProductSize(sicdWriter);
-    sicdWriter.initialize(mContainer);
+    sicdWriter.initialize(options, mContainer);
 
     // Rows [40, 60)
     // Cols [400, 456)

--- a/six/modules/c++/six.sidd/tests/test_byte_swap.cpp
+++ b/six/modules/c++/six.sidd/tests/test_byte_swap.cpp
@@ -98,9 +98,9 @@ void write(const sys::Int16_T* data, bool useStream, bool byteSwap)
             six::DataType::DERIVED));
     container->addData(createData().release());
 
-    six::NITFWriteControl writer;
-    writer.getOptions().setParameter(six::WriteControl::OPT_BYTE_SWAP, static_cast<int>(byteSwap));
-    writer.initialize(container);
+    six::Options options;
+    options.setParameter(six::WriteControl::OPT_BYTE_SWAP, static_cast<int>(byteSwap));
+    six::NITFWriteControl writer(options, container);
 
     if (useStream)
     {

--- a/six/modules/c++/six.sidd/tests/test_check_blocking.cpp
+++ b/six/modules/c++/six.sidd/tests/test_check_blocking.cpp
@@ -82,14 +82,15 @@ void writeSingleImage(const six::Data& data, const std::string& pathname,
     six::BufferList buffers(1);
     buffers[0] = buffer.get();
 
-    six::NITFWriteControl writer;
-    writer.getOptions().setParameter(
+    six::Options options;
+    options.setParameter(
             six::NITFHeaderCreator::OPT_NUM_ROWS_PER_BLOCK, blockSize);
-    writer.getOptions().setParameter(
+    options.setParameter(
             six::NITFHeaderCreator::OPT_NUM_COLS_PER_BLOCK, blockSize);
-    writer.getOptions().setParameter(
+    options.setParameter(
             six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE, productSize);
-    writer.initialize(container);
+
+    six::NITFWriteControl writer(options, container);
     writer.save(buffers, pathname, std::vector<std::string>());
 
 }
@@ -124,14 +125,15 @@ void writeTwoImages(const six::Data& data, const std::string& pathname,
     buffers[0] = firstBuffer.get();
     buffers[1] = secondBuffer.get();
 
-    six::NITFWriteControl writer;
-    writer.getOptions().setParameter(
+    six::Options options;
+    options.setParameter(
             six::NITFHeaderCreator::OPT_NUM_ROWS_PER_BLOCK, blockSize);
-    writer.getOptions().setParameter(
+    options.setParameter(
             six::NITFHeaderCreator::OPT_NUM_COLS_PER_BLOCK, blockSize);
-    writer.getOptions().setParameter(
+    options.setParameter(
             six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE, productSize);
-    writer.initialize(container);
+
+    six::NITFWriteControl writer(options, container);
     writer.save(buffers, pathname, std::vector<std::string>());
 }
 

--- a/six/modules/c++/six.sidd/tests/test_sidd_byte_provider.cpp
+++ b/six/modules/c++/six.sidd/tests/test_sidd_byte_provider.cpp
@@ -260,25 +260,25 @@ private:
         }
     }
 
-    void setWriterOptions(six::NITFWriteControl& writer)
+    void setWriterOptions(six::Options& options)
     {
         if (mSetMaxProductSize)
         {
-            writer.getOptions().setParameter(
+            options.setParameter(
                     six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE,
                     mMaxProductSize);
         }
 
         if (mNumRowsPerBlock != 0)
         {
-            writer.getOptions().setParameter(
+            options.setParameter(
                     six::NITFHeaderCreator::OPT_NUM_ROWS_PER_BLOCK,
                     mNumRowsPerBlock);
         }
 
         if (mNumColsPerBlock != 0)
         {
-            writer.getOptions().setParameter(
+            options.setParameter(
                     six::NITFHeaderCreator::OPT_NUM_COLS_PER_BLOCK,
                     mNumColsPerBlock);
         }
@@ -373,10 +373,9 @@ void Tester<DataTypeT>::normalWrite()
                            new six::XMLControlCreatorT<
                                    six::sidd::DerivedXMLControl>());
 
-    six::NITFWriteControl writer;
-    writer.setXMLControlRegistry(&xmlRegistry);
-    setWriterOptions(writer);
-    writer.initialize(container);
+    six::Options options;
+    setWriterOptions(options);
+    six::NITFWriteControl writer(options, container, &xmlRegistry);
 
     six::BufferList buffers;
     buffers.push_back(reinterpret_cast<six::UByte*>(&mImage[0]));

--- a/six/modules/c++/six.sidd/unittests/test_read_sidd_legend.cpp
+++ b/six/modules/c++/six.sidd/unittests/test_read_sidd_legend.cpp
@@ -232,15 +232,12 @@ struct TestHelper
         buffers.push_back(buffer4.get());
 
         // Write it out
-        six::NITFWriteControl writer;
-
-        writer.getOptions().setParameter(
+        six::Options options;
+        options.setParameter(
                 six::NITFHeaderCreator::OPT_MAX_PRODUCT_SIZE,
                 str::toString(maxSize));
 
-        writer.setXMLControlRegistry(&mXmlRegistry);
-        writer.initialize(container);
-
+        six::NITFWriteControl writer(options, container, &mXmlRegistry);
         writer.save(buffers, mPathname);
     }
 

--- a/six/modules/c++/six/include/six/ByteProvider.h
+++ b/six/modules/c++/six/include/six/ByteProvider.h
@@ -64,13 +64,22 @@ public:
                  const std::vector<std::string>& schemaPaths,
                  const std::vector<PtrAndLength>& desBuffers);
 
-    static void populateWriter(
+    /*!
+     * Populates the writer Options from given parameters
+     * \param container Container holding Data object
+     * \param maxProductSize Maximum size of image segment in bytes
+     * \param numRowsPerBlock Rows per block. Will be truncated if greater than
+     *        num rows in image
+     * \param numColsPerBlock Cols per block. Will be truncated if greater than
+     *        num cols in image
+     * \param[out] options Options to populate
+     */
+    static void populateOptions(
             mem::SharedPtr<Container> container,
-            const XMLControlRegistry& xmlRegistry,
             size_t maxProductSize,
             size_t numRowsPerBlock,
             size_t numColsPerBlock,
-            NITFWriteControl& writer);
+            Options& options);
 
     /*!
      * Compute the XML metadata, data extension segment (DES) buffers,

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -115,10 +115,12 @@ public:
     }
 
     //! \return Mutable NITF options
+    /*
     six::Options& getOptions()
     {
         return mNITFHeaderCreator->getOptions();
     }
+    */
 
     //! \return Const NITF options
     const six::Options& getOptions() const

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -114,14 +114,6 @@ public:
         return mNITFHeaderCreator->getContainer();
     }
 
-    //! \return Mutable NITF options
-    /*
-    six::Options& getOptions()
-    {
-        return mNITFHeaderCreator->getOptions();
-    }
-    */
-
     //! \return Const NITF options
     const six::Options& getOptions() const
     {

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -62,9 +62,11 @@ public:
      * Constructor. Calls initialize.
      * \param options Initialization options
      * \param container The data container
+     * \param xmlRegistry Optional XMLControlRegistry
      */
     NITFWriteControl(const six::Options& options,
-                     mem::SharedPtr<Container> container);
+                     mem::SharedPtr<Container> container,
+                     const XMLControlRegistry* xmlRegistry = NULL);
 
     //!  We are a 'NITF'
     std::string getFileType() const
@@ -77,6 +79,13 @@ public:
     {
         return mNITFHeaderCreator->getRecord();
     }
+
+    /*!
+     * Sets XMLControlRegistry. Overriding so we can pass to NITFHeaderCreator
+     * as well.
+     * \param xmlRegistry XMLControlRegistry to set
+     */
+    virtual void setXMLControlRegistry(const XMLControlRegistry* xmlRegistry);
 
     // Get the record that was generated during initialization
     nitf::Record& getRecord()
@@ -131,10 +140,10 @@ public:
      * \param headerCreator Populated NITF header creator
      */
     void setNITFHeaderCreator(std::auto_ptr<six::NITFHeaderCreator> headerCreator);
-  
+
     virtual void initialize(const six::Options& options,
                             mem::SharedPtr<Container> container);
-  
+
     virtual void initialize(mem::SharedPtr<Container> container);
 
     using WriteControl::save;
@@ -478,6 +487,7 @@ private:
                        size_t segmentNum,
                        size_t numImageSegments,
                        size_t productNum);
+
 private:
     //! Noncopyable
     NITFWriteControl(const NITFWriteControl& );

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -85,7 +85,10 @@ public:
      * as well.
      * \param xmlRegistry XMLControlRegistry to set
      */
-    virtual void setXMLControlRegistry(const XMLControlRegistry* xmlRegistry);
+    virtual void setXMLControlRegistry(const XMLControlRegistry* xmlRegistry)
+    {
+        setXMLControlRegistryImpl(xmlRegistry);
+    }
 
     // Get the record that was generated during initialization
     nitf::Record& getRecord()
@@ -431,6 +434,8 @@ protected:
     }
 
     bool shouldByteSwap() const;
+
+    void setXMLControlRegistryImpl(const XMLControlRegistry* xmlRegistry);
 
 private:
     /*!

--- a/six/modules/c++/six/include/six/WriteControl.h
+++ b/six/modules/c++/six/include/six/WriteControl.h
@@ -227,7 +227,7 @@ public:
         mOwnLog = log ? ownLog : true;
     }
 
-    void setXMLControlRegistry(const XMLControlRegistry* xmlRegistry)
+    virtual void setXMLControlRegistry(const XMLControlRegistry* xmlRegistry)
     {
         mXMLRegistry = xmlRegistry;
         if (!mXMLRegistry)

--- a/six/modules/c++/six/include/six/WriteControl.h
+++ b/six/modules/c++/six/include/six/WriteControl.h
@@ -229,9 +229,7 @@ public:
 
     virtual void setXMLControlRegistry(const XMLControlRegistry* xmlRegistry)
     {
-        mXMLRegistry = xmlRegistry;
-        if (!mXMLRegistry)
-            mXMLRegistry = &XMLControlFactory::getInstance();
+        setXMLControlRegistryImpl(xmlRegistry);
     }
 
     //! \return XML registry being used by the writer
@@ -254,6 +252,12 @@ public:
     }
 
 protected:
+    void setXMLControlRegistryImpl(const XMLControlRegistry* xmlRegistry)
+    {
+        mXMLRegistry = xmlRegistry;
+        if (!mXMLRegistry)
+            mXMLRegistry = &XMLControlFactory::getInstance();
+    }
     mem::SharedPtr<Container> mContainer;
     Options mOptions;
     logging::Logger *mLog;

--- a/six/modules/c++/six/source/CompressedByteProvider.cpp
+++ b/six/modules/c++/six/source/CompressedByteProvider.cpp
@@ -59,17 +59,19 @@ void CompressedByteProvider::initialize(
         size_t numRowsPerBlock,
         size_t numColsPerBlock)
 {
-    NITFWriteControl writer(container);
     const double byterate =
             static_cast<double>(countCompressedBytes(bytesPerBlock)) /
              countUncompressedPixels(*container->getData(0));
-    writer.getOptions().setParameter(
+    Options options;
+    options.setParameter(
             six::NITFHeaderCreator::OPT_J2K_COMPRESSION_BYTERATE, byterate);
-    writer.getOptions().setParameter(
+    options.setParameter(
             six::NITFHeaderCreator::OPT_J2K_COMPRESSION_LOSSLESS,
             isNumericallyLossless);
-    six::ByteProvider::populateWriter(container, xmlRegistry,
-            maxProductSize, numRowsPerBlock, numColsPerBlock, writer);
+    six::ByteProvider::populateOptions(container,
+            maxProductSize, numRowsPerBlock, numColsPerBlock, options);
+
+    NITFWriteControl writer(options, container, &xmlRegistry);
 
     initialize(writer, schemaPaths, bytesPerBlock);
 }

--- a/six/modules/c++/six/source/NITFWriteControl.cpp
+++ b/six/modules/c++/six/source/NITFWriteControl.cpp
@@ -49,14 +49,15 @@ NITFWriteControl::NITFWriteControl(const six::Options& options,
     mNITFHeaderCreator.reset(new six::NITFHeaderCreator(options, container));
     if (xmlRegistry)
     {
-        setXMLControlRegistry(xmlRegistry);
+        // Indirecting through *Impl to avoid virtual function call in ctor
+        setXMLControlRegistryImpl(xmlRegistry);
     }
 }
 
-void NITFWriteControl::setXMLControlRegistry(const XMLControlRegistry* xmlRegistry)
+void NITFWriteControl::setXMLControlRegistryImpl(const XMLControlRegistry* xmlRegistry)
 {
     mNITFHeaderCreator->setXMLControlRegistry(xmlRegistry);
-    WriteControl::setXMLControlRegistry(xmlRegistry);
+    WriteControl::setXMLControlRegistryImpl(xmlRegistry);
 }
 
 void NITFWriteControl::initialize(const six::Options& options,


### PR DESCRIPTION
…r initialization

This fixes the the bug, but I want to propose a couple broader changes to prevent similar bugs. 

We don't need the mutable versions of `getOptions()`. The options are used in initialization, so we shouldn't be able to change them later. Just set it up how you need it before giving it to `NITFWriteControl`.

Instead of having stuff like 

    NITFWriteControl::getOptions() { return mNITFHeaderCreator->getOptions(); }

`NITFWriteControl` should just own everything (so we don't have to worry about keeping the parent class up to date), and `NITFHeaderCreator` should hang on to all its dependencies by a reference or non-owning pointer. 

This last suggestion is a bit of a long-shot, but it seems needlessly complicated to make the caller have to keep track of when and whether to call `initialize()`. It would be nice to just rework all the `WriteControl` stuff to not even have a public `initialize()` method and just remove the constructors that allow it to be in an invalid state afterward. Probably not worth the effort, but I get a bit grumpy whenever I have to work this out again....

(I suppose no one will see this for a couple more days, so I'll start working on a new PR for the first two points...)