### PR TITLE
Six SICD Scalar Mesh

### DIFF
--- a/six/modules/c++/six.sicd/include/six/sicd/SICDMesh.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDMesh.h
@@ -158,12 +158,12 @@ public:
                const std::vector<double>& x,
                const std::vector<double>& y,
                size_t numScalarsPerCoord,
-               const std::map<std::string, std::vector<double>>& scalars);
+               const std::map<std::string, std::vector<double> >& scalars);
 
     /*!
      * \returns The scalar values over the mesh.
      */
-    const std::map<std::string, std::vector<double>>& getScalars() const
+    const std::map<std::string, std::vector<double> >& getScalars() const
     {
         return mScalars;
     }
@@ -186,21 +186,21 @@ public:
      *       scalars has been provided. This method will throw if the mesh
      *       is uninitialized.
      */
-    std::vector<Mesh::Field> getFields() const override;
+    virtual std::vector<Mesh::Field> getFields() const;
 
     /*!
      * Serializes the mesh to binary
      *
      * \param[out] values The serialized data.
      */
-    void serialize(std::vector<sys::byte>& values) const override;
+    virtual void serialize(std::vector<sys::byte>& values) const;
 
     /*!
      * Deserializes from binary to a mesh.
      *
      * \param values Data to deserialize.
      */
-    void deserialize(const sys::byte*& values) override;
+    virtual void deserialize(const sys::byte*& values);
 
 private:
     //! The number of scalars per x,y coordinate.
@@ -208,7 +208,7 @@ private:
 
     //! Map between the scalar identifier and the values over
     //! the mesh.
-    std::map<std::string, std::vector<double>> mScalars;
+    std::map<std::string, std::vector<double> > mScalars;
 };
 
 /*!

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -135,6 +135,9 @@ public:
      *  and returning the projected column coordinate in the
      *  slant plane image as output.
      * \param[out] noiseMesh Noise mesh
+     * \param[out] scalarMesh Optional scalar mesh - note that if the
+     *             mesh is not present within the SICD, scalarMesh
+     *             will be NULL.
      *
      * \throws See six::sicd::Utilities::getComplexData and
      *           six::sicd::Utilities::getWidebandData
@@ -148,7 +151,8 @@ public:
                          std::vector<std::complex<float> >& widebandData,
                          six::Poly2D& outputRowColToSlantRow,
                          six::Poly2D& outputRowColToSlantCol,
-                         std::auto_ptr<NoiseMesh>& noiseMesh);
+                         std::auto_ptr<NoiseMesh>& noiseMesh,
+                         std::auto_ptr<ScalarMesh>& scalarMesh);
 
     /*
      * Given a SICD pathname and list of schemas, provides a representation
@@ -419,6 +423,19 @@ public:
      *
      */
     static std::auto_ptr<NoiseMesh> getNoiseMesh(NITFReadControl& reader);
+
+    /*
+       * Given a reference to a loaded NITFReadControl, this function
+       * parses the SICD's DES and returns a ScalarMesh if present.
+       *
+       * \note If the scalar mesh is not present within the SICD,
+       *       the returned ScalarMesh will be null
+       *
+       * \param reader A NITFReadControl loaded with the desired SICD
+       *
+       * \return Scalar Mesh associated with the SICD NITF
+       */
+    static std::auto_ptr<ScalarMesh> getScalarMesh(NITFReadControl& reader);
 
     /*
      * Given a reference to a loaded NITFReadControl, this function

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -425,16 +425,16 @@ public:
     static std::auto_ptr<NoiseMesh> getNoiseMesh(NITFReadControl& reader);
 
     /*
-       * Given a reference to a loaded NITFReadControl, this function
-       * parses the SICD's DES and returns a ScalarMesh if present.
-       *
-       * \note If the scalar mesh is not present within the SICD,
-       *       the returned ScalarMesh will be null
-       *
-       * \param reader A NITFReadControl loaded with the desired SICD
-       *
-       * \return Scalar Mesh associated with the SICD NITF
-       */
+     * Given a reference to a loaded NITFReadControl, this function
+     * parses the SICD's DES and returns a ScalarMesh if present.
+     *
+     * \note If the scalar mesh is not present within the SICD,
+     *       the returned ScalarMesh will be null
+     *
+     * \param reader A NITFReadControl loaded with the desired SICD
+     *
+     * \return Scalar Mesh associated with the SICD NITF
+     */
     static std::auto_ptr<ScalarMesh> getScalarMesh(NITFReadControl& reader);
 
     /*

--- a/six/modules/c++/six.sicd/source/SICDMesh.cpp
+++ b/six/modules/c++/six.sicd/source/SICDMesh.cpp
@@ -96,7 +96,7 @@ ScalarMesh::ScalarMesh(
         const std::vector<double>& x,
         const std::vector<double>& y,
         size_t numScalarsPerCoord,
-        const std::map<std::string, std::vector<double>>& scalars):
+        const std::map<std::string, std::vector<double> >& scalars):
     PlanarCoordinateMesh(name, meshDims, x, y),
     mNumScalarsPerCoord(numScalarsPerCoord),
     mScalars(scalars)
@@ -117,7 +117,7 @@ std::vector<Mesh::Field> ScalarMesh::getFields() const
     }
 
     const std::string doubleTypeStr = "double";
-    std::map<std::string, std::vector<double>>::const_iterator it =
+    std::map<std::string, std::vector<double> >::const_iterator it =
             mScalars.begin();
     for (; it != mScalars.end(); ++it)
     {
@@ -137,7 +137,7 @@ void ScalarMesh::serialize(std::vector<sys::byte>& values) const
     six::serialize(mNumScalarsPerCoord, mSwapBytes, values);
 
     // Serialize the map
-    std::map<std::string, std::vector<double>>::const_iterator it =
+    std::map<std::string, std::vector<double> >::const_iterator it =
             mScalars.begin();
     for (; it != mScalars.end(); ++it)
     {

--- a/six/modules/c++/six.sicd/tests/test_mesh_roundtrip.cpp
+++ b/six/modules/c++/six.sicd/tests/test_mesh_roundtrip.cpp
@@ -58,11 +58,12 @@ double genRand()
            static_cast<double>(RAND_MAX);
 }
 
-void populateScalarMeshVectors(const types::RowCol<size_t>& meshDims,
-                               size_t numScalarsPerCoord,
-                               std::vector<double>& x,
-                               std::vector<double>& y,
-                               std::map<std::string, std::vector<double>>& scalars)
+void populateScalarMeshVectors(
+        const types::RowCol<size_t>& meshDims,
+        size_t numScalarsPerCoord,
+        std::vector<double>& x,
+        std::vector<double>& y,
+        std::map<std::string, std::vector<double> >& scalars)
 {
     x.clear();
     y.clear();
@@ -206,7 +207,7 @@ bool compareScalarMesh(const six::sicd::ScalarMesh& scalarMeshA,
         return false;
     }
 
-    std::map<std::string, std::vector<double>>::const_iterator it =
+    std::map<std::string, std::vector<double> >::const_iterator it =
             scalarMeshA.getScalars().begin();
 
     for (; it != scalarMeshA.getScalars().end(); ++it)
@@ -369,7 +370,7 @@ bool roundTripScalarMesh(const types::RowCol<size_t>& meshDims,
 {
     std::vector<double> x;
     std::vector<double> y;
-    std::map<std::string, std::vector<double>> scalars;
+    std::map<std::string, std::vector<double> > scalars;
 
     populateScalarMeshVectors(meshDims, numScalarsPerCoord, x, y, scalars);
 

--- a/six/modules/c++/six.sicd/tests/test_read_sicd_mesh.cpp
+++ b/six/modules/c++/six.sicd/tests/test_read_sicd_mesh.cpp
@@ -278,7 +278,7 @@ int main(int argc, char** argv)
                << scalarMesh->getNumScalarsPerCoord() << std::endl;
 
             std::cout << "Printing scalars:" << std::endl;
-            std::map<std::string, std::vector<double>>::const_iterator it =
+            std::map<std::string, std::vector<double> >::const_iterator it =
                     scalarMesh->getScalars().begin();
             for (; it != scalarMesh->getScalars().end(); ++it)
             {

--- a/six/modules/c++/six.sicd/tests/test_read_sicd_mesh.cpp
+++ b/six/modules/c++/six.sicd/tests/test_read_sicd_mesh.cpp
@@ -27,6 +27,7 @@ int main(int argc, char** argv)
         six::Poly2D outputRowColToSlantRow;
         six::Poly2D outputRowColToSlantCol;
         std::auto_ptr<six::sicd::NoiseMesh> noiseMesh;
+        std::auto_ptr<six::sicd::ScalarMesh> scalarMesh;
 
         std::cout << "Read SICD: " << sicdPathname << std::endl;
         six::sicd::Utilities::readSicd(sicdPathname,
@@ -37,7 +38,8 @@ int main(int argc, char** argv)
                                        widebandData,
                                        outputRowColToSlantRow,
                                        outputRowColToSlantCol,
-                                       noiseMesh);
+                                       noiseMesh,
+                                       scalarMesh);
 
         std::cout << "outputRowColToSlantRow: " << outputRowColToSlantRow << std::endl;
         std::cout << "outputRowColToSlantCol: " << outputRowColToSlantCol << std::endl;
@@ -265,6 +267,35 @@ int main(int argc, char** argv)
             "(dB) " << pow(10.0, meshPolyMeshRMSDb/10.0) << " (power)" << std::endl;
         std::cout << "    sicdPolyMeshPolyRMS: " << sicdPolyMeshPolyRMSDb <<
             "(dB) " << pow(10.0, sicdPolyMeshPolyRMSDb/10.0) << " (power)" << std::endl;
+
+        if (scalarMesh.get())
+        {
+            const types::RowCol<size_t> meshDims = scalarMesh->getMeshDims();
+            std::cout << "\nScalar Mesh dims: row = " << meshDims.row << ", col = "
+                      << meshDims.col << std::endl;
+
+            std::cout << "Number of grids of scalars: "
+               << scalarMesh->getNumScalarsPerCoord() << std::endl;
+
+            std::cout << "Printing scalars:" << std::endl;
+            std::map<std::string, std::vector<double>>::const_iterator it =
+                    scalarMesh->getScalars().begin();
+            for (; it != scalarMesh->getScalars().end(); ++it)
+            {
+                std::cout << "Key: " << it->first << std::endl;;
+                const std::vector<double>& scalars = it->second;
+                for (size_t row = 0; row < meshDims.row; ++row)
+                {
+                    for (size_t col = 0; col < meshDims.col; ++col)
+                    {
+                        std::cout  << scalars[row * meshDims.col + col] << " ";
+                    }
+
+                    std::cout  << "\n";
+                }
+                std::cout  << "\n";
+            }
+        }
     }   
     catch (const except::Exception& e)
     {

--- a/six/modules/c++/six.sicd/tests/test_read_sicd_mesh.cpp
+++ b/six/modules/c++/six.sicd/tests/test_read_sicd_mesh.cpp
@@ -275,7 +275,7 @@ int main(int argc, char** argv)
                       << meshDims.col << std::endl;
 
             std::cout << "Number of grids of scalars: "
-               << scalarMesh->getNumScalarsPerCoord() << std::endl;
+                      << scalarMesh->getNumScalarsPerCoord() << std::endl;
 
             std::cout << "Printing scalars:" << std::endl;
             std::map<std::string, std::vector<double> >::const_iterator it =

--- a/six/modules/c++/six/include/six/Serialize.h
+++ b/six/modules/c++/six/include/six/Serialize.h
@@ -142,6 +142,50 @@ struct Serializer<std::vector<T> >
 };
 
 /*!
+ * \struct Serializer
+ * \brief Implements serialization and deserialization for std::strings
+ */
+struct Serializer<std::string>
+{
+    /*!
+     * Serialize a std::string into the byte buffer.
+     *
+     * \param val The std::string to serialize.
+     * \param swapBytes Should byte-swapping be applied?
+     * \param[out] buffer The serialized data.
+     *
+     */
+    static void serializeImpl(const std::string& val,
+                              bool swapBytes,
+                              std::vector<sys::byte>& buffer)
+    {
+        const size_t length = val.size();
+        Serializer<size_t>::serializeImpl(length, swapBytes, buffer);
+        std::copy(val.begin(), val.end(), std::back_inserter(buffer));
+    }
+
+    /*!
+     * Deserialize a byte array into a std::string.
+     *
+     * \param buffer The data to deserialize. Pointer is incremented
+     *        by sizeof(size_t) + string_length.
+     * \param swapBytes Should byte-swapping be applied?
+     * \param[out] val The std::string to deserialize into.
+     */
+    static void deserializeImpl(const sys::byte*& buffer,
+                                bool swapBytes,
+                                std::string& val)
+    {
+        size_t length;
+        Serializer<size_t>::deserializeImpl(buffer, swapBytes, length);
+
+        const char* charPtr = reinterpret_cast<const char*>(buffer);
+        val.assign(charPtr, charPtr + length);
+        buffer += length;
+    }
+};
+
+/*!
  * Function interface to serialize.
  * \tparam T Data type to serialize. Argument determines which
  *  Serializer functor's implementation to use.

--- a/six/modules/c++/six/include/six/Serialize.h
+++ b/six/modules/c++/six/include/six/Serialize.h
@@ -154,7 +154,6 @@ struct Serializer<std::string>
      * \param val The std::string to serialize.
      * \param swapBytes Should byte-swapping be applied?
      * \param[out] buffer The serialized data.
-     *
      */
     static void serializeImpl(const std::string& val,
                               bool swapBytes,

--- a/six/modules/c++/six/include/six/Serialize.h
+++ b/six/modules/c++/six/include/six/Serialize.h
@@ -145,6 +145,7 @@ struct Serializer<std::vector<T> >
  * \struct Serializer
  * \brief Implements serialization and deserialization for std::strings
  */
+template <>
 struct Serializer<std::string>
 {
     /*!

--- a/six/modules/c++/six/unittests/test_serialize.cpp
+++ b/six/modules/c++/six/unittests/test_serialize.cpp
@@ -81,6 +81,17 @@ bool testVector(size_t length, bool byteSwap)
     six::deserialize<std::vector<T> >(buffer, byteSwap, valCopy);
     return val == valCopy;
 }
+
+bool testString(const std::string& str, bool byteSwap)
+{
+    std::vector<sys::byte> serializedData;
+    six::serialize<std::string>(str, byteSwap, serializedData);
+
+    const sys::byte* buffer = &serializedData[0];
+    std::string strCopy;
+    six::deserialize<std::string>(buffer, byteSwap, strCopy);
+    return str == strCopy;
+}
 }
 
 TEST_CASE(ScalarSerialize)
@@ -97,6 +108,17 @@ TEST_CASE(ScalarSerialize)
     TEST_ASSERT_TRUE(testScalar<size_t>(true));
     TEST_ASSERT_TRUE(testScalar<float>(true));
     TEST_ASSERT_TRUE(testScalar<double>(true));
+}
+
+TEST_CASE(StringSerialize)
+{
+    const std::string strNonEmpty = "TEST_STRING";
+    TEST_ASSERT_TRUE(testString(strNonEmpty, false));
+    TEST_ASSERT_TRUE(testString(strNonEmpty, true));
+
+    const std::string strEmpty = "";
+    TEST_ASSERT_TRUE(testString(strEmpty, false));
+    TEST_ASSERT_TRUE(testString(strEmpty, true));
 }
 
 TEST_CASE(VectorSerialize)
@@ -122,4 +144,5 @@ int main(int, char**)
     srand(time(NULL));
     TEST_CHECK(ScalarSerialize);
     TEST_CHECK(VectorSerialize);
+    TEST_CHECK(StringSerialize);
 }

--- a/six/modules/python/cphd/source/generated/cphd_wrap.cxx
+++ b/six/modules/python/cphd/source/generated/cphd_wrap.cxx
@@ -3111,41 +3111,42 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 #define SWIGTYPE_p_six__sicd__GainAndPhasePolys swig_types[101]
 #define SWIGTYPE_p_six__sicd__HalfPowerBeamwidths swig_types[102]
 #define SWIGTYPE_p_six__sicd__NoiseMesh swig_types[103]
-#define SWIGTYPE_p_size_t swig_types[104]
-#define SWIGTYPE_p_size_type swig_types[105]
-#define SWIGTYPE_p_ssize_t swig_types[106]
-#define SWIGTYPE_p_std__allocatorT_cphd__ArraySize_t swig_types[107]
-#define SWIGTYPE_p_std__allocatorT_cphd__ChannelParameters_t swig_types[108]
-#define SWIGTYPE_p_std__allocatorT_math__linear__VectorNT_3_double_t_t swig_types[109]
-#define SWIGTYPE_p_std__allocatorT_six__sicd__AntennaParameters_t swig_types[110]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__Antenna_t swig_types[111]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__DwellTimeParameters_t swig_types[112]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__FxParameters_t swig_types[113]
-#define SWIGTYPE_p_std__auto_ptrT_cphd__TOAParameters_t swig_types[114]
-#define SWIGTYPE_p_std__invalid_argument swig_types[115]
-#define SWIGTYPE_p_std__ostream swig_types[116]
-#define SWIGTYPE_p_std__vectorT_cphd__ArraySize_std__allocatorT_cphd__ArraySize_t_t swig_types[117]
-#define SWIGTYPE_p_std__vectorT_cphd__ChannelParameters_std__allocatorT_cphd__ChannelParameters_t_t swig_types[118]
-#define SWIGTYPE_p_std__vectorT_math__linear__VectorNT_3_double_t_std__allocatorT_math__linear__VectorNT_3_double_t_t_t swig_types[119]
-#define SWIGTYPE_p_std__vectorT_math__poly__OneDT_Vector3_t_std__allocatorT_math__poly__OneDT_Vector3_t_t_t swig_types[120]
-#define SWIGTYPE_p_std__vectorT_six__sicd__AntennaParameters_std__allocatorT_six__sicd__AntennaParameters_t_t swig_types[121]
-#define SWIGTYPE_p_std__vectorT_unsigned_char_std__allocatorT_unsigned_char_t_t swig_types[122]
-#define SWIGTYPE_p_std__vectorT_void_const_p_std__allocatorT_void_const_p_t_t swig_types[123]
-#define SWIGTYPE_p_swig__SwigPyIterator swig_types[124]
-#define SWIGTYPE_p_types__RowColT_double_t swig_types[125]
-#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[126]
-#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[127]
-#define SWIGTYPE_p_types__RowColT_size_t_t swig_types[128]
-#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[129]
-#define SWIGTYPE_p_uint16_t swig_types[130]
-#define SWIGTYPE_p_uint32_t swig_types[131]
-#define SWIGTYPE_p_uint64_t swig_types[132]
-#define SWIGTYPE_p_uint8_t swig_types[133]
-#define SWIGTYPE_p_unsigned_char swig_types[134]
-#define SWIGTYPE_p_value_type swig_types[135]
-#define SWIGTYPE_p_void swig_types[136]
-static swig_type_info *swig_types[138];
-static swig_module_info swig_module = {swig_types, 137, 0, 0, 0, 0};
+#define SWIGTYPE_p_six__sicd__ScalarMesh swig_types[104]
+#define SWIGTYPE_p_size_t swig_types[105]
+#define SWIGTYPE_p_size_type swig_types[106]
+#define SWIGTYPE_p_ssize_t swig_types[107]
+#define SWIGTYPE_p_std__allocatorT_cphd__ArraySize_t swig_types[108]
+#define SWIGTYPE_p_std__allocatorT_cphd__ChannelParameters_t swig_types[109]
+#define SWIGTYPE_p_std__allocatorT_math__linear__VectorNT_3_double_t_t swig_types[110]
+#define SWIGTYPE_p_std__allocatorT_six__sicd__AntennaParameters_t swig_types[111]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__Antenna_t swig_types[112]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__DwellTimeParameters_t swig_types[113]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__FxParameters_t swig_types[114]
+#define SWIGTYPE_p_std__auto_ptrT_cphd__TOAParameters_t swig_types[115]
+#define SWIGTYPE_p_std__invalid_argument swig_types[116]
+#define SWIGTYPE_p_std__ostream swig_types[117]
+#define SWIGTYPE_p_std__vectorT_cphd__ArraySize_std__allocatorT_cphd__ArraySize_t_t swig_types[118]
+#define SWIGTYPE_p_std__vectorT_cphd__ChannelParameters_std__allocatorT_cphd__ChannelParameters_t_t swig_types[119]
+#define SWIGTYPE_p_std__vectorT_math__linear__VectorNT_3_double_t_std__allocatorT_math__linear__VectorNT_3_double_t_t_t swig_types[120]
+#define SWIGTYPE_p_std__vectorT_math__poly__OneDT_Vector3_t_std__allocatorT_math__poly__OneDT_Vector3_t_t_t swig_types[121]
+#define SWIGTYPE_p_std__vectorT_six__sicd__AntennaParameters_std__allocatorT_six__sicd__AntennaParameters_t_t swig_types[122]
+#define SWIGTYPE_p_std__vectorT_unsigned_char_std__allocatorT_unsigned_char_t_t swig_types[123]
+#define SWIGTYPE_p_std__vectorT_void_const_p_std__allocatorT_void_const_p_t_t swig_types[124]
+#define SWIGTYPE_p_swig__SwigPyIterator swig_types[125]
+#define SWIGTYPE_p_types__RowColT_double_t swig_types[126]
+#define SWIGTYPE_p_types__RowColT_math__poly__TwoDT_double_t_t swig_types[127]
+#define SWIGTYPE_p_types__RowColT_scene__LatLon_t swig_types[128]
+#define SWIGTYPE_p_types__RowColT_size_t_t swig_types[129]
+#define SWIGTYPE_p_types__RowColT_ssize_t_t swig_types[130]
+#define SWIGTYPE_p_uint16_t swig_types[131]
+#define SWIGTYPE_p_uint32_t swig_types[132]
+#define SWIGTYPE_p_uint64_t swig_types[133]
+#define SWIGTYPE_p_uint8_t swig_types[134]
+#define SWIGTYPE_p_unsigned_char swig_types[135]
+#define SWIGTYPE_p_value_type swig_types[136]
+#define SWIGTYPE_p_void swig_types[137]
+static swig_type_info *swig_types[139];
+static swig_module_info swig_module = {swig_types, 138, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -55143,6 +55144,7 @@ static swig_type_info _swigt__p_six__sicd__ElectricalBoresight = {"_p_six__sicd_
 static swig_type_info _swigt__p_six__sicd__GainAndPhasePolys = {"_p_six__sicd__GainAndPhasePolys", "six::sicd::GainAndPhasePolys *|cphd::GainAndPhasePolys *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__HalfPowerBeamwidths = {"_p_six__sicd__HalfPowerBeamwidths", "six::sicd::HalfPowerBeamwidths *|cphd::HalfPowerBeamwidths *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_six__sicd__NoiseMesh = {"_p_six__sicd__NoiseMesh", "six::sicd::NoiseMesh *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_six__sicd__ScalarMesh = {"_p_six__sicd__ScalarMesh", "six::sicd::ScalarMesh *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_size_t = {"_p_size_t", "sys::Size_T *|size_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_size_type = {"_p_size_type", "size_type *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_ssize_t = {"_p_ssize_t", "sys::SSize_T *|ssize_t *", 0, 0, (void*)0, 0};
@@ -55282,6 +55284,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_six__sicd__GainAndPhasePolys,
   &_swigt__p_six__sicd__HalfPowerBeamwidths,
   &_swigt__p_six__sicd__NoiseMesh,
+  &_swigt__p_six__sicd__ScalarMesh,
   &_swigt__p_size_t,
   &_swigt__p_size_type,
   &_swigt__p_ssize_t,
@@ -55421,6 +55424,7 @@ static swig_cast_info _swigc__p_six__sicd__ElectricalBoresight[] = {  {&_swigt__
 static swig_cast_info _swigc__p_six__sicd__GainAndPhasePolys[] = {  {&_swigt__p_six__sicd__GainAndPhasePolys, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__HalfPowerBeamwidths[] = {  {&_swigt__p_six__sicd__HalfPowerBeamwidths, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_six__sicd__NoiseMesh[] = {  {&_swigt__p_six__sicd__NoiseMesh, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_six__sicd__ScalarMesh[] = {  {&_swigt__p_six__sicd__ScalarMesh, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_size_t[] = {  {&_swigt__p_size_t, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_size_type[] = {  {&_swigt__p_size_type, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_ssize_t[] = {  {&_swigt__p_ssize_t, 0, 0, 0},{0, 0, 0, 0}};
@@ -55560,6 +55564,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_six__sicd__GainAndPhasePolys,
   _swigc__p_six__sicd__HalfPowerBeamwidths,
   _swigc__p_six__sicd__NoiseMesh,
+  _swigc__p_six__sicd__ScalarMesh,
   _swigc__p_size_t,
   _swigc__p_size_type,
   _swigc__p_ssize_t,

--- a/six/modules/python/six.sicd/source/generated/six_sicd.py
+++ b/six/modules/python/six.sicd/source/generated/six_sicd.py
@@ -1544,6 +1544,7 @@ cvar = _six_sicd.cvar
 SICDMeshes.SLANT_PLANE_MESH_ID = _six_sicd.cvar.SICDMeshes_SLANT_PLANE_MESH_ID
 SICDMeshes.OUTPUT_PLANE_MESH_ID = _six_sicd.cvar.SICDMeshes_OUTPUT_PLANE_MESH_ID
 SICDMeshes.NOISE_MESH_ID = _six_sicd.cvar.SICDMeshes_NOISE_MESH_ID
+SICDMeshes.SCALAR_MESH_ID = _six_sicd.cvar.SICDMeshes_SCALAR_MESH_ID
 
 class PlanarCoordinateMesh(_object):
     """Proxy of C++ six::sicd::PlanarCoordinateMesh class."""
@@ -1603,6 +1604,59 @@ class PlanarCoordinateMesh(_object):
     __del__ = lambda self: None
 PlanarCoordinateMesh_swigregister = _six_sicd.PlanarCoordinateMesh_swigregister
 PlanarCoordinateMesh_swigregister(PlanarCoordinateMesh)
+
+class ScalarMesh(PlanarCoordinateMesh):
+    """Proxy of C++ six::sicd::ScalarMesh class."""
+
+    __swig_setmethods__ = {}
+    for _s in [PlanarCoordinateMesh]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, ScalarMesh, name, value)
+    __swig_getmethods__ = {}
+    for _s in [PlanarCoordinateMesh]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, ScalarMesh, name)
+    __repr__ = _swig_repr
+
+    def __init__(self, *args):
+        """
+        __init__(six::sicd::ScalarMesh self, std::string const & name) -> ScalarMesh
+        __init__(six::sicd::ScalarMesh self, std::string const & name, RowColSizeT meshDims, std_vector_double x, std_vector_double y, size_t numScalarsPerCoord, std::map< std::string,std::vector< double,std::allocator< double > > > const & scalars) -> ScalarMesh
+        """
+        this = _six_sicd.new_ScalarMesh(*args)
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+
+    def getScalars(self):
+        """getScalars(ScalarMesh self) -> std::map< std::string,std::vector< double,std::allocator< double > > > const &"""
+        return _six_sicd.ScalarMesh_getScalars(self)
+
+
+    def getNumScalarsPerCoord(self):
+        """getNumScalarsPerCoord(ScalarMesh self) -> size_t"""
+        return _six_sicd.ScalarMesh_getNumScalarsPerCoord(self)
+
+
+    def getFields(self):
+        """getFields(ScalarMesh self) -> std::vector< Mesh::Field,std::allocator< Mesh::Field > >"""
+        return _six_sicd.ScalarMesh_getFields(self)
+
+
+    def serialize(self, values):
+        """serialize(ScalarMesh self, std::vector< sys::byte,std::allocator< sys::byte > > & values)"""
+        return _six_sicd.ScalarMesh_serialize(self, values)
+
+
+    def deserialize(self, values):
+        """deserialize(ScalarMesh self, sys::byte const *& values)"""
+        return _six_sicd.ScalarMesh_deserialize(self, values)
+
+    __swig_destroy__ = _six_sicd.delete_ScalarMesh
+    __del__ = lambda self: None
+ScalarMesh_swigregister = _six_sicd.ScalarMesh_swigregister
+ScalarMesh_swigregister(ScalarMesh)
 
 class NoiseMesh(PlanarCoordinateMesh):
     """Proxy of C++ six::sicd::NoiseMesh class."""
@@ -4993,7 +5047,7 @@ class SixSicdUtilities(_object):
     def readSicd(*args):
         """
         readSicd(std::string const & sicdPathname, VectorString schemaPaths, std::auto_ptr< six::sicd::ComplexData > & complexData, std::vector< std::complex< float >,std::allocator< std::complex< float > > > & widebandData)
-        readSicd(std::string const & sicdPathname, VectorString schemaPaths, size_t orderX, size_t orderY, std::auto_ptr< six::sicd::ComplexData > & complexData, std::vector< std::complex< float >,std::allocator< std::complex< float > > > & widebandData, Poly2D outputRowColToSlantRow, Poly2D outputRowColToSlantCol, std::auto_ptr< six::sicd::NoiseMesh > & noiseMesh)
+        readSicd(std::string const & sicdPathname, VectorString schemaPaths, size_t orderX, size_t orderY, std::auto_ptr< six::sicd::ComplexData > & complexData, std::vector< std::complex< float >,std::allocator< std::complex< float > > > & widebandData, Poly2D outputRowColToSlantRow, Poly2D outputRowColToSlantCol, std::auto_ptr< six::sicd::NoiseMesh > & noiseMesh, std::auto_ptr< six::sicd::ScalarMesh > & scalarMesh)
         """
         return _six_sicd.SixSicdUtilities_readSicd(*args)
 
@@ -5082,6 +5136,12 @@ class SixSicdUtilities(_object):
 
     getNoiseMesh = staticmethod(getNoiseMesh)
 
+    def getScalarMesh(reader):
+        """getScalarMesh(NITFReadControl & reader) -> std::auto_ptr< six::sicd::ScalarMesh >"""
+        return _six_sicd.SixSicdUtilities_getScalarMesh(reader)
+
+    getScalarMesh = staticmethod(getScalarMesh)
+
     def getProjectionPolys(reader, orderX, orderY, complexData, outputRowColToSlantRow, outputRowColToSlantCol):
         """getProjectionPolys(NITFReadControl & reader, size_t orderX, size_t orderY, std::auto_ptr< six::sicd::ComplexData > & complexData, Poly2D outputRowColToSlantRow, Poly2D outputRowColToSlantCol)"""
         return _six_sicd.SixSicdUtilities_getProjectionPolys(reader, orderX, orderY, complexData, outputRowColToSlantRow, outputRowColToSlantCol)
@@ -5163,7 +5223,7 @@ def SixSicdUtilities_getValidDataPolygon(sicdData, projection, validData):
 def SixSicdUtilities_readSicd(*args):
     """
     readSicd(std::string const & sicdPathname, VectorString schemaPaths, std::auto_ptr< six::sicd::ComplexData > & complexData, std::vector< std::complex< float >,std::allocator< std::complex< float > > > & widebandData)
-    SixSicdUtilities_readSicd(std::string const & sicdPathname, VectorString schemaPaths, size_t orderX, size_t orderY, std::auto_ptr< six::sicd::ComplexData > & complexData, std::vector< std::complex< float >,std::allocator< std::complex< float > > > & widebandData, Poly2D outputRowColToSlantRow, Poly2D outputRowColToSlantCol, std::auto_ptr< six::sicd::NoiseMesh > & noiseMesh)
+    SixSicdUtilities_readSicd(std::string const & sicdPathname, VectorString schemaPaths, size_t orderX, size_t orderY, std::auto_ptr< six::sicd::ComplexData > & complexData, std::vector< std::complex< float >,std::allocator< std::complex< float > > > & widebandData, Poly2D outputRowColToSlantRow, Poly2D outputRowColToSlantCol, std::auto_ptr< six::sicd::NoiseMesh > & noiseMesh, std::auto_ptr< six::sicd::ScalarMesh > & scalarMesh)
     """
     return _six_sicd.SixSicdUtilities_readSicd(*args)
 
@@ -5227,6 +5287,10 @@ def SixSicdUtilities_createFakeComplexData():
 def SixSicdUtilities_getNoiseMesh(reader):
     """SixSicdUtilities_getNoiseMesh(NITFReadControl & reader) -> std::auto_ptr< six::sicd::NoiseMesh >"""
     return _six_sicd.SixSicdUtilities_getNoiseMesh(reader)
+
+def SixSicdUtilities_getScalarMesh(reader):
+    """SixSicdUtilities_getScalarMesh(NITFReadControl & reader) -> std::auto_ptr< six::sicd::ScalarMesh >"""
+    return _six_sicd.SixSicdUtilities_getScalarMesh(reader)
 
 def SixSicdUtilities_getProjectionPolys(reader, orderX, orderY, complexData, outputRowColToSlantRow, outputRowColToSlantCol):
     """SixSicdUtilities_getProjectionPolys(NITFReadControl & reader, size_t orderX, size_t orderY, std::auto_ptr< six::sicd::ComplexData > & complexData, Poly2D outputRowColToSlantRow, Poly2D outputRowColToSlantCol)"""

--- a/six/modules/python/six.sicd/source/six_sicd.i
+++ b/six/modules/python/six.sicd/source/six_sicd.i
@@ -210,6 +210,7 @@ nitf::Record _readRecord(const std::string& pathname)
 %auto_ptr(six::sicd::ComplexData);
 %auto_ptr(scene::ProjectionPolynomialFitter);
 %auto_ptr(six::sicd::NoiseMesh);
+%auto_ptr(six::sicd::ScalarMesh);
 
 %typemap(out) nitf::Uint32, nitf::Int32{$result = PyInt_FromLong($1);}
 %typemap(in) nitf::Uint32{$1 = (nitf::Uint32)PyInt_AsLong($input);}


### PR DESCRIPTION
Adds a new mesh type "Scalar Mesh" to SICDMesh. This mesh can be used to associate any number of scalars with a given x,y coordinate pair.  