### PR TITLE
Redwing patches from ew

### DIFF
--- a/six/modules/c++/six/source/NITFReadControl.cpp
+++ b/six/modules/c++/six/source/NITFReadControl.cpp
@@ -285,7 +285,11 @@ static std::vector<six::NITFImageInfo*> getImageInfos(six::Container& container)
 
     // We will validate that we got a SIDD DES per image product in the
     // for loop below
-    assert(container.getDataType() == DataType::DERIVED);
+    if (container.getDataType() != DataType::DERIVED)
+    {
+        throw except::Exception(Ctxt("Unrecognized Data Extension Segment")); // N.B. not assert(), calling code can catch an exception
+    }
+
     std::vector<six::NITFImageInfo*> retval;
     for (size_t ii = 0; ii < container.size(); ++ii)
     {

--- a/six/modules/c++/six/source/Utilities.cpp
+++ b/six/modules/c++/six/source/Utilities.cpp
@@ -1145,14 +1145,23 @@ void six::getErrors(const ErrorStatistics* errorStats,
             if (components->ionoError)
             {
                 const six::IonoError& ionoError(*components->ionoError);
-                errors.mIonoErrorCovar(0, 0) =
+                if (has_value(ionoError.ionoRangeVertical))
+                {
+                    errors.mIonoErrorCovar(0, 0) =
                         math::square(value(ionoError.ionoRangeVertical));
-                errors.mIonoErrorCovar(1, 1) =
+                }
+                if (has_value(ionoError.ionoRangeRateVertical))
+                {
+                    errors.mIonoErrorCovar(1, 1) =
                         math::square(value(ionoError.ionoRangeRateVertical));
-                errors.mIonoErrorCovar(0, 1) = errors.mIonoErrorCovar(1, 0) =
+                }
+                if (has_value(ionoError.ionoRangeVertical) && has_value(ionoError.ionoRangeRateVertical))
+                {
+                    errors.mIonoErrorCovar(0, 1) = errors.mIonoErrorCovar(1, 0) =
                         value(ionoError.ionoRangeVertical) *
                         value(ionoError.ionoRangeRateVertical) *
                         value(ionoError.ionoRgRgRateCC);
+                }
             }
 
             if (components->tropoError)


### PR DESCRIPTION
* corrects an error found when using certain non-SICD NITF files.  Previously an `assert()` failed and it could not be properly caught and handled.  Changing to an exception fixes the problem but otherwise preserves the existing behavior.

* corrects an error found when using SICD files that contain a certain combination of optional elements in the `ErrorStatistics` block.  Previously an exception was erroneously thrown for an undefined optional access.  We believe there might be other cases similar to this as well, but the files we tested with did not specifically exercise all combinations of optional elements.
