### PR TITLE
build SIX in coda

### DIFF
--- a/.github/workflows/frequent_check.yml
+++ b/.github/workflows/frequent_check.yml
@@ -48,7 +48,7 @@ jobs:
     - name: make
       run: |
         cd build
-        cmake --build . -j1
+        cmake --build . -j 2
         cmake --build . --target install
     - name: test
       run: |

--- a/0_build
+++ b/0_build
@@ -5,7 +5,7 @@
 rm -r -f out && mkdir out && cd out
 cmake -DCMAKE_INSTALL_PREFIX=install-autobuild -DENABLE_PYTHON=false ..
 
-cmake --build . -j1
+cmake --build . -j 2
 exec cmake --build . --target install
 
 

--- a/six/projects/csm/external/wscript
+++ b/six/projects/csm/external/wscript
@@ -57,14 +57,19 @@ def build(bld):
         #       need to use.
         vtsDir = 'vts_301_0'
         six_root = '../../../../../..'
+        nested_six_root = six_root + '/../..'
         install = six_root + '/install'
+        nested_install = nested_six_root + '/install'
         coda_oss = six_root + '/externals/coda-oss/modules/c++'
+        nested_coda_oss = nested_six_root + '/externals/coda-oss/modules/c++'
         bld.program(target='vts', name='vts',
                     includes=['include',
-                        install + '/include',
-                        coda_oss + '/sys/include', coda_oss + '/str/include', 
-                        coda_oss + '/std/include', coda_oss + '/coda_oss/include', coda_oss + '/gsl/include', 
-                        coda_oss + '/except/include'],
+                        install + '/include', nested_install + '/include',
+			coda_oss + '/sys/include', coda_oss + '/str/include', coda_oss + '/std/include',
+			coda_oss + '/coda_oss/include', coda_oss + '/gsl/include', coda_oss + '/except/include',
+			nested_coda_oss + '/sys/include', nested_coda_oss + '/str/include', nested_coda_oss + '/std/include',
+			nested_coda_oss + '/coda_oss/include', nested_coda_oss + '/gsl/include', nested_coda_oss + '/except/include'
+			],
                     source=bld.path.find_dir(os.path.join(vtsDir, 'source')).ant_glob('*.cpp'),
                     use='sys-c++ CSMAPI THREAD DL',
                     path=bld.path.find_dir(vtsDir),

--- a/six/projects/csm/wscript
+++ b/six/projects/csm/wscript
@@ -1,4 +1,4 @@
-MODULE_DEPS        = 'six.sicd six.sidd sys str except'
+MODULE_DEPS        = 'six.sicd six.sidd sys str std coda-oss gsl except'
 PLUGIN             = 'CSM'
 PLUGIN_VERSION     = '115'
 REMOVEPLUGINPREFIX = True


### PR DESCRIPTION
Tweak `wscript`s so that *SIX* can build in *CODA*'s **externals** directory.