### PR TITLE
TropoError and IonoError are optional

### DIFF
--- a/six/modules/c++/cphd/source/CPHDXMLParser.cpp
+++ b/six/modules/c++/cphd/source/CPHDXMLParser.cpp
@@ -1634,7 +1634,7 @@ void CPHDXMLParser::fromXML(const xml::lite::Element* errParamXML, ErrorParamete
             mCommon.parseDecorrType(rangeBiasDecorrXML, *(errParam.monostatic->radarSensor.rangeBiasDecorr));
         }
 
-        XMLElem tropoErrorXML = getFirstAndOnly(monostaticXML, "TropoError");
+        XMLElem tropoErrorXML = getOptional(monostaticXML, "TropoError");
         if(tropoErrorXML)
         {
             errParam.monostatic->tropoError.reset(new six::TropoError());
@@ -1643,7 +1643,7 @@ void CPHDXMLParser::fromXML(const xml::lite::Element* errParamXML, ErrorParamete
             mCommon.parseOptionalDecorrType(tropoErrorXML, "TropoRangeDecorr", errParam.monostatic->tropoError->tropoRangeDecorr);
         }
 
-        XMLElem ionoErrorXML = getFirstAndOnly(monostaticXML, "IonoError");
+        XMLElem ionoErrorXML = getOptional(monostaticXML, "IonoError");
         if(ionoErrorXML)
         {
             errParam.monostatic->ionoError.reset(new six::IonoError());


### PR DESCRIPTION
From K. T.:
> I have been using the six CPHD reader lately and found that it actually errors when either of the following two fields are missing:
> **CPHD.ErrorParameters.Monostatic.TropoError**
> **CPHD.ErrorParameters.Monostatic.IonoError**
> Since these are optional fields.

