### PR TITLE
Faster conversion of std::complex -> 8-bit amplitude and phase (3x speedup)

### DIFF
--- a/six/modules/c++/six.sicd/CMakeLists.txt
+++ b/six/modules/c++/six.sicd/CMakeLists.txt
@@ -6,6 +6,7 @@ coda_add_module(
         source/AreaPlaneUtility.cpp
         source/ComplexData.cpp
         source/ComplexDataBuilder.cpp
+        source/ComplexToAMP8IPHS8I.cpp
         source/ComplexXMLControl.cpp
         source/ComplexXMLParser.cpp
         source/ComplexXMLParser040.cpp

--- a/six/modules/c++/six.sicd/include/six/sicd/ComplexToAMP8IPHS8I.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ComplexToAMP8IPHS8I.h
@@ -1,0 +1,45 @@
+#ifndef __SIX_SICD_COMPLEXTOAMP8IPHS8I__
+#define __SIX_SICD_COMPLEXTOAMP8IPHS8I__
+
+#include <six/sicd/ImageData.h>
+
+namespace six
+{
+namespace sicd
+{
+/*!
+ * \brief A utility that's used to convert complex values into 8-bit amplitude and phase values.
+ */
+class ComplexToAMP8IPHS8I {
+public:
+    /*!
+     * Create a lookup structure that converts from complex to amplitude and phase.
+     * @param pAmplitudeTable optional amplitude table.
+     */
+    explicit ComplexToAMP8IPHS8I(const six::AmplitudeTable* pAmplitudeTable = nullptr);
+
+    /*!
+     * Get the nearest amplitude and phase value given a complex value
+     * @param v complex value to query with
+     * @return nearest amplitude and phase value
+     */
+    ImageData::AMP8I_PHS8I_t nearest_neighbor(const std::complex<double>& v) const;
+
+private:
+    //! The sorted set of possible magnitudes order from small to large.
+    std::array<double, UINT8_MAX + 1> magnitudes;
+    //! The difference in phase angle between two UINT phase values.
+    double phase_delta;
+    //! Unit vector rays that represent each direction that phase can point.
+    std::array<std::complex<double>, UINT8_MAX + 1> phase_directions;
+
+    /*!
+     * Get the phase of a complex value.
+     * @param v complex value
+     * @return phase between [0, 2PI]
+     */
+    static double GetPhase(const std::complex<double>& v);
+};
+}
+}
+#endif

--- a/six/modules/c++/six.sicd/source/ComplexToAMP8IPHS8I.cpp
+++ b/six/modules/c++/six.sicd/source/ComplexToAMP8IPHS8I.cpp
@@ -1,0 +1,86 @@
+#include <cassert>
+
+#include <six/sicd/ComplexToAMP8IPHS8I.h>
+#include <six/sicd/Utilities.h>
+#include <math/Utilities.h>
+
+namespace six {
+namespace sicd {
+
+ComplexToAMP8IPHS8I::ComplexToAMP8IPHS8I(const six::AmplitudeTable *pAmplitudeTable) {
+
+    // Be careful with indexing so that we don't wrap-around in the loops.
+    for (uint16_t i = 0; i <= UINT8_MAX; i++) {
+        // AmpPhase -> Complex
+        ImageData::AMP8I_PHS8I_t v;
+        v.first = i;
+        v.second = i;
+        auto complex = Utilities::from_AMP8I_PHS8I(v.first, v.second, pAmplitudeTable);
+        magnitudes[i] = {
+                std::abs(complex)
+        };
+    }
+
+    // I don't know if we can guarantee that the amplitude table is non-decreasing.
+    // Check to verify property at runtime.
+    if (!std::is_sorted(magnitudes.begin(), magnitudes.end())) {
+        throw std::runtime_error("magnitudes must be sorted");
+    }
+
+    const auto p0 = GetPhase(Utilities::from_AMP8I_PHS8I(1, 0, pAmplitudeTable));
+    const auto p1 = GetPhase(Utilities::from_AMP8I_PHS8I(1, 1, pAmplitudeTable));
+    assert(p0 == 0);
+    assert(p1 > p0);
+    phase_delta = p1 - p0;
+    for(int i = 0; i <= UINT8_MAX; i++) {
+        double y, x;
+        math::SinCos(p0 + i * phase_delta, y, x);
+        phase_directions[i] = { x, y };
+    }
+}
+
+/*!
+ * Find the nearest element given an iterator range.
+ * @tparam TIter type of iterator
+ * @param begin beginning of search range
+ * @param end end of search range
+ * @param value query value
+ * @return index of nearest value within the iterator range.
+ */
+template<typename TIter>
+static uint8_t nearest(const TIter& begin, const TIter& end, double value) {
+    auto it = std::lower_bound(begin, end, value);
+    if(it == begin) return uint8_t(0);
+    auto prev_it = std::prev(it);
+    auto nearest = (it == end || value - *prev_it <= *it - value) ? prev_it : it;
+    assert(std::distance(begin, nearest) <= std::numeric_limits<uint8_t>::max());
+    return static_cast<uint8_t>(std::distance(begin, nearest));
+}
+
+ImageData::AMP8I_PHS8I_t ComplexToAMP8IPHS8I::nearest_neighbor(const std::complex<double> &v) const {
+    ImageData::AMP8I_PHS8I_t ans;
+
+    // Phase is determined via arithmetic because it's equally spaced.
+    // There's an intentional conversion to zero when we cast 256 -> uint8. That wrap around
+    // handles cases that are close to 2PI.
+    ans.second = static_cast<uint8_t>(std::round(GetPhase(v) / phase_delta));
+
+    // We have to do a 1D nearest neighbor search for magnitude.
+    // But it's not the magnitude of the input complex value - it's the projection of
+    // the complex value onto the ray of candidate magnitudes at the selected phase.
+    // I.e. dot product.
+    std::complex<double> direction = phase_directions[ans.second];
+    double projection = direction.real() * v.real() + direction.imag() * v.imag();
+    assert(std::abs(projection - std::abs(v)) < 1e-5);
+    ans.first = nearest(magnitudes.begin(), magnitudes.end(), projection);
+    return ans;
+}
+
+
+double ComplexToAMP8IPHS8I::GetPhase(const std::complex<double> &v) {
+    double phase = std::arg(v);
+    if (phase < 0.0) phase += M_PI * 2.0; // Wrap from [0, 2PI]
+    return phase;
+}
+}
+}

--- a/six/modules/c++/six.sicd/source/ImageData.cpp
+++ b/six/modules/c++/six.sicd/source/ImageData.cpp
@@ -27,6 +27,7 @@
 #include <gsl/gsl.h>
 #include <mt/Algorithm.h>
 
+#include "six/sicd/ComplexToAMP8IPHS8I.h"
 #include "six/sicd/GeoData.h"
 #include "six/sicd/ImageData.h"
 #include "six/sicd/Utilities.h"
@@ -242,18 +243,17 @@ void ImageData::from_AMP8I_PHS8I(std::span<const AMP8I_PHS8I_t> inputs, std::spa
     }
 }
 
-static const KDTree* make_KDTree(const six::AmplitudeTable* pAmplitudeTable, std::unique_ptr<KDTree>& pTree)
+static const ComplexToAMP8IPHS8I* make_ComplexToAMP8IPHS8I(const six::AmplitudeTable* pAmplitudeTable, std::unique_ptr<ComplexToAMP8IPHS8I>& pTree)
 {
-    // create all of of the possible KDNodes values
     if (pAmplitudeTable == nullptr)
     {
         // this won't change, so OK to cache
-        static const KDTree tree(make_KDNodes(nullptr));
+        static const ComplexToAMP8IPHS8I tree{};
         return &tree;
     }
     else
     {
-        pTree = std::make_unique<KDTree>(make_KDNodes(pAmplitudeTable));
+        pTree = std::make_unique<ComplexToAMP8IPHS8I>(pAmplitudeTable);
         return pTree.get();
     }
 }
@@ -261,13 +261,12 @@ static const KDTree* make_KDTree(const six::AmplitudeTable* pAmplitudeTable, std
 void ImageData::to_AMP8I_PHS8I(std::span<const cx_float> inputs, std::span<AMP8I_PHS8I_t> results,
     ptrdiff_t cutoff_) const
 {
-    // make the KDTree to quickly find the nearest neighbor
-    std::unique_ptr<KDTree> pTree; // not-cached, non-NULL amplitudeTable
-    const auto& tree = *(make_KDTree(amplitudeTable.get(), pTree));
-    const auto nearest_neighbor_f = [&tree](const std::complex<float>& v)
+    // make a structure to quickly find the nearest neighbor
+    std::unique_ptr<ComplexToAMP8IPHS8I> pTree; // not-cached, non-NULL amplitudeTable
+    const auto& tree = *(make_ComplexToAMP8IPHS8I(amplitudeTable.get(), pTree));
+    const auto nearest_neighbor_f = [&](const std::complex<float>& v)
     {
-        auto result = tree.nearest_neighbor(six::sicd::ImageData::KDNode{ v });
-        return result.amp_and_value;
+        return tree.nearest_neighbor(v);
     };
 
     const auto begin = inputs.data(); // no iterators with our homebrew span<>


### PR DESCRIPTION
This change introduces a new acceleration structure that can efficiently map from `std::complex` to 8-bit amplitude and phase.
This is accomplished by exploiting the systematic distribution of the 8-bit amplitude and phase values in the original complex domain.

I measured the performance of `master` and this branch. Specifically, the runtime of `ImageData::to_AMP8I_PHS8I` that's called by the `read_8bit_ampphs_with_table` unit test:
- old: 9132ms
- new: 2884ms

This addresses #534 while keeping the mulit-threading performance improvement added by #536.