### PR TITLE
latest coda-oss and nitro

### DIFF
--- a/externals/coda-oss/ReleaseNotes.md
+++ b/externals/coda-oss/ReleaseNotes.md
@@ -11,6 +11,12 @@
  ```
 # coda-oss Release Notes
 
+## [Release 2022-08-30_cpp14](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30_cpp14)
+* Same as [Release 2022-08-30](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30) except that
+C++14 is now required (on [main](https://github.com/mdaus/coda-oss/tree/main)).
+The last C++11 build is [Release 2022-08-30](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30),
+cut from [master](https://github.com/mdaus/coda-oss/tree/master).
+
 ## [Release 2022-08-30](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30)
 * XML is now always written as UTF-8; the code will still try to read Windows-1252.
 * `Uri`s are no longer validated by default.

--- a/externals/nitro/ReleaseNotes.md
+++ b/externals/nitro/ReleaseNotes.md
@@ -1,5 +1,10 @@
 ﻿# NITRO (NITF i/o) Release Notes
 
+## [Version 2.11.0](https://github.com/mdaus/nitro/releases/tag/NITRO-2.11.0); August 30, 2022
+* [coda-oss](https://github.com/mdaus/coda-oss) release [2022-08-30_cpp14](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30_cpp14)
+* Cut from [main](https://github.com/mdaus/nitro/tree/main); identical to [Version 2.10.12](https://github.com/mdaus/nitro/releases/tag/NITRO-2.10.12)
+except that C++14 is now required.  [master](https://github.com/mdaus/nitro/tree/master) remains at C++11.
+
 ## [Version 2.10.12](https://github.com/mdaus/nitro/releases/tag/NITRO-2.10.12); August 30, 2022
 * [coda-oss](https://github.com/mdaus/coda-oss) release [2022-08-30](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30)
 * Build JPEG decompression as a plug-in.

--- a/externals/nitro/modules/c++/nitf/include/nitf/Version.hpp
+++ b/externals/nitro/modules/c++/nitf/include/nitf/Version.hpp
@@ -27,6 +27,7 @@
 #include "config/Version.h"
 #include "nitf/Version.h"
 
+ // 2.11.0	August 30, 2022 (C++14)
  // 2.10.12	August 30, 2022
 // 2.10.11	August 2, 2022
 // 2.10.10	June 29, 2022
@@ -34,8 +35,8 @@
 // 2.10.8	February 22, 2022
 // 2.10.7	December 13, 2021
 #define NITF_VERSION_MAJOR	2
-#define NITF_VERSION_MINOR	10
-#define NITF_VERSION_PATCH	12
+#define NITF_VERSION_MINOR	11
+#define NITF_VERSION_PATCH	0
 #define NITF_VERSION_BUILD		0
 #define NITF_VERSION CODA_OSS_MAKE_VERSION_MMPB(NITF_VERSION_MAJOR, NITF_VERSION_MINOR, NITF_VERSION_PATCH, NITF_VERSION_BUILD)
 

--- a/externals/nitro/modules/c/nrt/include/nrt/Version.h
+++ b/externals/nitro/modules/c/nrt/include/nrt/Version.h
@@ -1,5 +1,5 @@
 #pragma once
 
 #if !defined(NRT_LIB_VERSION)
-#define NRT_LIB_VERSION "2.10.12"
+#define NRT_LIB_VERSION "2.11.0"
 #endif


### PR DESCRIPTION
* [coda-oss 2022-08-30_cpp14](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30_cpp14)
* [NITRO-2.11.0](https://github.com/mdaus/nitro/releases/tag/NITRO-2.11.0)