### PR TITLE
Make DirectionParameters::calculateWeightFunction() a public function

### DIFF
--- a/six/modules/c++/six.sicd/include/six/sicd/Grid.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Grid.h
@@ -146,9 +146,9 @@ struct DirectionParameters
 
     void fillDerivedFields(const ImageData& imageData);
     void fillDerivedFields(const RgAzComp& rgAzComp, double offset = 0);
+    std::unique_ptr<Functor> calculateWeightFunction() const;
 
 private:
-    std::unique_ptr<Functor> calculateWeightFunction() const;
 
     bool validateWeights(const Functor& weightFunction,
             logging::Logger& log) const;


### PR DESCRIPTION
This function is useful to be used in other places, so I made it public here.