### PR TITLE
Bugfix/cphd fixes

### DIFF
--- a/six/modules/c++/cphd/include/cphd/CPHDXMLControl.h
+++ b/six/modules/c++/cphd/include/cphd/CPHDXMLControl.h
@@ -121,8 +121,8 @@ protected:
     bool mOwnLog;
 
 private:
-    //! Hardcoded version to uri mapping
-    static const std::unordered_map<std::string, std::string> VERSION_URI_MAP;
+    //! \return Hardcoded version to uri mapping
+    static std::unordered_map<std::string, std::string> getVersionUriMap();
 
     /*!
      *  This function takes in a Metadata object and converts

--- a/six/modules/c++/cphd/include/cphd/Wideband.h
+++ b/six/modules/c++/cphd/include/cphd/Wideband.h
@@ -349,7 +349,7 @@ public:
     /*!
      * Get sample type element size
      */
-    size_t getElementSize()
+    size_t getElementSize() const
     {
         return mElementSize;
     }

--- a/six/modules/c++/cphd/source/CPHDXMLControl.cpp
+++ b/six/modules/c++/cphd/source/CPHDXMLControl.cpp
@@ -38,12 +38,6 @@
 namespace cphd
 {
 
-const std::unordered_map<std::string, std::string> CPHDXMLControl::VERSION_URI_MAP =
-{
-    {"1.0.0", "urn:CPHD:1.0.0"},
-    {"1.0.1", "http://api.nsgreg.nga.mil/schema/cphd/1.0.1"}
-};
-
 CPHDXMLControl::CPHDXMLControl(logging::Logger* log, bool ownLog) :
     mLog(NULL),
     mOwnLog(false)
@@ -105,16 +99,25 @@ std::unique_ptr<xml::lite::Document> CPHDXMLControl::toXML(
     return doc;
 }
 
+std::unordered_map<std::string, std::string> CPHDXMLControl::getVersionUriMap()
+{
+    return {
+        {"1.0.0", "urn:CPHD:1.0.0"},
+        {"1.0.1", "http://api.nsgreg.nga.mil/schema/cphd/1.0.1"}
+    };
+}
+
 std::unique_ptr<xml::lite::Document> CPHDXMLControl::toXMLImpl(const Metadata& metadata)
 {
-    if (VERSION_URI_MAP.find(metadata.getVersion()) != VERSION_URI_MAP.end())
+    const auto versionUriMap = getVersionUriMap();
+    if (versionUriMap.find(metadata.getVersion()) != versionUriMap.end())
     {
-        return getParser(VERSION_URI_MAP.find(metadata.getVersion())->second)->toXML(metadata);
+        return getParser(versionUriMap.find(metadata.getVersion())->second)->toXML(metadata);
     }
     std::ostringstream ostr;
     ostr << "The version " << metadata.getVersion() << " is invalid. "
          << "Check if version is valid or "
-         << "add a <version, URI> entry to VERSION_URI_MAP";
+         << "add a <version, URI> entry to versionUriMap";
     throw except::Exception(Ctxt(ostr.str()));
 }
 
@@ -156,7 +159,8 @@ CPHDXMLControl::getParser(const std::string& uri) const
 
 std::string CPHDXMLControl::uriToVersion(const std::string& uri) const
 {
-    for (auto it = VERSION_URI_MAP.begin(); it != VERSION_URI_MAP.end(); ++it)
+    const auto versionUriMap = getVersionUriMap();
+    for (auto it = versionUriMap.begin(); it != versionUriMap.end(); ++it)
     {
         if (it->second == uri)
         {
@@ -166,7 +170,7 @@ std::string CPHDXMLControl::uriToVersion(const std::string& uri) const
     std::ostringstream ostr;
     ostr << "The URI " << uri << " is invalid. "
          << "Either input a valid URI or "
-         << "add a <version, URI> entry to VERSION_URI_MAP";
+         << "add a <version, URI> entry to versionUriMap";
     throw except::Exception(Ctxt(ostr.str()));
 }
 

--- a/six/modules/c++/cphd/source/CPHDXMLParser.cpp
+++ b/six/modules/c++/cphd/source/CPHDXMLParser.cpp
@@ -119,7 +119,7 @@ XMLElem CPHDXMLParser::toXML(const CollectionInformation& collectionID, XMLElem 
 
     // RadarMode
     XMLElem radarModeXML = newElement("RadarMode", collectionXML);
-    createString("ModeType", collectionID.radarMode.toString(), radarModeXML);
+    createString("ModeType", six::toString(collectionID.radarMode), radarModeXML);
     if(!six::Init::isUndefined(collectionID.radarModeID))
     {
         createString("ModeID", collectionID.radarModeID, radarModeXML);

--- a/six/modules/c++/cphd/source/PVPBlock.cpp
+++ b/six/modules/c++/cphd/source/PVPBlock.cpp
@@ -660,6 +660,17 @@ double PVPBlock::getTdIonoSRP(size_t channel, size_t set) const
                     "Parameter was not set"));
 }
 
+double PVPBlock::getSignal(size_t channel, size_t set) const
+{
+    verifyChannelVector(channel, set);
+    if (mData[channel][set].signal.get())
+    {
+        return *mData[channel][set].signal;
+    }
+    throw except::Exception(Ctxt(
+                    "Parameter was not set"));
+}
+
 void PVPBlock::setTxTime(double value, size_t channel, size_t vector)
 {
     verifyChannelVector(channel, vector);


### PR DESCRIPTION
Add missing implementations

Fix CPHD XML serialization for RadarModeType to match schema

Add const correctness

Refactor CPHDXMLControl to not use static version-to-URI map. Use case: I develop a plugin that reads CPHD data, and the application that calls that plugin also depends on the cphd-c++ module. Application segfaults when freeing both.