### PR TITLE
check if the default schema path exists

### DIFF
--- a/six/modules/c++/six/source/XMLControl.cpp
+++ b/six/modules/c++/six/source/XMLControl.cpp
@@ -115,9 +115,9 @@ void XMLControl::validate(const xml::lite::Document* doc,
         // log any error found and throw
         if (!errors.empty())
         {
-            for (size_t i = 0; i < errors.size(); ++i)
+            if (log)
             {
-                if (log)
+                for (size_t i = 0; i < errors.size(); ++i)
                 {
                     log->critical(errors[i].toString());
                 }

--- a/six/modules/c++/six/source/XMLControl.cpp
+++ b/six/modules/c++/six/source/XMLControl.cpp
@@ -71,6 +71,15 @@ void XMLControl::validate(const xml::lite::Document* doc,
     std::vector<std::string> paths(schemaPaths);
     loadSchemaPaths(paths);
 
+    if (schemaPaths.empty() && log)
+    {
+        std::ostringstream oss;
+        oss << "Coudn't validate XML - no schemas paths provided "
+            << " and " << six::SCHEMA_PATH << " not set.";
+
+        log->warn(oss.str());
+    }
+
     sys::OS os;
     // If the paths we have don't exist, throw
     for (size_t ii = 0; ii < paths.size(); ++ii)
@@ -108,7 +117,10 @@ void XMLControl::validate(const xml::lite::Document* doc,
         {
             for (size_t i = 0; i < errors.size(); ++i)
             {
-                log->critical(errors[i].toString());
+                if (log)
+                {
+                    log->critical(errors[i].toString());
+                }
             }
 
             //! this is a unique error thrown only in this location --

--- a/six/modules/c++/six/source/XMLControl.cpp
+++ b/six/modules/c++/six/source/XMLControl.cpp
@@ -44,14 +44,16 @@ void XMLControl::loadSchemaPaths(std::vector<std::string>& schemaPaths)
 {
     if (schemaPaths.empty())
     {
+        const sys::OS os;
+
         std::string envPath;
-        sys::OS().getEnvIfSet(six::SCHEMA_PATH, envPath);
+        os.getEnvIfSet(six::SCHEMA_PATH, envPath);
         str::trim(envPath);
         if (!envPath.empty())
         {
             schemaPaths.push_back(envPath);
         }
-        else
+        else if (os.exists(DEFAULT_SCHEMA_PATH))
         {
             schemaPaths.push_back(DEFAULT_SCHEMA_PATH);
         }


### PR DESCRIPTION
XMLControl validation was updated to always load a default schema path defined at config time. The default config path points to the install prefix directory. This causes runtime errors when the absolute path to the schema directory has been changed and no SIX_SCHEMA_PATH has been set (for example, renaming your source directory or creating a delivery).

