### PR TITLE
Faster 8AMPI_PHSI -> complex

### DIFF
--- a/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
@@ -106,6 +106,7 @@ struct ImageData
     cx_float from_AMP8I_PHS8I(const AMP8I_PHS8I_t&) const; // for unit-tests
     static void to_AMP8I_PHS8I(const AmplitudeTable*, std::span<const cx_float>, std::span<AMP8I_PHS8I_t>, ptrdiff_t cutoff = -1); // for unit-tests
 
+    static void from_AMP8I_PHS8I(const input_amplitudes_t& lookup, std::span<const AMP8I_PHS8I_t>, std::span<cx_float>, ptrdiff_t cutoff = -1);
     void from_AMP8I_PHS8I(std::span<const AMP8I_PHS8I_t>, std::span<cx_float>, ptrdiff_t cutoff = -1) const;
     void to_AMP8I_PHS8I(std::span<const cx_float>, std::span<AMP8I_PHS8I_t>, ptrdiff_t cutoff = -1) const;
 };

--- a/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
@@ -109,6 +109,16 @@ struct ImageData
     void from_AMP8I_PHS8I(std::span<const AMP8I_PHS8I_t>, std::span<cx_float>, ptrdiff_t cutoff = -1) const;
     void to_AMP8I_PHS8I(std::span<const cx_float>, std::span<AMP8I_PHS8I_t>, ptrdiff_t cutoff = -1) const;
 };
+
+/*!
+ * Create a lookup table for converting from AMP8I_PHS8I to complex.
+ * @param pAmplitudeTable Input amplitude table - may be nullptr if no amplitude table is defined.
+ * @param pValues_ Output table's with scope to keep it around past the function call - may be empty if there was no input amplitude table.
+ * @return reference to the lookup table.
+ */
+const input_amplitudes_t& get_RE32F_IM32F_values(const six::AmplitudeTable* pAmplitudeTable,
+                                                 std::unique_ptr<input_amplitudes_t>& pValues_);
+
 }
 }
 

--- a/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
@@ -41,6 +41,10 @@ namespace sicd
 {
 using cx_float = std::complex<float>;
 using AMP8I_PHS8I_t = std::pair<uint8_t, uint8_t>;
+//! Fixed size 256 element array of complex values.
+using input_values_t = std::array<std::complex<float>, UINT8_MAX + 1>;
+//! Fixed size 256 x 256 matrix of complex values.
+using input_amplitudes_t = std::array<input_values_t, UINT8_MAX + 1>;
 
 class GeoData;
 /*!

--- a/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
@@ -109,16 +109,16 @@ struct ImageData
     static void from_AMP8I_PHS8I(const input_amplitudes_t& lookup, std::span<const AMP8I_PHS8I_t>, std::span<cx_float>, ptrdiff_t cutoff = -1);
     void from_AMP8I_PHS8I(std::span<const AMP8I_PHS8I_t>, std::span<cx_float>, ptrdiff_t cutoff = -1) const;
     void to_AMP8I_PHS8I(std::span<const cx_float>, std::span<AMP8I_PHS8I_t>, ptrdiff_t cutoff = -1) const;
-};
 
-/*!
- * Create a lookup table for converting from AMP8I_PHS8I to complex.
- * @param pAmplitudeTable Input amplitude table - may be nullptr if no amplitude table is defined.
- * @param pValues_ Output table's with scope to keep it around past the function call - may be empty if there was no input amplitude table.
- * @return reference to the lookup table.
- */
-const input_amplitudes_t& get_RE32F_IM32F_values(const six::AmplitudeTable* pAmplitudeTable,
-                                                 std::unique_ptr<input_amplitudes_t>& pValues_);
+    /*!
+     * Create a lookup table for converting from AMP8I_PHS8I to complex.
+     * @param pAmplitudeTable Input amplitude table. May be nullptr if no amplitude table is defined.
+     * @param pValues_ Output table's scope to keep it around past the function call. May be empty if there was no input amplitude table.
+     * @return reference to the output lookup table.
+     */
+    static const input_amplitudes_t& get_RE32F_IM32F_values(const six::AmplitudeTable* pAmplitudeTable,
+                                                            std::unique_ptr<input_amplitudes_t>& pValues_);
+};
 
 }
 }

--- a/six/modules/c++/six.sicd/source/ImageData.cpp
+++ b/six/modules/c++/six.sicd/source/ImageData.cpp
@@ -155,9 +155,6 @@ static std::vector<KDNode_t> make_nodes(const six::AmplitudeTable* pAmplitudeTab
     return retval;
 }
 
-using input_values_t = std::array<std::complex<float>, UINT8_MAX + 1>;
-using input_amplitudes_t = std::array<input_values_t, UINT8_MAX + 1>;
-
 // input_amplitudes_t is too big for the stack
 static std::unique_ptr<input_amplitudes_t> AMP8I_PHS8I_to_RE32F_IM32F_(const six::AmplitudeTable* pAmplitudeTable)
 {

--- a/six/modules/c++/six.sicd/source/ImageData.cpp
+++ b/six/modules/c++/six.sicd/source/ImageData.cpp
@@ -227,6 +227,12 @@ void ImageData::from_AMP8I_PHS8I(std::span<const AMP8I_PHS8I_t> inputs, std::spa
 
     std::unique_ptr<input_amplitudes_t> pValues_;
     const auto& values = get_RE32F_IM32F_values(amplitudeTable.get(), pValues_);
+    from_AMP8I_PHS8I(values, inputs, results, cutoff_);
+}
+
+void ImageData::from_AMP8I_PHS8I(const input_amplitudes_t& values, std::span<const AMP8I_PHS8I_t> inputs, std::span<std::complex<float>> results,
+    ptrdiff_t cutoff_)
+{
     const auto get_RE32F_IM32F_value_f = [&values](const six::sicd::AMP8I_PHS8I_t& v)
     {
         return values[v.first][v.second];

--- a/six/modules/c++/six.sicd/source/ImageData.cpp
+++ b/six/modules/c++/six.sicd/source/ImageData.cpp
@@ -172,7 +172,7 @@ static std::unique_ptr<input_amplitudes_t> AMP8I_PHS8I_to_RE32F_IM32F_(const six
 }
 
 // This is a non-templatized function so that there is copy of the "static" data with a NULL AmplutdeTable.
-static const input_amplitudes_t* get_RE32F_IM32F_values(const six::AmplitudeTable* pAmplitudeTable)
+static const input_amplitudes_t* get_cached_RE32F_IM32F_values(const six::AmplitudeTable* pAmplitudeTable)
 {
     if (pAmplitudeTable == nullptr)
     {
@@ -190,7 +190,7 @@ std::complex<float> ImageData::from_AMP8I_PHS8I(const AMP8I_PHS8I_t& input) cons
     }
 
     auto const pAmplitudeTable = amplitudeTable.get();
-    auto const pValues = get_RE32F_IM32F_values(pAmplitudeTable);
+    auto const pValues = get_cached_RE32F_IM32F_values(pAmplitudeTable);
 
     // Do we have a cahced result to use (no amplitude table)?
     // Or must it be recomputed (have an amplutude table)?
@@ -203,10 +203,10 @@ std::complex<float> ImageData::from_AMP8I_PHS8I(const AMP8I_PHS8I_t& input) cons
     return std::complex<float>(gsl::narrow_cast<float>(S.real()), gsl::narrow_cast<float>(S.imag()));
 }
 
-static const input_amplitudes_t& get_RE32F_IM32F_values(const six::AmplitudeTable* pAmplitudeTable,
+const input_amplitudes_t& get_RE32F_IM32F_values(const six::AmplitudeTable* pAmplitudeTable,
     std::unique_ptr<input_amplitudes_t>& pValues_)
 {
-    const input_amplitudes_t* pValues = get_RE32F_IM32F_values(pAmplitudeTable);
+    const input_amplitudes_t* pValues = get_cached_RE32F_IM32F_values(pAmplitudeTable);
     if (pValues == nullptr)
     {
         assert(pAmplitudeTable != nullptr);

--- a/six/modules/c++/six.sicd/source/ImageData.cpp
+++ b/six/modules/c++/six.sicd/source/ImageData.cpp
@@ -203,7 +203,7 @@ std::complex<float> ImageData::from_AMP8I_PHS8I(const AMP8I_PHS8I_t& input) cons
     return std::complex<float>(gsl::narrow_cast<float>(S.real()), gsl::narrow_cast<float>(S.imag()));
 }
 
-const input_amplitudes_t& get_RE32F_IM32F_values(const six::AmplitudeTable* pAmplitudeTable,
+const input_amplitudes_t& ImageData::get_RE32F_IM32F_values(const six::AmplitudeTable* pAmplitudeTable,
     std::unique_ptr<input_amplitudes_t>& pValues_)
 {
     const input_amplitudes_t* pValues = get_cached_RE32F_IM32F_values(pAmplitudeTable);


### PR DESCRIPTION
The multi-threaded improvements in #536 aren't used by `six::sicd::Utilities::getWidebandData()`. That method loops sequentially through the 8-bit amp phase values and calls `six::sicd::Utilities::from_AMP8I_PHS8I()`, which then calls expensive `sincos()`. The end result is long read times for large images.

This pull request improves performance by reusing the conversion implemented in the `ImageData` class. Reusing that method means that `getWidebandData()` now uses a lookup table and runs across multiple threads (at least when reading `8AMPI_PHSI`).

I tried to minimize the number of changes to make it understandable. Modifications are welcome.