### PR TITLE
Fix XML serialization bugs

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,10 @@
 
 # SIX Release Notes
 
+## Version 3.1.11; ??? ?, 2022
+* Lastest [coda-oss](https://github.com/mdaus/coda-oss) and [nitro](https://github.com/mdaus/nitro) (updates from **master**, no new releases)
+* Fix bug in XML serializaton where `double`s were given a class of `xs::double` (two `:`s) instead of `xs:double`.
+
 ## Version 3.1.10; May 3, 2022
 * [coda-oss](https://github.com/mdaus/coda-oss) version [2022-05-03](https://github.com/mdaus/coda-oss/releases/tag/2022-05-03)
 * [nitro](https://github.com/mdaus/nitro) version [2.10.9](https://github.com/mdaus/nitro/releases/tag/NITRO-2.10.9)

--- a/six/modules/c++/six/source/XMLControl.cpp
+++ b/six/modules/c++/six/source/XMLControl.cpp
@@ -335,7 +335,20 @@ std::unique_ptr<Data> XMLControl::fromXML(const xml::lite::Document& doc,
 
 std::string XMLControl::dataTypeToString(DataType dataType, bool appendXML)
 {
-    std::string str = dataType;
+    std::string str;
+    switch (dataType)
+    {
+    case DataType::COMPLEX:
+        str = "SICD";
+        break;
+    case DataType::DERIVED:
+        str = "SIDD";
+        break;
+    default:
+        throw except::Exception(
+            Ctxt("Invalid data type " + str::toString(dataType)));
+    }
+
     if (appendXML)
     {
         str += "_XML";

--- a/six/modules/c++/six/source/XmlLite.cpp
+++ b/six/modules/c++/six/source/XmlLite.cpp
@@ -249,7 +249,7 @@ xml::lite::Element& XmlLite::createInt_(const std::string& name, int p, xml::lit
 xml::lite::Element& XmlLite::createDouble(const xml::lite::QName& name, double p, xml::lite::Element& parent) const
 {
     p = value(p); // be sure this is initialized; throws if not
-    return createValue(name, p, parent, mAddClassAttributes, "xs::double", getDefaultURI());
+    return createValue(name, p, parent, mAddClassAttributes, "xs:double", getDefaultURI());
 }
 xml::lite::Element& XmlLite::createDouble(const xml::lite::QName& name, const std::optional<double>& p, xml::lite::Element& parent) const
 {
@@ -274,7 +274,7 @@ xml::lite::Element* XmlLite::createOptionalDouble(const std::string& name, doubl
 }
 xml::lite::Element* XmlLite::createOptionalDouble(const xml::lite::QName& name, const std::optional<double>& p, xml::lite::Element& parent) const
 {
-    return createOptionalValue(name, p, parent, mAddClassAttributes, "xs::double", getDefaultURI());
+    return createOptionalValue(name, p, parent, mAddClassAttributes, "xs:double", getDefaultURI());
 }
 xml::lite::Element* XmlLite::createOptionalDouble(const std::string& name, const std::optional<double>& p, xml::lite::Element& parent) const
 {

--- a/six/modules/c++/six/unittests/test_xml_control.cpp
+++ b/six/modules/c++/six/unittests/test_xml_control.cpp
@@ -96,9 +96,29 @@ TEST_CASE(ignoreEmptyEnvVariable)
     }
 }
 
+TEST_CASE(dataTypeToString)
+{
+    std::string result = six::XMLControl::dataTypeToString(six::DataType::COMPLEX);
+    TEST_ASSERT_EQ("SICD_XML", result);
+
+    result = six::XMLControl::dataTypeToString(six::DataType::DERIVED, false /*appendXML*/);
+    TEST_ASSERT_EQ("SIDD", result);
+
+    // Generate a garbage value to test the exception.  Have to hack-things-up
+    // because there are overloads on six::DataType for integer assignment.
+    auto dataType = six::DataType::COMPLEX;
+    void* pDataType = &dataType;
+    int* pIntDataType = static_cast<int*>(pDataType);
+    *pIntDataType = 999; // bypass overloads; should now be a garbage value
+    TEST_ASSERT_NOT_EQ(dataType, six::DataType::COMPLEX);
+    TEST_ASSERT_NOT_EQ(dataType, six::DataType::DERIVED);
+    TEST_EXCEPTION(six::XMLControl::dataTypeToString(dataType)); // the "default:" case label will throw, as desired
+}
+
 TEST_MAIN((void)argv; (void)argc;
     TEST_CHECK(loadCompiledSchemaPath);
     TEST_CHECK(respectGivenPaths);
     TEST_CHECK(loadFromEnvVariable);
     TEST_CHECK(ignoreEmptyEnvVariable);
+    TEST_CHECK(dataTypeToString);
     )

--- a/six/modules/c++/six/unittests/test_xml_control.cpp
+++ b/six/modules/c++/six/unittests/test_xml_control.cpp
@@ -115,10 +115,41 @@ TEST_CASE(dataTypeToString)
     TEST_EXCEPTION(six::XMLControl::dataTypeToString(dataType)); // the "default:" case label will throw, as desired
 }
 
+TEST_CASE(testXmlLiteAttributeClass)
+{
+    six::XmlLite xmlLite(xml::lite::Uri("urn:example.com"), true /*addClassAttributes*/);
+    auto root = xmlLite.newElement("root", nullptr /*prnt*/);
+
+    {
+        auto& e = xmlLite.createDouble("double", 3.14, *root);
+        const auto& attrib = e.attribute("class");
+        TEST_ASSERT_EQ(attrib, "xs:double");
+    }
+    {
+        auto& e = xmlLite.createInt("int", 314, *root);
+        const auto& attrib = e.attribute("class");
+        TEST_ASSERT_EQ(attrib, "xs:int");
+    }
+    {
+        auto& e = xmlLite.createString("string", "abc", *root);
+        const auto& attrib = e.attribute("class");
+        TEST_ASSERT_EQ(attrib, "xs:string");
+    }
+    {
+        auto* e = xmlLite.createBooleanType(xml::lite::QName("Boolean"), six::BooleanType::IS_TRUE, *root);
+        const auto& attrib = e->attribute("class");
+        TEST_ASSERT_EQ(attrib, "xs:boolean");
+    }
+
+    // TODO: xs:date, xs:dateTime
+}
+
+
 TEST_MAIN((void)argv; (void)argc;
     TEST_CHECK(loadCompiledSchemaPath);
     TEST_CHECK(respectGivenPaths);
     TEST_CHECK(loadFromEnvVariable);
     TEST_CHECK(ignoreEmptyEnvVariable);
     TEST_CHECK(dataTypeToString);
+    TEST_CHECK(testXmlLiteAttributeClass);
     )


### PR DESCRIPTION
* `double`s were getting written with a **class** of `xs::double` (two `:`s) instead of `xs:double`.
* `SICD`/`SIDD` wasn't generated for `six::DataType`.
* new unittests for the above