### PR TITLE
minor CPHDWriter tweaks from another branch

### DIFF
--- a/six/modules/c++/cphd/CMakeLists.txt
+++ b/six/modules/c++/cphd/CMakeLists.txt
@@ -13,6 +13,7 @@ coda_add_module(
         source/CPHDXMLParser.cpp
         source/Channel.cpp
         source/Data.cpp
+        source/DataWriter.cpp
         source/Dwell.cpp
         source/ErrorParameters.cpp
         source/FileHeader.cpp

--- a/six/modules/c++/cphd/cphd.vcxproj
+++ b/six/modules/c++/cphd/cphd.vcxproj
@@ -121,6 +121,7 @@
     <ClInclude Include="include\cphd\CPHDXMLControl.h" />
     <ClInclude Include="include\cphd\CPHDXMLParser.h" />
     <ClInclude Include="include\cphd\Data.h" />
+    <ClInclude Include="include\cphd\DataWriter.h" />
     <ClInclude Include="include\cphd\Dwell.h" />
     <ClInclude Include="include\cphd\Enums.h" />
     <ClInclude Include="include\cphd\ErrorParameters.h" />
@@ -156,6 +157,7 @@
     <ClCompile Include="source\CPHDXMLControl.cpp" />
     <ClCompile Include="source\CPHDXMLParser.cpp" />
     <ClCompile Include="source\Data.cpp" />
+    <ClCompile Include="source\DataWriter.cpp" />
     <ClCompile Include="source\Dwell.cpp" />
     <ClCompile Include="source\ErrorParameters.cpp" />
     <ClCompile Include="source\FileHeader.cpp" />

--- a/six/modules/c++/cphd/cphd.vcxproj.filters
+++ b/six/modules/c++/cphd/cphd.vcxproj.filters
@@ -105,6 +105,9 @@
     <ClInclude Include="include\cphd\Wideband.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\cphd\DataWriter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -183,6 +186,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="source\Wideband.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="source\DataWriter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/six/modules/c++/cphd/include/cphd/CPHDReader.h
+++ b/six/modules/c++/cphd/include/cphd/CPHDReader.h
@@ -19,8 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-#ifndef __CPHD_CPHD_READER_H__
-#define __CPHD_CPHD_READER_H__
+#ifndef SIX_cphd_CPHDReader_h_INCLUDED_
+#define SIX_cphd_CPHDReader_h_INCLUDED_
+#pragma once
 
 #include <memory>
 
@@ -162,4 +163,4 @@ private:
 };
 }
 
-#endif
+#endif // SIX_cphd_CPHDReader_h_INCLUDED_

--- a/six/modules/c++/cphd/include/cphd/CPHDWriter.h
+++ b/six/modules/c++/cphd/include/cphd/CPHDWriter.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef __CPHD_CPHD_WRITER_H__
-#define __CPHD_CPHD_WRITER_H__
+#ifndef SIX_cphd_CPHDWriter_h_INCLUDED_
+#define SIX_cphd_CPHDWriter_h_INCLUDED_
 #pragma once
 
 #include <string>
@@ -35,142 +35,10 @@
 #include <cphd/Metadata.h>
 #include <cphd/PVP.h>
 #include <cphd/PVPBlock.h>
+#include <cphd/DataWriter.h>
 
 namespace cphd
 {
-
-/*
- *  \class DataWriter
- *
- *  \brief Class to handle writing to file and byte swapping
- */
-struct DataWriter
-{
-    /*
-     *  \func DataWriter
-     *  \brief Constructor
-     *
-     *  \param stream The seekable output stream to be written
-     *  \param numThreads Number of threads for parallel processing
-     */
-    DataWriter(std::shared_ptr<io::SeekableOutputStream> stream,
-               size_t numThreads);
-
-    /*
-     *  Destructor
-     */
-    virtual ~DataWriter();
-
-    /*
-     *  \func operator()
-     *  \brief Overload operator performs write and endian swap
-     *
-     *  \param data Pointer to the data that will be written to the filestream
-     *  \param numElements Total number of elements in array
-     *  \param elementSize Size of each element
-     */
-    virtual void operator()(const sys::ubyte* data,
-                            size_t numElements,
-                            size_t elementSize) = 0;
-    virtual void operator()(const std::byte* data,
-                            size_t numElements,
-                            size_t elementSize)
-    {
-        (*this)(reinterpret_cast<const sys::ubyte*>(data), numElements, elementSize);
-    }
-
-protected:
-    //! Output stream of CPHD
-    std::shared_ptr<io::SeekableOutputStream> mStream;
-    //! Number of threads for parallelism
-    const size_t mNumThreads;
-};
-
-/*
- *  \class DataWriterLittleEndian
- *
- *  \brief Class to handle writing to output stream and byte swapping
- *
- *  For little endian to big endian storage
- */
-struct DataWriterLittleEndian final : public DataWriter
-{
-    /*
-     *  \func DataWriterLittleEndian
-     *  \brief Constructor
-     *
-     *  \param stream The seekable output stream to be written
-     *  \param numThreads Number of threads for parallel processing
-     *  \param scratchSize Size of buffer to be used for scratch space
-     */
-    DataWriterLittleEndian(std::shared_ptr<io::SeekableOutputStream> stream,
-                           size_t numThreads,
-                           size_t scratchSize);
-
-    /*
-     *  \func operator()
-     *  \brief Overload operator performs write and endian swap
-     *
-     *  \param data Pointer to the data that will be written to the filestream
-     *  \param numElements Total number of elements in array
-     *  \param elementSize Size of each element
-     */
-    void operator()(const sys::ubyte* data,
-                            size_t numElements,
-                            size_t elementSize) override;
-    void operator()(const std::byte* data,
-                            size_t numElements,
-                            size_t elementSize) override
-    {
-        (*this)(reinterpret_cast<const sys::ubyte*>(data), numElements, elementSize);
-    }
-
-
-private:
-    // Scratch space buffer
-    std::vector<std::byte> mScratch;
-};
-
-/*
- *  \class DataWriterBigEndian
- *
- *  \brief Class to handle writing to file
- *
- *  No byte swap. Already big endian.
- */
-struct DataWriterBigEndian final : public DataWriter
-{
-    /*
-     *  \func DataWriter
-     *  \brief Constructor
-     *
-     *  \param stream The seekable output stream to be written
-     *  \param numThreads Number of threads for parallel processing
-     */
-    DataWriterBigEndian(std::shared_ptr<io::SeekableOutputStream> stream,
-                        size_t numThreads);
-
-    /*
-     *  \func operator()
-     *  \brief Overload operator performs write
-     *
-     *  No endian swapping is necessary. Already Big Endian.
-     *
-     *  \param data Pointer to the data that will be written to the filestream
-     *  \param numElements Total number of elements in array
-     *  \param elementSize Size of each element
-     */
-    void operator()(const sys::ubyte* data,
-                            size_t numElements,
-                            size_t elementSize) override;
-    void operator()(const std::byte* data,
-                            size_t numElements,
-                            size_t elementSize) override
-    {
-        (*this)(reinterpret_cast<const sys::ubyte*>(data), numElements, elementSize);
-    }
-};
-
 
 /*
  *  \class CPHDWriter
@@ -407,4 +275,4 @@ private:
 };
 }
 
-#endif
+#endif // SIX_cphd_CPHDWriter_h_INCLUDED_

--- a/six/modules/c++/cphd/include/cphd/CPHDWriter.h
+++ b/six/modules/c++/cphd/include/cphd/CPHDWriter.h
@@ -47,7 +47,7 @@ namespace cphd
  *  Used to write a CPHD file. You must be able to provide the
  *  appropriate metadata and vector based metadata.
  */
-struct CPHDWriter
+struct CPHDWriter final
 {
     /*
      *  \func Constructor
@@ -100,6 +100,13 @@ struct CPHDWriter
             const std::vector<std::string>& schemaPaths = std::vector<std::string>(),
             size_t numThreads = 0,
             size_t scratchSpaceSize = 4 * 1024 * 1024);
+
+    CPHDWriter() = delete;
+    CPHDWriter(const CPHDWriter&) = delete;
+    CPHDWriter& operator=(const CPHDWriter&) = delete;
+    CPHDWriter(CPHDWriter&&) = delete;
+    CPHDWriter& operator=(CPHDWriter&&) = delete;
+    ~CPHDWriter() = default;
 
     /*
      *  \func write
@@ -219,6 +226,10 @@ struct CPHDWriter
     {
         mStream->close();
     }
+    std::shared_ptr<io::SeekableOutputStream> getStream() const
+    {
+        return mStream;
+    }
 
 private:
     /*
@@ -255,7 +266,6 @@ private:
 
     //! DataWriter object
     std::unique_ptr<DataWriter> mDataWriter;
-    void initializeDataWriter();
 
     // Book-keeping element
     //! metadata information

--- a/six/modules/c++/cphd/include/cphd/DataWriter.h
+++ b/six/modules/c++/cphd/include/cphd/DataWriter.h
@@ -26,6 +26,7 @@
 
 #include <vector>
 #include <std/bit>
+#include <std/cstddef> // std::byte
 
 #include <io/FileOutputStream.h>
 #include <sys/OS.h>

--- a/six/modules/c++/cphd/include/cphd/DataWriter.h
+++ b/six/modules/c++/cphd/include/cphd/DataWriter.h
@@ -1,0 +1,182 @@
+/* =========================================================================
+ * This file is part of cphd-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * cphd-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SIX_cphd_DataWriter_h_INCLUDED_
+#define SIX_cphd_DataWriter_h_INCLUDED_
+#pragma once
+
+#include <vector>
+#include <std/bit>
+
+#include <io/FileOutputStream.h>
+#include <sys/OS.h>
+
+namespace cphd
+{
+
+/*
+ *  \class DataWriter
+ *
+ *  \brief Class to handle writing to file and byte swapping
+ */
+struct DataWriter
+{
+    /*
+     *  \func DataWriter
+     *  \brief Constructor
+     *
+     *  \param stream The seekable output stream to be written
+     *  \param numThreads Number of threads for parallel processing
+     */
+    DataWriter(io::OutputStream& stream, size_t numThreads);
+    
+    DataWriter() = delete;
+    DataWriter(const DataWriter&) = delete;
+    DataWriter& operator=(const DataWriter&) = delete;
+    DataWriter(DataWriter&&) = default;
+    DataWriter& operator=(DataWriter&&) = default;
+
+    /*
+     *  Destructor
+     */
+    virtual ~DataWriter() = default;
+
+    /*
+     *  \func operator()
+     *  \brief Overload operator performs write and endian swap
+     *
+     *  \param data Pointer to the data that will be written to the filestream
+     *  \param numElements Total number of elements in array
+     *  \param elementSize Size of each element
+     */
+    virtual void operator()(const void* data, size_t numElements, size_t elementSize) = 0;
+
+protected:
+    //! Output stream of CPHD
+    io::OutputStream& mStream;
+    //! Number of threads for parallelism
+    const size_t mNumThreads;
+};
+
+/*
+ *  \class DataWriterLittleEndian
+ *
+ *  \brief Class to handle writing to output stream and byte swapping
+ *
+ *  For little endian to big endian storage
+ */
+struct DataWriterLittleEndian final : public DataWriter
+{
+    /*
+     *  \func DataWriterLittleEndian
+     *  \brief Constructor
+     *
+     *  \param stream The seekable output stream to be written
+     *  \param numThreads Number of threads for parallel processing
+     *  \param scratchSize Size of buffer to be used for scratch space
+     */
+    DataWriterLittleEndian(io::OutputStream&, size_t numThreads, size_t scratchSize);
+    DataWriterLittleEndian() = delete;
+    DataWriterLittleEndian(const DataWriterLittleEndian&) = delete;
+    DataWriterLittleEndian& operator=(const DataWriterLittleEndian&) = delete;
+    DataWriterLittleEndian(DataWriterLittleEndian&&) = default;
+    DataWriterLittleEndian& operator=(DataWriterLittleEndian&&) = default;
+    ~DataWriterLittleEndian() = default;
+
+    /*
+     *  \func operator()
+     *  \brief Overload operator performs write and endian swap
+     *
+     *  \param data Pointer to the data that will be written to the filestream
+     *  \param numElements Total number of elements in array
+     *  \param elementSize Size of each element
+     */
+    void operator()(const void* data, size_t numElements,  size_t elementSize) override;
+
+private:
+    // Scratch space buffer
+    std::vector<std::byte> mScratch;
+};
+
+/*
+ *  \class DataWriterBigEndian
+ *
+ *  \brief Class to handle writing to file
+ *
+ *  No byte swap. Already big endian.
+ */
+struct DataWriterBigEndian final : public DataWriter
+{
+    /*
+     *  \func DataWriter
+     *  \brief Constructor
+     *
+     *  \param stream The seekable output stream to be written
+     *  \param numThreads Number of threads for parallel processing
+     */
+    DataWriterBigEndian(io::OutputStream&, size_t numThreads);
+    DataWriterBigEndian() = delete;
+    DataWriterBigEndian(const DataWriterBigEndian&) = delete;
+    DataWriterBigEndian& operator=(const DataWriterBigEndian&) = delete;
+    DataWriterBigEndian(DataWriterBigEndian&&) = default;
+    DataWriterBigEndian& operator=(DataWriterBigEndian&&) = default;
+    ~DataWriterBigEndian() = default;
+
+    /*
+     *  \func operator()
+     *  \brief Overload operator performs write
+     *
+     *  No endian swapping is necessary. Already Big Endian.
+     *
+     *  \param data Pointer to the data that will be written to the filestream
+     *  \param numElements Total number of elements in array
+     *  \param elementSize Size of each element
+     */
+    void operator()(const void* data, size_t numElements, size_t elementSize) override;
+};
+
+// Create the appropriate DataWriter instance using std::endian::native.  There are fancier
+// ways of doing this compile-time "if" check, but this is relatively straight-forward to understand;
+// C++20 brings `consteval if`.
+namespace details
+{
+    template<std::endian endianness>
+    auto make_DataWriter(io::OutputStream&, size_t numThreads, size_t scratchSize);
+    template<>
+    inline auto make_DataWriter<std::endian::big>(io::OutputStream& stream, size_t numThreads, size_t /*scratchSize*/)
+    {
+        return std::make_unique<DataWriterBigEndian>(stream, numThreads);
+    }
+    template<>
+    inline auto make_DataWriter<std::endian::little>(io::OutputStream& stream, size_t numThreads, size_t scratchSize)
+    {
+        return std::make_unique<DataWriterLittleEndian>(stream, numThreads, scratchSize);
+    }
+}
+inline auto make_DataWriter(io::OutputStream& stream, size_t numThreads, size_t scratchSize)
+{
+    return details::make_DataWriter<std::endian::native>(stream, numThreads, scratchSize);
+}
+
+}
+
+#endif // SIX_cphd_DataWriter_h_INCLUDED_

--- a/six/modules/c++/cphd/source/CPHDWriter.cpp
+++ b/six/modules/c++/cphd/source/CPHDWriter.cpp
@@ -40,13 +40,6 @@
 namespace cphd
 {
 
-void CPHDWriter::initializeDataWriter()
-{
-    // Get the correct dataWriter.
-    // The CPHD file needs to be big endian.
-    mDataWriter = make_DataWriter(*mStream, mNumThreads, mScratchSpaceSize);
-}
-
 CPHDWriter::CPHDWriter(const Metadata& metadata,
                        std::shared_ptr<io::SeekableOutputStream> outStream,
                        const std::vector<std::string>& schemaPaths,
@@ -59,7 +52,9 @@ CPHDWriter::CPHDWriter(const Metadata& metadata,
     mSchemaPaths(schemaPaths),
     mStream(outStream)
 {
-    initializeDataWriter();
+    // Get the correct dataWriter.
+    // The CPHD file needs to be big endian.
+    mDataWriter = make_DataWriter(*mStream, mNumThreads, mScratchSpaceSize);
 }
 
 CPHDWriter::CPHDWriter(const Metadata& metadata,
@@ -67,16 +62,12 @@ CPHDWriter::CPHDWriter(const Metadata& metadata,
                        const std::vector<std::string>& schemaPaths,
                        size_t numThreads,
                        size_t scratchSpaceSize) :
-    mMetadata(metadata),
-    mElementSize(metadata.data.getNumBytesPerSample()),
-    mScratchSpaceSize(scratchSpaceSize),
-    mNumThreads(numThreads),
-    mSchemaPaths(schemaPaths)
+    CPHDWriter(metadata,
+        std::make_shared<io::FileOutputStream>(pathname), // Initialize output stream
+        schemaPaths,
+        numThreads,
+        scratchSpaceSize)
 {
-    // Initialize output stream
-    mStream = std::make_shared<io::FileOutputStream>(pathname);
-
-    initializeDataWriter();
 }
 
 void CPHDWriter::writeMetadata(size_t supportSize,

--- a/six/modules/c++/cphd/source/DataWriter.cpp
+++ b/six/modules/c++/cphd/source/DataWriter.cpp
@@ -1,0 +1,83 @@
+/* =========================================================================
+ * This file is part of cphd-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * cphd-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <cphd/DataWriter.h>
+
+#include <thread>
+#include <std/memory>
+
+#include <except/Exception.h>
+
+#include <cphd/ByteSwap.h>
+#undef min
+#undef max
+
+
+namespace cphd
+{
+DataWriter::DataWriter(io::OutputStream& stream, size_t numThreads) :
+    mStream(stream),
+    mNumThreads(numThreads == 0 ? std::thread::hardware_concurrency() : numThreads)
+{
+}
+
+DataWriterLittleEndian::DataWriterLittleEndian(
+        io::OutputStream& stream,
+        size_t numThreads,
+        size_t scratchSize) :
+    DataWriter(stream, numThreads),
+    mScratch(scratchSize)
+{
+}
+void DataWriterLittleEndian::operator()(const void* pData, size_t numElements, size_t elementSize)
+{
+    const auto data = static_cast<const sys::ubyte*>(pData);
+
+    size_t dataProcessed = 0;
+    const size_t dataSize = numElements * elementSize;
+    while (dataProcessed < dataSize)
+    {
+        const size_t dataToProcess =
+                std::min(mScratch.size(), dataSize - dataProcessed);
+
+        memcpy(mScratch.data(), data + dataProcessed, dataToProcess);
+
+        cphd::byteSwap(mScratch.data(),
+                       elementSize,
+                       dataToProcess / elementSize,
+                       mNumThreads);
+
+        mStream.write(mScratch.data(), dataToProcess);
+
+        dataProcessed += dataToProcess;
+    }
+}
+
+DataWriterBigEndian::DataWriterBigEndian(io::OutputStream& stream, size_t numThreads) :
+    DataWriter(stream, numThreads)
+{
+}
+void DataWriterBigEndian::operator()(const void* data, size_t numElements, size_t elementSize)
+{
+    mStream.write(data, numElements * elementSize);
+}
+
+}

--- a/six/modules/c++/cphd03/include/cphd03/CPHDWriter.h
+++ b/six/modules/c++/cphd03/include/cphd03/CPHDWriter.h
@@ -42,7 +42,7 @@ namespace cphd03
  *  \brief Used to write a CPHD file. You must be able to provide the
  *         appropriate metadata and vector based metadata.
  */
-struct CPHDWriter
+struct CPHDWriter final
 {
     /*
      *  \func Constructor
@@ -89,6 +89,13 @@ struct CPHDWriter
                const std::string& pathname,
                size_t numThreads = 0,
                size_t scratchSpaceSize = 4 * 1024 * 1024);
+
+    CPHDWriter() = delete;
+    CPHDWriter(const CPHDWriter&) = delete;
+    CPHDWriter& operator=(const CPHDWriter&) = delete;
+    CPHDWriter(CPHDWriter&&) = delete;
+    CPHDWriter& operator=(CPHDWriter&&) = delete;
+    ~CPHDWriter() = default;
 
     /*
      *  \func addImage
@@ -168,10 +175,11 @@ struct CPHDWriter
 
     void close()
     {
-        if (mStream.get())
-        {
-            mStream->close();
-        }
+        mStream->close();
+    }
+    std::shared_ptr<io::SeekableOutputStream> getStream() const
+    {
+        return mStream;
     }
 
 private:
@@ -187,7 +195,6 @@ private:
                            size_t size);
 
     std::unique_ptr<cphd::DataWriter> mDataWriter;
-    void initializeDataWriter();
 
     Metadata mMetadata;
     const size_t mElementSize;
@@ -199,8 +206,8 @@ private:
     std::vector<const std::byte*> mCPHDData;
     std::vector<const std::byte*> mVBMData;
 
-    size_t mCPHDSize;
-    size_t mVBMSize;
+    size_t mCPHDSize = 0;
+    size_t mVBMSize = 0;
 };
 }
 

--- a/six/modules/c++/cphd03/source/CPHDWriter.cpp
+++ b/six/modules/c++/cphd03/source/CPHDWriter.cpp
@@ -38,15 +38,7 @@ void CPHDWriter::initializeDataWriter()
 {
     //! Get the correct dataWriter.
     //  The CPHD file needs to be big endian.
-    auto endianness = std::endian::native; // "conditional expression is constant"
-    if (endianness == std::endian::big)
-    {
-        mDataWriter = std::make_unique<cphd::DataWriterBigEndian>(mStream, mNumThreads);
-    }
-    else
-    {
-        mDataWriter = std::make_unique<cphd::DataWriterLittleEndian>(mStream, mNumThreads, mScratchSpaceSize);
-    }
+    mDataWriter = cphd::make_DataWriter(*mStream, mNumThreads, mScratchSpaceSize);
 }
 
 

--- a/six/modules/c++/cphd03/source/CPHDWriter.cpp
+++ b/six/modules/c++/cphd03/source/CPHDWriter.cpp
@@ -34,14 +34,6 @@
 
 namespace cphd03
 {
-void CPHDWriter::initializeDataWriter()
-{
-    //! Get the correct dataWriter.
-    //  The CPHD file needs to be big endian.
-    mDataWriter = cphd::make_DataWriter(*mStream, mNumThreads, mScratchSpaceSize);
-}
-
-
 CPHDWriter::CPHDWriter(const Metadata& metadata,
                        std::shared_ptr<io::SeekableOutputStream> stream,
                        size_t numThreads,
@@ -50,28 +42,22 @@ CPHDWriter::CPHDWriter(const Metadata& metadata,
     mElementSize(metadata.data.getNumBytesPerSample()),
     mScratchSpaceSize(scratchSpaceSize),
     mNumThreads(numThreads),
-    mStream(stream),
-    mCPHDSize(0),
-    mVBMSize(0)
+    mStream(stream)
 {
-    initializeDataWriter();
+    //! Get the correct dataWriter.
+    //  The CPHD file needs to be big endian.
+    mDataWriter = cphd::make_DataWriter(*mStream, mNumThreads, mScratchSpaceSize);
 }
 
 CPHDWriter::CPHDWriter(const Metadata& metadata,
                        const std::string& pathname,
                        size_t numThreads,
                        size_t scratchSpaceSize) :
-    mMetadata(metadata),
-    mElementSize(metadata.data.getNumBytesPerSample()),
-    mScratchSpaceSize(scratchSpaceSize),
-    mNumThreads(numThreads),
-    mCPHDSize(0),
-    mVBMSize(0)
-{
-    // Create file stream to write
-    mStream = std::make_shared<io::FileOutputStream>(pathname);
-
-    initializeDataWriter();
+    CPHDWriter(metadata,
+        std::make_shared<io::FileOutputStream>(pathname),  // Create file stream to write
+        numThreads,
+        scratchSpaceSize)
+{   
 }
 
 template <typename T>


### PR DESCRIPTION
The work for revamping `CPHDWriter` is on-hold.  In the meantime, chain the constructor and put `DataWriter` in a separate file.