### PR TITLE
Fix bugs specific to Python 3.5

### DIFF
--- a/six/modules/python/cphd/source/cphd.i
+++ b/six/modules/python/cphd/source/cphd.i
@@ -159,6 +159,15 @@ using six::Vector3;
     }
 }
 
+%extend cphd::CPHDWriter
+{
+%pythoncode
+%{
+    def __del__(self):
+        self.close()
+%}
+}
+
 %pythoncode
 %{
 import numpy
@@ -166,8 +175,8 @@ import multiprocessing
 from coda.coda_types import RowColSizeT
 
 def toBuffer(self, channel = 0):
-
-    numpyArray = numpy.empty(shape = ((self.getVBMsize(channel) / 8)), dtype = 'double')
+    numpyArray = numpy.empty(shape = int((self.getVBMsize(channel) / 8)),
+                             dtype = 'double')
     pointer, ro = numpyArray.__array_interface__['data']
 
     self.getVBMdata(channel, pointer)
@@ -199,11 +208,8 @@ def write(self, pathname, data, vbm, channel):
     self.addImageImpl(imagePointer, dims, vbmPointer)
     self.write(pathname)
 
-def __del__(self):
-    self.close()
 
 CPHDWriter.writeCPHD = write
-CPHDWriter.__del__ = __del__
 
 def read(self,
          channel = 0,

--- a/six/modules/python/cphd/source/generated/cphd.py
+++ b/six/modules/python/cphd/source/generated/cphd.py
@@ -2021,6 +2021,10 @@ class CPHDWriter(_object):
         """addImageImpl(CPHDWriter self, long long image, RowColSizeT dims, long long vbm)"""
         return _cphd.CPHDWriter_addImageImpl(self, image, dims, vbm)
 
+
+    def __del__(self):
+        self.close()
+
     __swig_destroy__ = _cphd.delete_CPHDWriter
     __del__ = lambda self: None
 CPHDWriter_swigregister = _cphd.CPHDWriter_swigregister
@@ -2032,8 +2036,8 @@ import multiprocessing
 from coda.coda_types import RowColSizeT
 
 def toBuffer(self, channel = 0):
-
-    numpyArray = numpy.empty(shape = ((self.getVBMsize(channel) / 8)), dtype = 'double')
+    numpyArray = numpy.empty(shape = int((self.getVBMsize(channel) / 8)),
+                             dtype = 'double')
     pointer, ro = numpyArray.__array_interface__['data']
 
     self.getVBMdata(channel, pointer)
@@ -2065,11 +2069,8 @@ def write(self, pathname, data, vbm, channel):
     self.addImageImpl(imagePointer, dims, vbmPointer)
     self.write(pathname)
 
-def __del__(self):
-    self.close()
 
 CPHDWriter.writeCPHD = write
-CPHDWriter.__del__ = __del__
 
 def read(self,
          channel = 0,

--- a/six/modules/python/six/source/generated/six_base_wrap.cxx
+++ b/six/modules/python/six/source/generated/six_base_wrap.cxx
@@ -3061,109 +3061,108 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_nitf_DateTime swig_types[51]
 #define SWIGTYPE_p_nitf__DateTime swig_types[52]
 #define SWIGTYPE_p_nitf__FileSecurity swig_types[53]
-#define SWIGTYPE_p_nitf__NITFException swig_types[54]
-#define SWIGTYPE_p_off_t swig_types[55]
-#define SWIGTYPE_p_pid_t swig_types[56]
-#define SWIGTYPE_p_scene__AngleMagnitude swig_types[57]
-#define SWIGTYPE_p_scene__Errors swig_types[58]
-#define SWIGTYPE_p_scene__FrameType swig_types[59]
-#define SWIGTYPE_p_scene__LatLon swig_types[60]
-#define SWIGTYPE_p_scene__LatLonAlt swig_types[61]
-#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[62]
-#define SWIGTYPE_p_six__AmplitudeTable swig_types[63]
-#define SWIGTYPE_p_six__AppliedType swig_types[64]
-#define SWIGTYPE_p_six__AutofocusType swig_types[65]
-#define SWIGTYPE_p_six__BooleanType swig_types[66]
-#define SWIGTYPE_p_six__ByteSwapping swig_types[67]
-#define SWIGTYPE_p_six__Classification swig_types[68]
-#define SWIGTYPE_p_six__CollectType swig_types[69]
-#define SWIGTYPE_p_six__ComplexImageGridType swig_types[70]
-#define SWIGTYPE_p_six__ComplexImagePlaneType swig_types[71]
-#define SWIGTYPE_p_six__Components swig_types[72]
-#define SWIGTYPE_p_six__CompositeSCP swig_types[73]
-#define SWIGTYPE_p_six__Constants swig_types[74]
-#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[75]
-#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[76]
-#define SWIGTYPE_p_six__CorrCoefs swig_types[77]
-#define SWIGTYPE_p_six__DESValidationException swig_types[78]
-#define SWIGTYPE_p_six__Data swig_types[79]
-#define SWIGTYPE_p_six__DataType swig_types[80]
-#define SWIGTYPE_p_six__DecimationMethod swig_types[81]
-#define SWIGTYPE_p_six__DecorrType swig_types[82]
-#define SWIGTYPE_p_six__DemodType swig_types[83]
-#define SWIGTYPE_p_six__DisplayType swig_types[84]
-#define SWIGTYPE_p_six__DualPolarizationType swig_types[85]
-#define SWIGTYPE_p_six__EarthModelType swig_types[86]
-#define SWIGTYPE_p_six__ErrorStatistics swig_types[87]
-#define SWIGTYPE_p_six__FFTSign swig_types[88]
-#define SWIGTYPE_p_six__ImageBeamCompensationType swig_types[89]
-#define SWIGTYPE_p_six__ImageFormationType swig_types[90]
-#define SWIGTYPE_p_six__Init swig_types[91]
-#define SWIGTYPE_p_six__IonoError swig_types[92]
-#define SWIGTYPE_p_six__LUT swig_types[93]
-#define SWIGTYPE_p_six__MagnificationMethod swig_types[94]
-#define SWIGTYPE_p_six__MissingRequiredException swig_types[95]
-#define SWIGTYPE_p_six__NoiseLevel swig_types[96]
-#define SWIGTYPE_p_six__Options swig_types[97]
-#define SWIGTYPE_p_six__OrientationType swig_types[98]
-#define SWIGTYPE_p_six__Parameter swig_types[99]
-#define SWIGTYPE_p_six__ParameterCollection swig_types[100]
-#define SWIGTYPE_p_six__PixelType swig_types[101]
-#define SWIGTYPE_p_six__PolarizationSequenceType swig_types[102]
-#define SWIGTYPE_p_six__PolarizationType swig_types[103]
-#define SWIGTYPE_p_six__PosVelError swig_types[104]
-#define SWIGTYPE_p_six__ProjectionType swig_types[105]
-#define SWIGTYPE_p_six__RMAlgoType swig_types[106]
-#define SWIGTYPE_p_six__RadarModeType swig_types[107]
-#define SWIGTYPE_p_six__RadarSensor swig_types[108]
-#define SWIGTYPE_p_six__Radiometric swig_types[109]
-#define SWIGTYPE_p_six__ReferencePoint swig_types[110]
-#define SWIGTYPE_p_six__RegionType swig_types[111]
-#define SWIGTYPE_p_six__RowColEnum swig_types[112]
-#define SWIGTYPE_p_six__SCP swig_types[113]
-#define SWIGTYPE_p_six__SCPType swig_types[114]
-#define SWIGTYPE_p_six__SideOfTrackType swig_types[115]
-#define SWIGTYPE_p_six__SlowTimeBeamCompensationType swig_types[116]
-#define SWIGTYPE_p_six__TropoError swig_types[117]
-#define SWIGTYPE_p_six__UninitializedValueException swig_types[118]
-#define SWIGTYPE_p_six__XMLControl swig_types[119]
-#define SWIGTYPE_p_six__XMLControlCreator swig_types[120]
-#define SWIGTYPE_p_six__XMLControlRegistry swig_types[121]
-#define SWIGTYPE_p_six__XYZEnum swig_types[122]
-#define SWIGTYPE_p_size_t swig_types[123]
-#define SWIGTYPE_p_size_type swig_types[124]
-#define SWIGTYPE_p_ssize_t swig_types[125]
-#define SWIGTYPE_p_std__auto_ptrT_six__AmplitudeTable_t swig_types[126]
-#define SWIGTYPE_p_std__auto_ptrT_six__Components_t swig_types[127]
-#define SWIGTYPE_p_std__auto_ptrT_six__CompositeSCP_t swig_types[128]
-#define SWIGTYPE_p_std__auto_ptrT_six__CorrCoefs_t swig_types[129]
-#define SWIGTYPE_p_std__auto_ptrT_six__ErrorStatistics_t swig_types[130]
-#define SWIGTYPE_p_std__auto_ptrT_six__IonoError_t swig_types[131]
-#define SWIGTYPE_p_std__auto_ptrT_six__PosVelError_t swig_types[132]
-#define SWIGTYPE_p_std__auto_ptrT_six__RadarSensor_t swig_types[133]
-#define SWIGTYPE_p_std__auto_ptrT_six__Radiometric_t swig_types[134]
-#define SWIGTYPE_p_std__auto_ptrT_six__TropoError_t swig_types[135]
-#define SWIGTYPE_p_std__auto_ptrT_six__XMLControlCreator_t swig_types[136]
-#define SWIGTYPE_p_std__invalid_argument swig_types[137]
-#define SWIGTYPE_p_std__mapT_std__string_six__Parameter_t__const_iterator swig_types[138]
-#define SWIGTYPE_p_std__ostream swig_types[139]
-#define SWIGTYPE_p_std__string swig_types[140]
-#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[141]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[142]
-#define SWIGTYPE_p_types__RgAzT_double_t swig_types[143]
-#define SWIGTYPE_p_types__RowColT_double_t swig_types[144]
-#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[145]
-#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[146]
-#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[147]
-#define SWIGTYPE_p_uint16_t swig_types[148]
-#define SWIGTYPE_p_uint32_t swig_types[149]
-#define SWIGTYPE_p_uint64_t swig_types[150]
-#define SWIGTYPE_p_uint8_t swig_types[151]
-#define SWIGTYPE_p_unsigned_char swig_types[152]
-#define SWIGTYPE_p_value_type swig_types[153]
-#define SWIGTYPE_p_xml__lite__Document swig_types[154]
-static swig_type_info *swig_types[156];
-static swig_module_info swig_module = {swig_types, 155, 0, 0, 0, 0};
+#define SWIGTYPE_p_off_t swig_types[54]
+#define SWIGTYPE_p_pid_t swig_types[55]
+#define SWIGTYPE_p_scene__AngleMagnitude swig_types[56]
+#define SWIGTYPE_p_scene__Errors swig_types[57]
+#define SWIGTYPE_p_scene__FrameType swig_types[58]
+#define SWIGTYPE_p_scene__LatLon swig_types[59]
+#define SWIGTYPE_p_scene__LatLonAlt swig_types[60]
+#define SWIGTYPE_p_scene__PlaneProjectionModel swig_types[61]
+#define SWIGTYPE_p_six__AmplitudeTable swig_types[62]
+#define SWIGTYPE_p_six__AppliedType swig_types[63]
+#define SWIGTYPE_p_six__AutofocusType swig_types[64]
+#define SWIGTYPE_p_six__BooleanType swig_types[65]
+#define SWIGTYPE_p_six__ByteSwapping swig_types[66]
+#define SWIGTYPE_p_six__Classification swig_types[67]
+#define SWIGTYPE_p_six__CollectType swig_types[68]
+#define SWIGTYPE_p_six__ComplexImageGridType swig_types[69]
+#define SWIGTYPE_p_six__ComplexImagePlaneType swig_types[70]
+#define SWIGTYPE_p_six__Components swig_types[71]
+#define SWIGTYPE_p_six__CompositeSCP swig_types[72]
+#define SWIGTYPE_p_six__Constants swig_types[73]
+#define SWIGTYPE_p_six__CornersT_scene__LatLonAlt_t swig_types[74]
+#define SWIGTYPE_p_six__CornersT_scene__LatLon_t swig_types[75]
+#define SWIGTYPE_p_six__CorrCoefs swig_types[76]
+#define SWIGTYPE_p_six__DESValidationException swig_types[77]
+#define SWIGTYPE_p_six__Data swig_types[78]
+#define SWIGTYPE_p_six__DataType swig_types[79]
+#define SWIGTYPE_p_six__DecimationMethod swig_types[80]
+#define SWIGTYPE_p_six__DecorrType swig_types[81]
+#define SWIGTYPE_p_six__DemodType swig_types[82]
+#define SWIGTYPE_p_six__DisplayType swig_types[83]
+#define SWIGTYPE_p_six__DualPolarizationType swig_types[84]
+#define SWIGTYPE_p_six__EarthModelType swig_types[85]
+#define SWIGTYPE_p_six__ErrorStatistics swig_types[86]
+#define SWIGTYPE_p_six__FFTSign swig_types[87]
+#define SWIGTYPE_p_six__ImageBeamCompensationType swig_types[88]
+#define SWIGTYPE_p_six__ImageFormationType swig_types[89]
+#define SWIGTYPE_p_six__Init swig_types[90]
+#define SWIGTYPE_p_six__IonoError swig_types[91]
+#define SWIGTYPE_p_six__LUT swig_types[92]
+#define SWIGTYPE_p_six__MagnificationMethod swig_types[93]
+#define SWIGTYPE_p_six__MissingRequiredException swig_types[94]
+#define SWIGTYPE_p_six__NoiseLevel swig_types[95]
+#define SWIGTYPE_p_six__Options swig_types[96]
+#define SWIGTYPE_p_six__OrientationType swig_types[97]
+#define SWIGTYPE_p_six__Parameter swig_types[98]
+#define SWIGTYPE_p_six__ParameterCollection swig_types[99]
+#define SWIGTYPE_p_six__PixelType swig_types[100]
+#define SWIGTYPE_p_six__PolarizationSequenceType swig_types[101]
+#define SWIGTYPE_p_six__PolarizationType swig_types[102]
+#define SWIGTYPE_p_six__PosVelError swig_types[103]
+#define SWIGTYPE_p_six__ProjectionType swig_types[104]
+#define SWIGTYPE_p_six__RMAlgoType swig_types[105]
+#define SWIGTYPE_p_six__RadarModeType swig_types[106]
+#define SWIGTYPE_p_six__RadarSensor swig_types[107]
+#define SWIGTYPE_p_six__Radiometric swig_types[108]
+#define SWIGTYPE_p_six__ReferencePoint swig_types[109]
+#define SWIGTYPE_p_six__RegionType swig_types[110]
+#define SWIGTYPE_p_six__RowColEnum swig_types[111]
+#define SWIGTYPE_p_six__SCP swig_types[112]
+#define SWIGTYPE_p_six__SCPType swig_types[113]
+#define SWIGTYPE_p_six__SideOfTrackType swig_types[114]
+#define SWIGTYPE_p_six__SlowTimeBeamCompensationType swig_types[115]
+#define SWIGTYPE_p_six__TropoError swig_types[116]
+#define SWIGTYPE_p_six__UninitializedValueException swig_types[117]
+#define SWIGTYPE_p_six__XMLControl swig_types[118]
+#define SWIGTYPE_p_six__XMLControlCreator swig_types[119]
+#define SWIGTYPE_p_six__XMLControlRegistry swig_types[120]
+#define SWIGTYPE_p_six__XYZEnum swig_types[121]
+#define SWIGTYPE_p_size_t swig_types[122]
+#define SWIGTYPE_p_size_type swig_types[123]
+#define SWIGTYPE_p_ssize_t swig_types[124]
+#define SWIGTYPE_p_std__auto_ptrT_six__AmplitudeTable_t swig_types[125]
+#define SWIGTYPE_p_std__auto_ptrT_six__Components_t swig_types[126]
+#define SWIGTYPE_p_std__auto_ptrT_six__CompositeSCP_t swig_types[127]
+#define SWIGTYPE_p_std__auto_ptrT_six__CorrCoefs_t swig_types[128]
+#define SWIGTYPE_p_std__auto_ptrT_six__ErrorStatistics_t swig_types[129]
+#define SWIGTYPE_p_std__auto_ptrT_six__IonoError_t swig_types[130]
+#define SWIGTYPE_p_std__auto_ptrT_six__PosVelError_t swig_types[131]
+#define SWIGTYPE_p_std__auto_ptrT_six__RadarSensor_t swig_types[132]
+#define SWIGTYPE_p_std__auto_ptrT_six__Radiometric_t swig_types[133]
+#define SWIGTYPE_p_std__auto_ptrT_six__TropoError_t swig_types[134]
+#define SWIGTYPE_p_std__auto_ptrT_six__XMLControlCreator_t swig_types[135]
+#define SWIGTYPE_p_std__invalid_argument swig_types[136]
+#define SWIGTYPE_p_std__mapT_std__string_six__Parameter_t__const_iterator swig_types[137]
+#define SWIGTYPE_p_std__ostream swig_types[138]
+#define SWIGTYPE_p_std__string swig_types[139]
+#define SWIGTYPE_p_std__vectorT_std__string_std__allocatorT_std__string_t_t swig_types[140]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[141]
+#define SWIGTYPE_p_types__RgAzT_double_t swig_types[142]
+#define SWIGTYPE_p_types__RowColT_double_t swig_types[143]
+#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[144]
+#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[145]
+#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[146]
+#define SWIGTYPE_p_uint16_t swig_types[147]
+#define SWIGTYPE_p_uint32_t swig_types[148]
+#define SWIGTYPE_p_uint64_t swig_types[149]
+#define SWIGTYPE_p_uint8_t swig_types[150]
+#define SWIGTYPE_p_unsigned_char swig_types[151]
+#define SWIGTYPE_p_value_type swig_types[152]
+#define SWIGTYPE_p_xml__lite__Document swig_types[153]
+static swig_type_info *swig_types[155];
+static swig_module_info swig_module = {swig_types, 154, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -6218,13 +6217,7 @@ SWIGINTERN PyObject *_wrap_new_DateTime__SWIG_0(PyObject *SWIGUNUSEDPARM(self), 
   {
     try
     {
-      try {
-        result = (nitf::DateTime *)new nitf::DateTime();
-      }
-      catch(nitf::NITFException &_e) {
-        SWIG_Python_Raise(SWIG_NewPointerObj((new nitf::NITFException(static_cast< const nitf::NITFException& >(_e))),SWIGTYPE_p_nitf__NITFException,SWIG_POINTER_OWN), "nitf::NITFException", SWIGTYPE_p_nitf__NITFException); SWIG_fail;
-      }
-      
+      result = (nitf::DateTime *)new nitf::DateTime();
     } 
     catch (const std::exception& e)
     {
@@ -6276,13 +6269,7 @@ SWIGINTERN PyObject *_wrap_new_DateTime__SWIG_1(PyObject *SWIGUNUSEDPARM(self), 
   {
     try
     {
-      try {
-        result = (nitf::DateTime *)new nitf::DateTime(arg1);
-      }
-      catch(nitf::NITFException &_e) {
-        SWIG_Python_Raise(SWIG_NewPointerObj((new nitf::NITFException(static_cast< const nitf::NITFException& >(_e))),SWIGTYPE_p_nitf__NITFException,SWIG_POINTER_OWN), "nitf::NITFException", SWIGTYPE_p_nitf__NITFException); SWIG_fail;
-      }
-      
+      result = (nitf::DateTime *)new nitf::DateTime(arg1);
     } 
     catch (const std::exception& e)
     {
@@ -6334,13 +6321,7 @@ SWIGINTERN PyObject *_wrap_new_DateTime__SWIG_2(PyObject *SWIGUNUSEDPARM(self), 
   {
     try
     {
-      try {
-        result = (nitf::DateTime *)new nitf::DateTime(arg1);
-      }
-      catch(nitf::NITFException &_e) {
-        SWIG_Python_Raise(SWIG_NewPointerObj((new nitf::NITFException(static_cast< const nitf::NITFException& >(_e))),SWIGTYPE_p_nitf__NITFException,SWIG_POINTER_OWN), "nitf::NITFException", SWIGTYPE_p_nitf__NITFException); SWIG_fail;
-      }
-      
+      result = (nitf::DateTime *)new nitf::DateTime(arg1);
     } 
     catch (const std::exception& e)
     {
@@ -6411,13 +6392,7 @@ SWIGINTERN PyObject *_wrap_new_DateTime__SWIG_3(PyObject *SWIGUNUSEDPARM(self), 
   {
     try
     {
-      try {
-        result = (nitf::DateTime *)new nitf::DateTime((std::string const &)*arg1,(std::string const &)*arg2);
-      }
-      catch(nitf::NITFException &_e) {
-        SWIG_Python_Raise(SWIG_NewPointerObj((new nitf::NITFException(static_cast< const nitf::NITFException& >(_e))),SWIGTYPE_p_nitf__NITFException,SWIG_POINTER_OWN), "nitf::NITFException", SWIGTYPE_p_nitf__NITFException); SWIG_fail;
-      }
-      
+      result = (nitf::DateTime *)new nitf::DateTime((std::string const &)*arg1,(std::string const &)*arg2);
     } 
     catch (const std::exception& e)
     {
@@ -7668,13 +7643,7 @@ SWIGINTERN PyObject *_wrap_DateTime_format__SWIG_0(PyObject *SWIGUNUSEDPARM(self
   {
     try
     {
-      try {
-        ((nitf::DateTime const *)arg1)->format((std::string const &)*arg2,arg3,arg4);
-      }
-      catch(nitf::NITFException &_e) {
-        SWIG_Python_Raise(SWIG_NewPointerObj((new nitf::NITFException(static_cast< const nitf::NITFException& >(_e))),SWIGTYPE_p_nitf__NITFException,SWIG_POINTER_OWN), "nitf::NITFException", SWIGTYPE_p_nitf__NITFException); SWIG_fail;
-      }
-      
+      ((nitf::DateTime const *)arg1)->format((std::string const &)*arg2,arg3,arg4);
     } 
     catch (const std::exception& e)
     {
@@ -7755,13 +7724,7 @@ SWIGINTERN PyObject *_wrap_DateTime_format__SWIG_1(PyObject *SWIGUNUSEDPARM(self
   {
     try
     {
-      try {
-        ((nitf::DateTime const *)arg1)->format((std::string const &)*arg2,*arg3);
-      }
-      catch(nitf::NITFException &_e) {
-        SWIG_Python_Raise(SWIG_NewPointerObj((new nitf::NITFException(static_cast< const nitf::NITFException& >(_e))),SWIGTYPE_p_nitf__NITFException,SWIG_POINTER_OWN), "nitf::NITFException", SWIGTYPE_p_nitf__NITFException); SWIG_fail;
-      }
-      
+      ((nitf::DateTime const *)arg1)->format((std::string const &)*arg2,*arg3);
     } 
     catch (const std::exception& e)
     {
@@ -7829,13 +7792,7 @@ SWIGINTERN PyObject *_wrap_DateTime_format__SWIG_2(PyObject *SWIGUNUSEDPARM(self
   {
     try
     {
-      try {
-        result = ((nitf::DateTime const *)arg1)->format((std::string const &)*arg2);
-      }
-      catch(nitf::NITFException &_e) {
-        SWIG_Python_Raise(SWIG_NewPointerObj((new nitf::NITFException(static_cast< const nitf::NITFException& >(_e))),SWIGTYPE_p_nitf__NITFException,SWIG_POINTER_OWN), "nitf::NITFException", SWIGTYPE_p_nitf__NITFException); SWIG_fail;
-      }
-      
+      result = ((nitf::DateTime const *)arg1)->format((std::string const &)*arg2);
     } 
     catch (const std::exception& e)
     {
@@ -80409,7 +80366,6 @@ static swig_type_info _swigt__p_mt__SingletonT_six__XMLControlRegistry_true_t = 
 static swig_type_info _swigt__p_nitf_DateTime = {"_p_nitf_DateTime", "nitf_DateTime *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf__DateTime = {"_p_nitf__DateTime", "nitf::DateTime *|six::DateTime *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_nitf__FileSecurity = {"_p_nitf__FileSecurity", "nitf::FileSecurity *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_nitf__NITFException = {"_p_nitf__NITFException", "nitf::NITFException *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_off_t = {"_p_off_t", "off_t *|sys::Off_T *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_pid_t = {"_p_pid_t", "sys::Pid_T *|pid_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_scene__AngleMagnitude = {"_p_scene__AngleMagnitude", "scene::AngleMagnitude *|six::AngleMagnitude *", 0, 0, (void*)0, 0};
@@ -80566,7 +80522,6 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_nitf_DateTime,
   &_swigt__p_nitf__DateTime,
   &_swigt__p_nitf__FileSecurity,
-  &_swigt__p_nitf__NITFException,
   &_swigt__p_off_t,
   &_swigt__p_pid_t,
   &_swigt__p_scene__AngleMagnitude,
@@ -80723,7 +80678,6 @@ static swig_cast_info _swigc__p_mt__SingletonT_six__XMLControlRegistry_true_t[] 
 static swig_cast_info _swigc__p_nitf_DateTime[] = {  {&_swigt__p_nitf_DateTime, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_nitf__DateTime[] = {  {&_swigt__p_nitf__DateTime, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_nitf__FileSecurity[] = {  {&_swigt__p_nitf__FileSecurity, 0, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_nitf__NITFException[] = {  {&_swigt__p_nitf__NITFException, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_off_t[] = {  {&_swigt__p_off_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_pid_t[] = {  {&_swigt__p_pid_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_scene__AngleMagnitude[] = {  {&_swigt__p_scene__AngleMagnitude, 0, 0, 0},{0, 0, 0, 0}};
@@ -80880,7 +80834,6 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_nitf_DateTime,
   _swigc__p_nitf__DateTime,
   _swigc__p_nitf__FileSecurity,
-  _swigc__p_nitf__NITFException,
   _swigc__p_off_t,
   _swigc__p_pid_t,
   _swigc__p_scene__AngleMagnitude,


### PR DESCRIPTION
Two bugs here:
 - TypeError from assigning float to the `shape` argument 
 - the global `__del__` function was getting destroyed before the `CPHDWriter instance`, so I had to make it a bound method