### PR TITLE
Feature/multi channel writer and type fixes

### DIFF
--- a/six/modules/c++/cphd/include/cphd/PVP.h
+++ b/six/modules/c++/cphd/include/cphd/PVP.h
@@ -25,7 +25,7 @@
 
 #include <ostream>
 #include <vector>
-#include <unordered_map>
+#include <map>
 #include <stddef.h>
 #include <six/Types.h>
 #include <six/Init.h>
@@ -364,7 +364,7 @@ struct Pvp
     /*
      *  (Optional) User defined PV parameters
      */
-    std::unordered_map<std::string,APVPType> addedPVP;
+    std::map<std::string, APVPType> addedPVP;
 
     /*
      *  \func Constructor

--- a/six/modules/c++/cphd/include/cphd/PVPBlock.h
+++ b/six/modules/c++/cphd/include/cphd/PVPBlock.h
@@ -26,6 +26,7 @@
 #include <ostream>
 #include <vector>
 #include <complex>
+#include <cstdint>
 #include <stddef.h>
 #include <unordered_map>
 
@@ -172,7 +173,7 @@ struct PVPBlock
     double getTOAE1(size_t channel, size_t set) const;
     double getTOAE2(size_t channel, size_t set) const;
     double getTdIonoSRP(size_t channel, size_t set) const;
-    double getSignal(size_t channel, size_t set) const;
+    std::int64_t getSignal(size_t channel, size_t set) const;
 
     template<typename T>
     T getAddedPVP(size_t channel, size_t set, const std::string& name) const
@@ -212,7 +213,7 @@ struct PVPBlock
     void setTOAE1(double value, size_t channel, size_t set);
     void setTOAE2(double value, size_t channel, size_t set);
     void setTdIonoSRP(double value, size_t channel, size_t set);
-    void setSignal(double value, size_t channel, size_t set);
+    void setSignal(std::int64_t value, size_t channel, size_t set);
 
     template<typename T>
     void setAddedPVP(T value, size_t channel, size_t set, const std::string& name)
@@ -441,7 +442,7 @@ protected:
         mem::ScopedCopyablePtr<double> toaE1;
         mem::ScopedCopyablePtr<double> toaE2;
         mem::ScopedCopyablePtr<double> tdIonoSRP;
-        mem::ScopedCopyablePtr<double> signal;
+        mem::ScopedCopyablePtr<std::int64_t> signal;
 
         //! (Optional) Additional parameters
         std::unordered_map<std::string,six::Parameter> addedPVP;

--- a/six/modules/c++/cphd/source/CPHDWriter.cpp
+++ b/six/modules/c++/cphd/source/CPHDWriter.cpp
@@ -237,12 +237,14 @@ void CPHDWriter::write(const PVPBlock& pvpBlock,
 
     // Doesn't require pading because pvp block is always 8 bytes words
     // Write wideband (or signal) block
+    size_t elementsWritten = 0;  // Used to increment widebandData pointer
     for (size_t ii = 0; ii < mMetadata.data.getNumChannels(); ++ii)
     {
         size_t numElements = mMetadata.data.getNumVectors(ii) *
                 mMetadata.data.getNumSamples(ii);
         // writeCPHDData handles compressed data as well
-        writeCPHDData<T>(widebandData, numElements, ii);
+        writeCPHDData<T>(widebandData + elementsWritten, numElements, ii);
+        elementsWritten += numElements;
     }
 }
 

--- a/six/modules/c++/cphd/source/PVPBlock.cpp
+++ b/six/modules/c++/cphd/source/PVPBlock.cpp
@@ -164,43 +164,117 @@ void PVPBlock::PVPSet::write(const PVPBlock& pvpBlock, const Pvp& p, const sys::
     }
     if (pvpBlock.hasSignal())
     {
-        signal.reset(new double());
+        signal.reset(new std::int64_t());
         ::setData(input + p.signal.getByteOffset(), *signal);
     }
     for (auto it = p.addedPVP.begin(); it != p.addedPVP.end(); ++it)
     {
-        if (it->second.getFormat() == "F4" || it->second.getFormat() == "F8")
+        if (it->second.getFormat() == "F4")
+        {
+            float val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "F8")
         {
             double val;
             ::setData(input + it->second.getByteOffset(), val);
             addedPVP[it->first] = six::Parameter();
             addedPVP.find(it->first)->second.setValue(val);
         }
-        else if (it->second.getFormat() == "U1" || it->second.getFormat() == "U2" ||
-                 it->second.getFormat() == "U4" || it->second.getFormat() == "U8")
+        else if (it->second.getFormat() == "U1")
         {
-            unsigned int val;
+            std::uint8_t val;
             ::setData(input + it->second.getByteOffset(), val);
             addedPVP[it->first] = six::Parameter();
             addedPVP.find(it->first)->second.setValue(val);
         }
-        else if (it->second.getFormat() == "I1" || it->second.getFormat() == "I2" ||
-                 it->second.getFormat() == "I4" || it->second.getFormat() == "I8")
+        else if (it->second.getFormat() == "U2")
         {
-            int val;
+            std::uint16_t val;
             ::setData(input + it->second.getByteOffset(), val);
             addedPVP[it->first] = six::Parameter();
             addedPVP.find(it->first)->second.setValue(val);
         }
-        else if (it->second.getFormat() == "CI2" || it->second.getFormat() == "CI4" ||
-                 it->second.getFormat() == "CI8" || it->second.getFormat() == "CI16")
+        else if (it->second.getFormat() == "U4")
         {
-            std::complex<int> val;
+            std::uint32_t val;
             ::setData(input + it->second.getByteOffset(), val);
             addedPVP[it->first] = six::Parameter();
             addedPVP.find(it->first)->second.setValue(val);
         }
-        else if (it->second.getFormat() == "CF8" || it->second.getFormat() == "CF16")
+        else if (it->second.getFormat() == "U8")
+        {
+            std::uint64_t val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "I1")
+        {
+            std::int8_t val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "I2")
+        {
+            std::int16_t val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "I4")
+        {
+            std::int32_t val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "I8")
+        {
+            std::int64_t val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "CI2")
+        {
+            std::complex<std::int8_t> val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "CI4")
+        {
+            std::complex<std::int16_t> val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "CI8")
+        {
+            std::complex<std::int32_t> val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "CI16")
+        {
+            std::complex<std::int64_t> val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "CF8")
+        {
+            std::complex<float> val;
+            ::setData(input + it->second.getByteOffset(), val);
+            addedPVP[it->first] = six::Parameter();
+            addedPVP.find(it->first)->second.setValue(val);
+        }
+        else if (it->second.getFormat() == "CF16")
         {
             std::complex<double> val;
             ::setData(input + it->second.getByteOffset(), val);
@@ -211,7 +285,8 @@ void PVPBlock::PVPSet::write(const PVPBlock& pvpBlock, const Pvp& p, const sys::
         {
             const auto pVal = input + it->second.getByteOffset();
             std::string val;
-            val.assign(reinterpret_cast<const char*>(pVal), it->second.getByteSize());
+            val.assign(reinterpret_cast<const char*>(pVal),
+                       it->second.getByteSize());
             addedPVP[it->first] = six::Parameter();
             addedPVP.find(it->first)->second.setValue(val);
         }
@@ -274,26 +349,67 @@ void PVPBlock::PVPSet::read(const Pvp& p, sys::ubyte* dest_) const
     }
     for (auto it = p.addedPVP.begin(); it != p.addedPVP.end(); ++it)
     {
-        if (it->second.getFormat() == "F4" || it->second.getFormat() == "F8")
+        if (it->second.getFormat() == "F4")
+        {
+            ::getData(dest + it->second.getByteOffset(), static_cast<float>(addedPVP.find(it->first)->second));
+        }
+        else if (it->second.getFormat() == "F8")
         {
             ::getData(dest + it->second.getByteOffset(), static_cast<double>(addedPVP.find(it->first)->second));
         }
-        else if (it->second.getFormat() == "U1" || it->second.getFormat() == "U2" ||
-                 it->second.getFormat() == "U4" || it->second.getFormat() == "U8")
+        else if (it->second.getFormat() == "U1")
         {
-            ::getData(dest + it->second.getByteOffset(), static_cast<unsigned int>(addedPVP.find(it->first)->second));
+            ::getData(dest + it->second.getByteOffset(), static_cast<std::uint8_t>(addedPVP.find(it->first)->second));
         }
-        else if (it->second.getFormat() == "I1" || it->second.getFormat() == "I2" ||
-                 it->second.getFormat() == "I4" || it->second.getFormat() == "I8")
+        else if (it->second.getFormat() == "U2")
         {
-            ::getData(dest + it->second.getByteOffset(), static_cast<int>(addedPVP.find(it->first)->second));
+            ::getData(dest + it->second.getByteOffset(), static_cast<std::uint16_t>(addedPVP.find(it->first)->second));
         }
-        else if (it->second.getFormat() == "CI2" || it->second.getFormat() == "CI4" ||
-                 it->second.getFormat() == "CI8" || it->second.getFormat() == "CI16")
+        else if (it->second.getFormat() == "U4")
         {
-            ::getData(dest + it->second.getByteOffset(), addedPVP.find(it->first)->second.getComplex<int>());
+            ::getData(dest + it->second.getByteOffset(), static_cast<std::uint32_t>(addedPVP.find(it->first)->second));
         }
-        else if (it->second.getFormat() == "CF8" || it->second.getFormat() == "CF16")
+        else if (it->second.getFormat() == "U8")
+        {
+            ::getData(dest + it->second.getByteOffset(), static_cast<std::uint64_t>(addedPVP.find(it->first)->second));
+        }
+        else if (it->second.getFormat() == "I1")
+        {
+            ::getData(dest + it->second.getByteOffset(), static_cast<std::int8_t>(addedPVP.find(it->first)->second));
+        }
+        else if (it->second.getFormat() == "I2")
+        {
+            ::getData(dest + it->second.getByteOffset(), static_cast<std::int16_t>(addedPVP.find(it->first)->second));
+        }
+        else if (it->second.getFormat() == "I4")
+        {
+            ::getData(dest + it->second.getByteOffset(), static_cast<std::int32_t>(addedPVP.find(it->first)->second));
+        }
+        else if (it->second.getFormat() == "I8")
+        {
+            ::getData(dest + it->second.getByteOffset(), static_cast<std::int64_t>(addedPVP.find(it->first)->second));
+        }
+        else if (it->second.getFormat() == "CI2")
+        {
+            ::getData(dest + it->second.getByteOffset(), addedPVP.find(it->first)->second.getComplex<std::int8_t>());
+        }
+        else if (it->second.getFormat() == "CI4")
+        {
+            ::getData(dest + it->second.getByteOffset(), addedPVP.find(it->first)->second.getComplex<std::int16_t>());
+        }
+        else if (it->second.getFormat() == "CI8")
+        {
+            ::getData(dest + it->second.getByteOffset(), addedPVP.find(it->first)->second.getComplex<std::int32_t>());
+        }
+        else if (it->second.getFormat() == "CI16")
+        {
+            ::getData(dest + it->second.getByteOffset(), addedPVP.find(it->first)->second.getComplex<std::int64_t>());
+        }
+        else if (it->second.getFormat() == "CF8")
+        {
+            ::getData(dest + it->second.getByteOffset(), addedPVP.find(it->first)->second.getComplex<float>());
+        }
+        else if (it->second.getFormat() == "CF16")
         {
             ::getData(dest + it->second.getByteOffset(), addedPVP.find(it->first)->second.getComplex<double>());
         }
@@ -689,7 +805,7 @@ double PVPBlock::getTdIonoSRP(size_t channel, size_t set) const
                     "Parameter was not set"));
 }
 
-double PVPBlock::getSignal(size_t channel, size_t set) const
+std::int64_t PVPBlock::getSignal(size_t channel, size_t set) const
 {
     verifyChannelVector(channel, set);
     if (mData[channel][set].signal.get())
@@ -874,12 +990,12 @@ void PVPBlock::setTdIonoSRP(double value, size_t channel, size_t vector)
                             "Parameter was not specified in XML"));
 }
 
-void PVPBlock::setSignal(double value, size_t channel, size_t vector)
+void PVPBlock::setSignal(std::int64_t value, size_t channel, size_t vector)
 {
     verifyChannelVector(channel, vector);
     if (hasSignal())
     {
-        mData[channel][vector].signal.reset(new double(value));
+        mData[channel][vector].signal.reset(new std::int64_t(value));
         return;
     }
     throw except::Exception(Ctxt(


### PR DESCRIPTION
Implements the back-end C++ changes from #351. Changes to the Python bindings are left out due to issues building SWIG bindings for SIX and its external libs directly from SWIG source.

### Features

* Support writing multiple CPHD channels to file from a single wideband buffer.
* Support 1-, 2-, and 4-byte datatypes within the `PVPBlock`. All user-defined PVP were hard-coded to 8-byte types before.
* Make cphd::PVPBlock used std::map to store added PVP parameters instead of std::unordered_map. This was needed to support older versions of SWIG.

### Fixes

* Fix signal datatype in PVP to be 8-byte integer according to the CPHD v1.x spec. Was set to double previously.