### PR TITLE
Bugfix/multi segment area plane blocks

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,6 +6,7 @@
 * replace KDTree *`std::complex<float>` -> AMP8I_PHS8I conversion* with a
   ["math based" approach](https://github.com/ngageoint/six-library/pull/537#issuecomment-1026453353).
 * restore SIDD 2.0 `AngleMagnitudeType`, SIDD 3.0 is `AngleZeroToExclusive360MagnitudeType`
+* bugfix: "We found a bug/mistake/error in **six.sicd/source/RadarCollection.cpp**, specifically the function to rotate the Area\Plane\SegmentList block."
 
 ## Version 3.1.8; December 13, 2021
 * [coda-oss](https://github.com/mdaus/coda-oss) version [2021-12-13](https://github.com/mdaus/coda-oss/releases/tag/2021-12-13)

--- a/six/modules/c++/six.sicd/source/RadarCollection.cpp
+++ b/six/modules/c++/six.sicd/source/RadarCollection.cpp
@@ -24,6 +24,9 @@
 #include <gsl/gsl.h>
 #include <six/Utilities.h>
 
+#undef min
+#undef max
+
 namespace
 {
 template <typename T>
@@ -344,8 +347,8 @@ types::RowCol<double> AreaPlane::getAdjustedReferencePoint() const
     //       pixel-centered 0-based.  More generally than this, we need to
     //       account for the SICD FirstLine/FirstSample offset
     //
-    refPt.row -= static_cast<double>(xDirection->first);
-    refPt.col -= static_cast<double>(yDirection->first);
+    refPt.row -= gsl::narrow_cast<double>(xDirection->first);
+    refPt.col -= gsl::narrow_cast<double>(yDirection->first);
 
     return refPt;
 }
@@ -430,10 +433,10 @@ void Segment::rotateCCW(size_t numColumns)
     const auto numColumns_ = gsl::narrow<int64_t>(numColumns);
     const six::RowColDouble start(types::RowCol<int64_t>(numColumns_ - 1 - endSample, startLine));
     const six::RowColDouble end(types::RowCol<int64_t>(numColumns_ - 1 - startSample, endLine));
-    startLine = static_cast<int>(start.row);
-    startSample = static_cast<int>(start.col);
-    endLine = static_cast<int>(end.row);
-    endSample = static_cast<int>(end.col);
+    startLine = gsl::narrow_cast<int>(start.row);
+    startSample = gsl::narrow_cast<int>(start.col);
+    endLine = gsl::narrow_cast<int>(end.row);
+    endSample = gsl::narrow_cast<int>(end.col);
 }
 
 

--- a/six/modules/c++/six.sicd/source/RadarCollection.cpp
+++ b/six/modules/c++/six.sicd/source/RadarCollection.cpp
@@ -20,6 +20,8 @@
  *
  */
 #include <six/sicd/RadarCollection.h>
+
+#include <gsl/gsl.h>
 #include <six/Utilities.h>
 
 namespace
@@ -409,11 +411,11 @@ void AreaPlane::rotateCCW()
 
     for (size_t ii = 0; ii < segmentList.size(); ++ii)
     {
-        segmentList[ii]->rotateCCW(yDirection->elements);
+        segmentList[ii]->rotateCCW(xDirection->elements);
     }
 }
 
-void Segment::rotateCCW(size_t /*numColumns*/)
+void Segment::rotateCCW(size_t numColumns)
 {
     /*
      *   5   wth           --    ! is reference corner
@@ -425,8 +427,9 @@ void Segment::rotateCCW(size_t /*numColumns*/)
      *                    !--
      */
    
-    const six::RowColDouble start(types::RowCol<int>(startSample * -1, startLine));
-    const six::RowColDouble end(types::RowCol<int>(endSample * -1, endLine));
+    const auto numColumns_ = gsl::narrow<int64_t>(numColumns);
+    const six::RowColDouble start(types::RowCol<int64_t>(numColumns_ - 1 - endSample, startLine));
+    const six::RowColDouble end(types::RowCol<int64_t>(numColumns_ - 1 - startSample, endLine));
     startLine = static_cast<int>(start.row);
     startSample = static_cast<int>(start.col);
     endLine = static_cast<int>(end.row);

--- a/six/modules/c++/six.sicd/unittests/test_area_plane.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_area_plane.cpp
@@ -174,9 +174,9 @@ TEST_CASE(testRotatePlane)
     TEST_ASSERT_EQ(plane.xDirection->spacing, 5);
     TEST_ASSERT_EQ(plane.yDirection->spacing, 7);
 
-    TEST_ASSERT_EQ(plane.segmentList[0]->startLine, 0);
+    TEST_ASSERT_EQ(plane.segmentList[0]->startLine, 1);
     TEST_ASSERT_EQ(plane.segmentList[0]->startSample, 1);
-    TEST_ASSERT_EQ(plane.segmentList[0]->endLine, -8);
+    TEST_ASSERT_EQ(plane.segmentList[0]->endLine, 9);
     TEST_ASSERT_EQ(plane.segmentList[0]->endSample, 4);
 
     TEST_ASSERT_EQ(originalNumLines, plane.segmentList[0]->getNumSamples());
@@ -188,11 +188,28 @@ TEST_CASE(testRotatePlane)
 TEST_CASE(testCanRotateFourTimes)
 {
     six::sicd::AreaPlane plane;
-    scene::ECEFToLLATransform transformer;
     plane.orientation = six::OrientationType::LEFT;
     plane.yDirection->elements = 10;
     plane.xDirection->elements = 20;
     plane.referencePoint.rowCol = six::RowColDouble(1, 2);
+
+    plane.yDirection->spacing = 5;
+    plane.xDirection->spacing = 7;
+
+    plane.yDirection->unitVector[0] = 0;
+    plane.yDirection->unitVector[1] = 1;
+    plane.yDirection->unitVector[2] = 0;
+
+    plane.xDirection->unitVector[0] = 1;
+    plane.xDirection->unitVector[1] = 0;
+    plane.xDirection->unitVector[2] = 0;
+
+    plane.segmentList.resize(1);
+    plane.segmentList[0].reset(new six::sicd::Segment());
+    plane.segmentList[0]->startLine = 1;
+    plane.segmentList[0]->startSample = 0;
+    plane.segmentList[0]->endLine = 4;
+    plane.segmentList[0]->endSample = 8;
 
     std::unique_ptr<six::sicd::AreaPlane> originalPlane(plane.clone());
     plane.rotateCCW();


### PR DESCRIPTION
From E. Williams "We found a bug/mistake/error in **six.sicd/source/RadarCollection.cpp**, specifically the function to rotate the Area\Plane\SegmentList block."