### PR TITLE
Fix incorrect sensor partials.

### DIFF
--- a/six/modules/c++/scene/include/scene/AdjustableParams.h
+++ b/six/modules/c++/scene/include/scene/AdjustableParams.h
@@ -52,14 +52,16 @@ struct AdjustableParams
 
     static int group(ParamsEnum param);
 
+    /// The returned Vector3 is a reference to values in the object's mParams.
     Vector3 getARPVector() const
     {
-        return Vector3(mParams[ARP_RADIAL]);
+        return Vector3(&mParams[ARP_RADIAL]);
     }
 
+    /// The returned Vector3 is a reference to values in the object's mParams.
     Vector3 getARPVelocityVector() const
     {
-        return Vector3(mParams[ARP_VEL_RADIAL]);
+        return Vector3(&mParams[ARP_VEL_RADIAL]);
     }
 
     double operator[](std::ptrdiff_t idx) const


### PR DESCRIPTION
This fixes a regression introduced with [this commit](https://github.com/ngageoint/six-library/commit/27b8f6aa58af1f11867943fe59ef390c758eaa21#diff-d8287431fb5918098d5ae91c321fefa17399b8f5366893b4a7788ef189b71509) about year ago.

Without this fix, the `getARPVector()` and `getARPVelocityVector()` methods return vectors filled with constant values.
These values are used when performing `imageToSceneAdjustment`.