### PR TITLE
Disable expensive test if on Windows

### DIFF
--- a/six/modules/python/six/tests/runTests.py
+++ b/six/modules/python/six/tests/runTests.py
@@ -144,8 +144,10 @@ def run(sourceDir):
                 siddTestRunner.run('test_sidd_byte_provider')):
             return False
 
-        if not sampleTestRunner.run('test_large_offset'):
-            return False
+        # This test is too expensive for Windows to handle
+        if platform.system() != 'Windows':
+            if not sampleTestRunner.run('test_large_offset'):
+                return False
 
         if not sampleTestRunner.run(
                 'test_create_sidd_with_compressed_byte_provider'):


### PR DESCRIPTION
Disable test that uses too much memory and crashes Jenkins