### PR TITLE
262 use valid data polygon when fitting projection polynomials

### DIFF
--- a/six/modules/c++/scene/include/scene/ProjectionPolynomialFitter.h
+++ b/six/modules/c++/scene/include/scene/ProjectionPolynomialFitter.h
@@ -76,8 +76,8 @@ public:
      * with respect to a global space.  This basically translates to the
      * segment's startLine/startSample values for a multi-segment SICD).
      * \param outExtent Output extent in pixels
-     * \param polygon The output plane polygon to use to determine the grid of
-     * points.
+     * \param polygon The polygon of output plane pixel coordinate used to
+     * determine the grid of points.
      * \param numPoints1D Number of points to use in each direction when
      * sampling the grid.  Defaults to 10.
      */
@@ -318,6 +318,13 @@ public:
     }
 
 private:
+    void projectToSlantPlane(const ProjectionModel& projModel,
+                             const GridECEFTransform& gridTransform,
+                             const types::RowCol<double>& outPixelStart,
+                             const types::RowCol<double>& currentOffset,
+                             size_t row,
+                             size_t col);
+
     void getSlantPlaneSamples(
             const types::RowCol<size_t>& inPixelStart,
             const types::RowCol<double>& inSceneCenter,

--- a/six/modules/c++/scene/include/scene/ProjectionPolynomialFitter.h
+++ b/six/modules/c++/scene/include/scene/ProjectionPolynomialFitter.h
@@ -63,6 +63,33 @@ public:
             const types::RowCol<size_t>& outExtent,
             size_t numPoints1D = DEFAULTS_POINTS_1D);
 
+    /* Samples a numPoints1D x numPoints1D grid of points that spans
+     * the extent of a polygon using sceneToImage().
+     *
+     * \param projModel Projection model that knows how to use sceneToImage()
+     * to convert from an ECEF location to meters from the slant plane SCP
+     * \param gridTransform Transform that knows how to convert from
+     * output row/col pixel space to ECEF space
+     * \param fullExtent Full extent of the global output plane.
+     * \param outPixelStart Output space start pixel (i.e. if this is
+     * non-zero, it indicates the reference point used with gridTransform is
+     * with respect to a global space.  This basically translates to the
+     * segment's startLine/startSample values for a multi-segment SICD).
+     * \param outExtent Output extent in pixels
+     * \param polygon The output plane polygon to use to determine the grid of
+     * points.
+     * \param numPoints1D Number of points to use in each direction when
+     * sampling the grid.  Defaults to 10.
+     */
+    ProjectionPolynomialFitter(
+            const ProjectionModel& projModel,
+            const GridECEFTransform& gridTransform,
+            const types::RowCol<size_t>& fullExtent,
+            const types::RowCol<double>& outPixelStart,
+            const types::RowCol<size_t>& outExtent,
+            const std::vector<types::RowCol<double> >& polygon,
+            size_t numPoints1D = DEFAULTS_POINTS_1D);
+
     // Returns the output plane rows used during sampling in case you want to
     // do your own polynomial fitting
     const math::linear::Matrix2D<double>& getOutputPlaneRows() const

--- a/six/modules/c++/scene/source/ProjectionPolynomialFitter.cpp
+++ b/six/modules/c++/scene/source/ProjectionPolynomialFitter.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <scene/ProjectionPolynomialFitter.h>
+#include <draw/PolygonMask.h>
 
 namespace
 {
@@ -98,6 +99,143 @@ ProjectionPolynomialFitter::ProjectionPolynomialFitter(
             mSceneCoordinates(ii, jj) =
                     projModel.sceneToImage(sPos, &timeCOA);
             mTimeCOA(ii, jj) = timeCOA;
+        }
+    }
+}
+
+ProjectionPolynomialFitter::ProjectionPolynomialFitter(
+        const ProjectionModel& projModel,
+        const GridECEFTransform& gridTransform,
+        const types::RowCol<size_t>& outExtent,
+        const types::RowCol<double>& outPixelStart,
+        const types::RowCol<size_t>& outExtent,
+        const std::vector<types::RowCol<double> >& polygon,
+        size_t numPoints1D) :
+    mNumPoints1D(numPoints1D),
+    mOutputPlaneRows(numPoints1D, numPoints1D),
+    mOutputPlaneCols(numPoints1D, numPoints1D),
+    mSceneCoordinates(numPoints1D,
+                      numPoints1D,
+                      types::RowCol<double>(0.0, 0.0)),
+    mTimeCOA(numPoints1D, numPoints1D)
+{
+    // Get bounding rectangle of output plane polygon.
+    double minRow =  std::numeric_limits<double>::max();
+    double maxRow = -std::numeric_limits<double>::max();
+    double minCol =  std::numeric_limits<double>::max();
+    double maxCol = -std::numeric_limits<double>::max();
+
+    for (size_t ii = 0; ii < polygon.size(); ++ii)
+    {
+        minRow = std::min(minRow, polygon[ii].row);
+        maxRow = std::max(maxRow, polygon[ii].row);
+        minCol = std::min(minCol, polygon[ii].col);
+        maxCol = std::max(maxCol, polygon[ii].col);
+    }
+
+    minRow = std::max(0.0, minRow);
+    minCol = std::max(0.0, minCol);
+
+    // Get size_t extent of the set of points.
+    const size_t minRowI = static_cast<size_t>(std::ceil(minRow));
+    const size_t minColI = static_cast<size_t>(std::ceil(minCol));
+    const size_t maxRowI = static_cast<size_t>(std::floor(maxRow));
+    const size_t maxColI = static_cast<size_t>(std::floor(maxCol));
+
+    if (minRowI > maxRowI || minColI > maxColI)
+    {
+        throw except::Exception(Ctxt(
+            "Bounding rectangle has no area"));
+    }
+
+    // The offset and extent are relative to the entire global output plane.
+    types::RowCol<double> boundingOffset(
+        static_cast<double>(minRowI),
+        static_cast<double>(minColI));
+    types::RowCol<size_t> boundingExtent(maxRowI - minRowI + 1,
+                                         maxColI - minColI + 1);
+
+    // No offset for the polygon mask.
+    types::RowCol<sys::SSize_T> pmOffset(0,0);
+
+    // Get the PolygonMas. For each row of the polygon this will determine
+    // the first and last column of the row inside the convex hull of the
+    // polygon sent in.
+    draw::PolygonMask polygonMask(polygon, fullExtent, pmOffset);
+    
+    // Compute a delta in the row direction as if the entire bounding row 
+    // extent will be covered by the point grid.
+    const double initialDeltaRow =
+        static_cast<double>(boundingExtent.row - 1) / (numPoints1D - 1);
+
+    // Scale factor for shrinking the row extent.
+    const double shrinkFactor = 0.1;
+
+    // Shring the row extent a bit.
+    const double deltaToRemove = initialDeltaRow * shrinkFactor;
+
+    // Get the new row start and end values.
+    const size_t newStartRow = static_cast<size_t>(
+        std::ceil(boundingOffset.row + deltaToRemove));
+    const size_t newEndRow = static_cast<size_t>(
+        std::floor(boundingOffset.row + boundingExtent.row - 1 -
+                   deltaToRemove));
+
+    // Check the new row extent.
+    if (newStartRow > newEndRow)
+    {
+        throw except::Exception(Ctxt(
+            "New bounding rectangle has no area"));
+    }
+
+    // Compute the row exent.
+    const size_t newExtentRow = (newEndRow - newStartRow + 1);
+    
+    // Compute the delta in the row direction for the new extent.
+    const double newDeltaRow =
+         static_cast<double>(newExtentRow - 1) / 
+         static_cast<double>(numPoints1D - 1);
+
+    double currentOffsetRow = static_cast<double>(newStartRow);
+    for (size_t ii = 0; ii < numPoints1D; ++ii, currentOffsetRow += newDeltaRow)
+    {
+        double currentRow = std::floor(currentOffsetRow);
+        size_t row = static_cast<size_t>(currentRow);
+
+        // Get the start column and number of columns inside the polygon row
+        // the current row.
+        const types::Range colRange = polygonMask.getRange(row);
+
+        // Check that there are internal points.
+        if (colRange.mNumElements == 0)
+        {
+            throw except::Exception(Ctxt(
+                "Column range has no elements"));
+        }
+
+        // Compute the delta in the column direction to cover the internal
+        // points.
+        const double newDeltaCol =
+            static_cast<double>(colRange.mNumElements - 1) /
+            static_cast<double>(numPoints1D - 1);
+
+        double currentCol = static_cast<double>(colRange.mStartElement);
+        for (size_t jj = 0; jj < numPoints1D; ++jj, currentCol += newDeltaCol)
+        {
+            const type::RowCol<double> currentOffset(currentRow, currentCol);
+
+            // Get the coordinate relative to the outPixelStart.
+            mOutputPlaneRows(ii, jj) = currentOffset.row - outputPixelStart.row;
+            mOutputPlaneCols(ii, jj) = currentOffset.col - outputPixelStart.col;
+
+            // Find ECEF of the output plane pixel.
+            const scene::Vector3 ecef =
+                gridTransform.rowColToECEF(currentOffset);
+
+            // Project ECEF coordinate into the slant plane and get meters from
+            // the slant plane scene center point.
+            double timeCOA = 0.0;
+            mSceneCoordinates(ii, jj) = projModel.sceneToImage(ecef, &timeCOA);
         }
     }
 }

--- a/six/modules/c++/scene/wscript
+++ b/six/modules/c++/scene/wscript
@@ -1,6 +1,6 @@
 NAME            = 'scene'
 MAINTAINER      = 'adam.sylvester@mdaus.com'
-MODULE_DEPS     = 'io math math.linear math.poly types draw'
+MODULE_DEPS     = 'io math math.linear math.poly types polygon'
 TEST_FILTER     = 'test_scene.cpp'
 
 options = configure = distclean = lambda p: None

--- a/six/modules/c++/scene/wscript
+++ b/six/modules/c++/scene/wscript
@@ -1,6 +1,6 @@
 NAME            = 'scene'
 MAINTAINER      = 'adam.sylvester@mdaus.com'
-MODULE_DEPS     = 'io math math.linear math.poly types'
+MODULE_DEPS     = 'io math math.linear math.poly types draw'
 TEST_FILTER     = 'test_scene.cpp'
 
 options = configure = distclean = lambda p: None

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -67,7 +67,7 @@ public:
     static std::auto_ptr<scene::ProjectionPolynomialFitter>
     getPolynomialFitter(const ComplexData& complexData,
                         size_t numPoints1D =
-                          scene::ProjectionPolynomialFitter::DEFAULT_POINTS_1D);
+                         scene::ProjectionPolynomialFitter::DEFAULTS_POINTS_1D);
 
     /*!
      * Build ProjectionPolynomialFitter from complexData. Use the valid data
@@ -80,7 +80,7 @@ public:
     getPolynomialFitterVDP(
         const ComplexData& complexData,
         size_t numPoints1D =
-            scene::ProjectionPolynomialFitter::DEFAULT_POINTS_1D);
+            scene::ProjectionPolynomialFitter::DEFAULTS_POINTS_1D);
 
     /*
      * If the SICD contains a valid data polygon, provides this.
@@ -578,8 +578,8 @@ public:
      */
     static void projectPixelsToSlantPlane(
         const six::sicd::ComplexData& complexData,
-        const std::vector<types::RowCol<double> >& spPixels,
-        std::vector<types::RowCol<double> >& opPixels);
+        const std::vector<types::RowCol<double> >& opPixels,
+        std::vector<types::RowCol<double> >& spPixels);
 };
 }
 }

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -61,10 +61,26 @@ public:
      * given GriddedDisplayType.
      * This always uses a PlanarGridECEFTransform
      * \param complexData ComplexData from which to construct fitter
+     * \param numPoints1D Number of points to use in each direction of grid.
      * \return ProjectionPolynomialFitter from ComplexData
      */
     static std::auto_ptr<scene::ProjectionPolynomialFitter>
-    getPolynomialFitter(const ComplexData& complexData);
+    getPolynomialFitter(const ComplexData& complexData,
+                        size_t numPoints1D =
+                          scene::ProjectionPolynomialFitter::DEFAULT_POINTS_1D);
+
+    /*!
+     * Build ProjectionPolynomialFitter from complexData. Use the valid data
+     * polygon to constrain the grid points.
+     * \param complexData ComplexData from which to construct fitter
+     * \param numPoints1D Number of points to use in each direction of grid.
+     * \return ProjectionPolynomialFitter from ComplexData
+     */
+    static std::auto_ptr<scene::ProjectionPolynomialFitter>
+    getPolynomialFitterVDP(
+        const ComplexData& complexData,
+        size_t numPoints1D =
+            scene::ProjectionPolynomialFitter::DEFAULT_POINTS_1D);
 
     /*
      * If the SICD contains a valid data polygon, provides this.
@@ -411,6 +427,7 @@ public:
      * \param reader A NITFReadControl loaded with the desired SICD
      * \param orderX X order of fitted polynomials.
      * \param orderY Y order of fitted polynomials.
+     * \param complexData ComplexData from which to construct fitter
      * \param[out] outputRowColToSlantRow Projection polynomial taking
      *  (row, column) coordinate in the output plane image as input
      *  and returning the projected row coordinate in the slant plane
@@ -531,6 +548,38 @@ public:
             six::Poly2D& outputXYToSlantY,                  
             six::Poly2D& slantXYToOutputX,                  
             six::Poly2D& slantXYToOutputY);
+
+    /*!
+     * Project slan plane pixel locations to the output plane pixel locations.
+     * \param complexData Complex metadata.
+     * \param spPixels Slant plane pixel coordinates.
+     * \param opPixels Output plane pixel coordinates.
+     */
+    static void projectPixelsToOutputPlane(
+        const six::sicd::ComplexData& complexData,
+        const std::vector<types::RowCol<double> >& spPixels,
+        std::vector<types::RowCol<double> >& opPixels);
+
+    /*!
+     * Project slant plane valid data polygon pixel locations to output
+     * plane pixel locations.
+     * \param complexData Complex metadata.
+     * \param opPixels Output plane pixel coordinates.
+     */
+    static void projectValidDataPolygonToOutputPlane(
+        const six::sicd::ComplexData& complexData,
+        std::vector<types::RowCol<double> >& opPixels);
+
+    /*!
+     * Project output plane pixel locations to slant plane pixel locations.
+     * \param complexData Complex metadata.
+     * \param opPixels Output plane pixel coordinates.
+     * \param spPixels Slant plane pixel coordinates.
+     */
+    static void projectPixelsToSlantPlane(
+        const six::sicd::ComplexData& complexData,
+        const std::vector<types::RowCol<double> >& spPixels,
+        std::vector<types::RowCol<double> >& opPixels);
 };
 }
 }

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -32,6 +32,7 @@
 #include <six/sicd/ComplexData.h>
 #include <six/sicd/SICDMesh.h>
 #include <six/NITFReadControl.h>
+#include <six/sicd/AreaPlaneUtility.h>
 
 namespace six
 {
@@ -57,30 +58,29 @@ public:
             const scene::SceneGeometry* geom);
 
     /*!
+     * Get information in or deriveable from the ComplexData.
+     */
+    static void getModelComponents(
+        const ComplexData& complexData,
+        std::auto_ptr<scene::SceneGeometry>& geometry,
+        std::auto_ptr<scene::ProjectionModel>& projectionModel,
+        six::sicd::AreaPlane& areaPlane);
+
+    /*!
      * Build ProjectionPolynomialFitter from complexData and
      * given GriddedDisplayType.
      * This always uses a PlanarGridECEFTransform
      * \param complexData ComplexData from which to construct fitter
      * \param numPoints1D Number of points to use in each direction of grid.
+     * \param sampleWithinValidDataPolygon Only get grid sample points from
+     * with the valid data polygon.
      * \return ProjectionPolynomialFitter from ComplexData
      */
     static std::auto_ptr<scene::ProjectionPolynomialFitter>
     getPolynomialFitter(const ComplexData& complexData,
                         size_t numPoints1D =
-                         scene::ProjectionPolynomialFitter::DEFAULTS_POINTS_1D);
-
-    /*!
-     * Build ProjectionPolynomialFitter from complexData. Use the valid data
-     * polygon to constrain the grid points.
-     * \param complexData ComplexData from which to construct fitter
-     * \param numPoints1D Number of points to use in each direction of grid.
-     * \return ProjectionPolynomialFitter from ComplexData
-     */
-    static std::auto_ptr<scene::ProjectionPolynomialFitter>
-    getPolynomialFitterVDP(
-        const ComplexData& complexData,
-        size_t numPoints1D =
-            scene::ProjectionPolynomialFitter::DEFAULTS_POINTS_1D);
+                         scene::ProjectionPolynomialFitter::DEFAULTS_POINTS_1D,
+                        bool sampleWithinValidDataPolygon = false);
 
     /*
      * If the SICD contains a valid data polygon, provides this.
@@ -550,7 +550,7 @@ public:
             six::Poly2D& slantXYToOutputY);
 
     /*!
-     * Project slan plane pixel locations to the output plane pixel locations.
+     * Project slant plane pixel locations to the output plane pixel locations.
      * \param complexData Complex metadata.
      * \param spPixels Slant plane pixel coordinates.
      * \param opPixels Output plane pixel coordinates.

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -267,7 +267,8 @@ Utilities::getProjectionModel(const ComplexData* data,
 }
 
 std::auto_ptr<scene::ProjectionPolynomialFitter>
-Utilities::getPolynomialFitter(const ComplexData& complexData)
+Utilities::getPolynomialFitter(const ComplexData& complexData,
+                               size_t numPoints1D)
 {
     std::auto_ptr<scene::SceneGeometry> geometry(
             getSceneGeometry(&complexData));
@@ -300,7 +301,56 @@ Utilities::getPolynomialFitter(const ComplexData& complexData)
                 *projectionModel,
                 ecefTransform,
                 offset,
-                extent));
+                extent,
+                numPoints1D));
+}
+
+std::auto_ptr<scene::ProjectionPolynomialFitter>
+Utilities::getPolynomialFitterVDP(const ComplexData& complexData,
+                               size_t numPoints1D)
+{
+    std::auto_ptr<scene::SceneGeometry> geometry(
+            getSceneGeometry(&complexData));
+    std::auto_ptr<scene::ProjectionModel> projectionModel(
+            getProjectionModel(&complexData, geometry.get()));
+    AreaPlane areaPlane;
+    if (AreaPlaneUtility::hasAreaPlane(complexData))
+    {
+        areaPlane = *complexData.radarCollection->area->plane;
+    }
+    else
+    {
+        AreaPlaneUtility::deriveAreaPlane(complexData, areaPlane);
+    }
+
+    const RowColDouble sampleSpacing(areaPlane.xDirection->spacing,
+            areaPlane.yDirection->spacing);
+    const scene::PlanarGridECEFTransform ecefTransform(
+            sampleSpacing,
+            areaPlane.referencePoint.rowCol,
+            areaPlane.xDirection->unitVector,
+            areaPlane.yDirection->unitVector,
+            areaPlane.referencePoint.ecef);
+
+    types::RowCol<size_t> fullExtent(areaPlane.xDirection->elements,
+                                     areaPlane.yDirection->elements);
+    types::RowCol<size_t> offset;
+    types::RowCol<size_t> extent;
+    complexData.getOutputPlaneOffsetAndExtent(areaPlane, offset, extent);
+
+    // Get the valid data polygon in the output plane.
+    std::vector<types::RowCol<double> > polygon;
+    Utilities::projectValidDataPolygonToOutputPlane(complexData, polygon);
+
+    return std::auto_ptr<scene::ProjectionPolynomialFitter>(
+            new scene::ProjectionPolynomialFitter(
+                *projectionModel,
+                ecefTransform,
+                fullExtent,
+                offset,
+                extent,
+                polygon,
+                numPoints1D));
 }
 
 void Utilities::getValidDataPolygon(
@@ -996,6 +1046,22 @@ void Utilities::getProjectionPolys(NITFReadControl& reader,
                                outputRowColToSlantCol);
 }
 
+void getProjectionPolys(
+    std::auto_ptr<ComplexData>& complexData,
+    const types::RowCol<size_t>& inPixelStart,
+    const types::RowCol<double>& inSceneCenter,
+    const types::RowCol<double>& interimSceneCenter,
+    const types::RowCol<double>& interimSampleSpacing,
+    size_t polyOrderX,
+    size_t polyOrderY,
+    six::Poly2D& outputRowColToSlantRow,
+    six::Poly2D& outputRowColToSlantCol,
+    size_t numPoints1D,
+    double* meanResidualErrorRow,
+    double* meanResidualErrorCol)
+{
+}
+
 six::Poly2D Utilities::transformXYPolyToRowColPoly(
     const six::Poly2D& polyXY,
     const types::RowCol<double>& outSampleSpacing,
@@ -1077,7 +1143,146 @@ void Utilities::fitXYProjectionPolys(
     outputXYToSlantY = math::poly::fit(outputX, outputY, slantY, orderX, orderY);
     slantXYToOutputX = math::poly::fit(slantX, slantY, outputX, orderX, orderY);
     slantXYToOutputY = math::poly::fit(slantX, slantY, outputY, orderX, orderY);
-}                 
-}
 }
 
+void projectPixelsToOutputPlane(
+    const six::sicd::ComplexData& complexData,
+    const std::vector<types::RowCol<double> >& spPixels,
+    std::vector<types::RowCol<double> >& opPixels)
+{
+    std::auto_ptr<scene::SceneGeometry> geometry(
+            Utilities::getSceneGeometry(&complexData));
+    std::auto_ptr<scene::ProjectionModel> projectionModel(
+            Utilities::getProjectionModel(&complexData, geometry.get()));
+    AreaPlane areaPlane;
+    if (AreaPlaneUtility::hasAreaPlane(complexData))
+    {
+        areaPlane = *complexData.radarCollection->area->plane;
+    }
+    else
+    {
+        AreaPlaneUtility::deriveAreaPlane(complexData, areaPlane);
+    }
+
+    const types::RowCol<double> opSampleSpacing(areaPlane.xDirection->spacing,
+                                               areaPlane.yDirection->spacing);
+ 
+    const types::RowCol<double> opCenterPixel(
+        static_cast<double>(areaPlane.xDirection->elements / 2 + 1),
+        static_cast<double>(areaPlane.yDirection->elements / 2 + 1));
+
+    const six::Vector3 opORPECEF = areaPlane.referencePoint.ecef;
+    const six::Vector3 opZ = Utilities::getGroundPlaneNormal(complexData);
+
+    // Project slant plane pixels to output plane pixels.
+    opPixels.resize(spPixels.size());
+    for (size_t ii = 0; ii < spPixels.size(); ++ii)
+    {
+        const types::RowCol<double> spXY(
+            complexData.pixelToImagePoint(spPixels[ii]));
+
+        // Convert to output plane ECEF.
+        six::Vector3 opECEF = projectionModel->imageToScene(spXY, opORPEC, opZ);
+
+        // Convert ECEF to output distance to the output plane ORP.
+        six::Vector3 diffECEF = opECEF - opORPECEF;
+        double opX = diffECEF.dot(areaPlane.xDirection->unitVector);
+        double opY = diffECEF.dot(areaPlane.yDirection->unitVector);
+
+        // Convert XY to pixels.
+        opPixels[ii] = types::RowCol<double>(
+            opX / opSampleSpacing.row + opCenterPixel.row,
+            opY / opSampleSpacing.col + opCenterPixel.col);
+    }
+   
+}
+
+void projectValidDataPolygonToOutputPlane(
+    const six::sicd::ComplexData& complexData,
+    std::vector<types::RowCol<double> >& opPixels)
+{
+    // If we don't have a valid data polygon, then the entire SICD is valid.
+    std::vector<six::RowColInt> validData = complexData.imageData->validData;
+    if (validData.size() == 0)
+    {
+        // Get dimensions of SICD.
+        sys::SSize_T numRows =
+            static_cast<sys::SSize_T>)complexData.getNumRows());
+        sys::SSize_T numCols =
+            static_cast<sys::SSize_T>)complexData.getNumCols());
+
+        validData.push_back(six::RowColInt(0, 0));
+        validData.push_back(six::RowColInt(0, numCols - 1));
+        validData.push_back(six::RowColInt(numRows - 1, numCols - 1));
+        validData.push_back(six::RowColInt(numRows - 1, 0));
+    }
+
+    // Convert to double coordinates.
+    std::vector<types::RowCol<double> > spPixels(validData.size());
+    for (size_t ii = 0; ii < validData.size(); ++i)
+    {
+        spPixels[ii] = types::RowCol<double>(
+            static_cast<double>(validData[ii].row),
+            static_cast<double>(validData[ii].col));
+    }
+
+    // Project to the output plane.
+    projectPixelsToOutputPlane(complexData, spPixels, opPixels);
+}
+
+void projectPixelsToSlantPlane(
+    const six::sicd::ComplexData& complexData,
+    const std::vector<types::RowCol<double> >& spPixels,
+    std::vector<types::RowCol<double> >& opPixels)
+{
+    std::auto_ptr<scene::SceneGeometry> geometry(
+            Utilities::getSceneGeometry(&complexData));
+    std::auto_ptr<scene::ProjectionModel> projectionModel(
+            Utilities::getProjectionModel(&complexData, geometry.get()));
+    AreaPlane areaPlane;
+    if (AreaPlaneUtility::hasAreaPlane(complexData))
+    {
+        areaPlane = *complexData.radarCollection->area->plane;
+    }
+    else
+    {
+        AreaPlaneUtility::deriveAreaPlane(complexData, areaPlane);
+    }
+
+    const types::RowCol<double> opSampleSpacing(areaPlane.xDirection->spacing,
+                                               areaPlane.yDirection->spacing);
+    const scene::PlanarGridECEFTransform ecefTransform(
+            opSampleSpacing,
+            areaPlane.referencePoint.rowCol,
+            areaPlane.xDirection->unitVector,
+            areaPlane.yDirection->unitVector,
+            areaPlane.referencePoint.ecef);
+    const types::RowCol<double> spSampleSpacing(
+        complexData.grid->row->sampleSpacing,
+        complexData.grid->col->sampleSpacing);
+    const types::RowCol<double> spOrigOffset(
+        static_cast<double>(complexData.imageData->firstRow),
+        static_cast<double>(complexData.imageData->firstCol));
+    const types::RowCol<double> spSCP(complexData.imageData->scpPixel);
+    const types::RowCol<double> spOffset(
+        spSCP.row - spOrigOffset.row,
+        spSCP.col - spOrigOffset.col);
+    
+    // Project output plane pixels to slant plane pixels.
+    spPixels.resize(opPixels.size());
+    for (size_t ii = 0; ii < opPixels.size(); ++ii)
+    {
+        // Convert output plane pixel to ECEF.
+        const scene::Vector3 ecef = ecefTransform.rowColToECEF(opPixels[ii]);
+        
+        // Convert ECEF to slant plane distance from SCP.
+        double timeCOA = 0.0;
+        const types::RowCol<double> spXY =
+            projectionModel->sceneToImage(ecef, &timeCOA);
+
+        // Convert to slant plane pixel.
+        spPixels[ii] = (spXY / spSampleSpacing + spOffset);
+    }
+}
+}
+}

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -1046,22 +1046,6 @@ void Utilities::getProjectionPolys(NITFReadControl& reader,
                                outputRowColToSlantCol);
 }
 
-void getProjectionPolys(
-    std::auto_ptr<ComplexData>& complexData,
-    const types::RowCol<size_t>& inPixelStart,
-    const types::RowCol<double>& inSceneCenter,
-    const types::RowCol<double>& interimSceneCenter,
-    const types::RowCol<double>& interimSampleSpacing,
-    size_t polyOrderX,
-    size_t polyOrderY,
-    six::Poly2D& outputRowColToSlantRow,
-    six::Poly2D& outputRowColToSlantCol,
-    size_t numPoints1D,
-    double* meanResidualErrorRow,
-    double* meanResidualErrorCol)
-{
-}
-
 six::Poly2D Utilities::transformXYPolyToRowColPoly(
     const six::Poly2D& polyXY,
     const types::RowCol<double>& outSampleSpacing,
@@ -1145,7 +1129,7 @@ void Utilities::fitXYProjectionPolys(
     slantXYToOutputY = math::poly::fit(slantX, slantY, outputY, orderX, orderY);
 }
 
-void projectPixelsToOutputPlane(
+void Utilities::projectPixelsToOutputPlane(
     const six::sicd::ComplexData& complexData,
     const std::vector<types::RowCol<double> >& spPixels,
     std::vector<types::RowCol<double> >& opPixels)
@@ -1182,7 +1166,8 @@ void projectPixelsToOutputPlane(
             complexData.pixelToImagePoint(spPixels[ii]));
 
         // Convert to output plane ECEF.
-        six::Vector3 opECEF = projectionModel->imageToScene(spXY, opORPEC, opZ);
+        six::Vector3 opECEF = projectionModel->imageToScene(spXY, opORPECEF,
+                                                            opZ);
 
         // Convert ECEF to output distance to the output plane ORP.
         six::Vector3 diffECEF = opECEF - opORPECEF;
@@ -1197,7 +1182,7 @@ void projectPixelsToOutputPlane(
    
 }
 
-void projectValidDataPolygonToOutputPlane(
+void Utilities::projectValidDataPolygonToOutputPlane(
     const six::sicd::ComplexData& complexData,
     std::vector<types::RowCol<double> >& opPixels)
 {
@@ -1207,9 +1192,9 @@ void projectValidDataPolygonToOutputPlane(
     {
         // Get dimensions of SICD.
         sys::SSize_T numRows =
-            static_cast<sys::SSize_T>)complexData.getNumRows());
+            static_cast<sys::SSize_T>(complexData.getNumRows());
         sys::SSize_T numCols =
-            static_cast<sys::SSize_T>)complexData.getNumCols());
+            static_cast<sys::SSize_T>(complexData.getNumCols());
 
         validData.push_back(six::RowColInt(0, 0));
         validData.push_back(six::RowColInt(0, numCols - 1));
@@ -1219,7 +1204,7 @@ void projectValidDataPolygonToOutputPlane(
 
     // Convert to double coordinates.
     std::vector<types::RowCol<double> > spPixels(validData.size());
-    for (size_t ii = 0; ii < validData.size(); ++i)
+    for (size_t ii = 0; ii < validData.size(); ++ii)
     {
         spPixels[ii] = types::RowCol<double>(
             static_cast<double>(validData[ii].row),
@@ -1230,10 +1215,10 @@ void projectValidDataPolygonToOutputPlane(
     projectPixelsToOutputPlane(complexData, spPixels, opPixels);
 }
 
-void projectPixelsToSlantPlane(
+void Utilities::projectPixelsToSlantPlane(
     const six::sicd::ComplexData& complexData,
-    const std::vector<types::RowCol<double> >& spPixels,
-    std::vector<types::RowCol<double> >& opPixels)
+    const std::vector<types::RowCol<double> >& opPixels,
+    std::vector<types::RowCol<double> >& spPixels)
 {
     std::auto_ptr<scene::SceneGeometry> geometry(
             Utilities::getSceneGeometry(&complexData));
@@ -1242,7 +1227,7 @@ void projectPixelsToSlantPlane(
     AreaPlane areaPlane;
     if (AreaPlaneUtility::hasAreaPlane(complexData))
     {
-        areaPlane = *complexData.radarCollection->area->plane;
+         areaPlane = *complexData.radarCollection->area->plane;
     }
     else
     {

--- a/six/modules/c++/six.sicd/tests/test_vdp_polyfit.cpp
+++ b/six/modules/c++/six.sicd/tests/test_vdp_polyfit.cpp
@@ -1,0 +1,117 @@
+/* =========================================================================
+ * This file is part of six-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * six-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <iostream>
+#include <stdexcept>
+#include <memory>
+#include <complex>
+
+#include <sys/Path.h>
+//#include <except/Exception.h>
+//#include <io/StandardStreams.h>
+#include <six/Utilities.h>
+//#include <six/sicd/ComplexXMLControl.h>
+#include <six/sicd/Utilities.h>
+#include <six/sicd/ComplexData.h>
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        // Parse the command line
+        const std::string progname(argv[0]);
+        if (argc != 2 && argc != 3)
+        {
+            std::cerr << "Usage: " << sys::Path::basename(progname)
+                      << " <SICD pathname> [<schema dirname>]\n\n";
+            return 1;
+        }
+
+        const std::string sicdPathname(argv[1]);
+
+        std::vector<std::string> schemaPaths;
+        if (argc == 3)
+        {
+            schemaPaths.push_back(argv[2]);
+        }
+        else
+        {
+            schemaPaths.push_back(six::findSchemaPath(progname));
+        }
+
+        std::auto_ptr<six::sicd::ComplexData> complexData(
+            six::sicd::Utilities::getComplexData(sicdPathname, schemaPaths));
+
+        std::auto_ptr<scene::ProjectionPolynomialFitter> polyfitter(
+            six::sicd::Utilities::getPolynomialFitterVDP(
+                *complexData).release());
+
+        const types::RowCol<size_t> spPixelStart(0, 0);
+        const types::RowCol<double> spSceneCenter(
+            complexData->imageData->scpPixel);
+        const types::RowCol<double> spSampleSpacing(
+            complexData->grid->row->sampleSpacing,
+            complexData->grid->col->sampleSpacing);
+        const size_t polyOrder = 4;
+        six::Poly2D outputRowColToSlantRow;
+        six::Poly2D outputRowColToSlantCol;
+        double meanResidualErrorRow = 0.0;
+        double meanResidualErrorCol = 0.0;
+
+        polyfitter->fitOutputToSlantPolynomials(
+                   spPixelStart,
+                   spSceneCenter,   
+                   spSceneCenter,
+                   spSampleSpacing,
+                   polyOrder,
+                   polyOrder,
+                   outputRowColToSlantRow,
+                   outputRowColToSlantCol,
+                   &meanResidualErrorRow,
+                   &meanResidualErrorCol);
+
+        std::cout << "outputRowColToSlantRow:" << outputRowColToSlantRow <<
+            std::endl;
+        std::cout << "outputRowColToSlantCol:" << outputRowColToSlantCol <<
+            std::endl;
+        std::cout << "meanResidualErrorRow:" << meanResidualErrorRow <<
+            std::endl;
+        std::cout << "meanResidualErrorCol:" << meanResidualErrorCol <<
+            std::endl;
+    }
+    catch (const except::Exception& e)
+    {
+        std::cerr << "Caught exception: " << e.getMessage() << std::endl;
+        return 1;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Caught exception: " << e.what() << std::endl;
+        return 1;
+    }
+    catch (...)
+    {
+        std::cerr << "Caught exception: " << "Unknown exception" << std::endl;
+        return 1;
+    }
+}
+


### PR DESCRIPTION
Given a SICD, the code extracts the slant plane valid data polygon (pixels). These pixels are projected to the output plane and a convex hull is computed. The matrix of output plane pixel coordinates used in the polynomial fitting routines is constrained by the convex hull coordinates. This code required addition of the PolygonMask class.