### PR TITLE
allow SICD XML to be parsed with preserveCharacterData(true)

### DIFF
--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -58,7 +58,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)six\modules\c++\scene\include\;$(SolutionDir)six\modules\c++\six\include\;$(SolutionDir)six\modules\c++\six.sidd\include\;$(SolutionDir)six\modules\c++\six.sicd\include\;$(SolutionDir)six\modules\c++\cphd\include\;$(SolutionDir)six\modules\c++\cphd03\include\;$(SolutionDir)externals\nitro\modules\c\nrt\include\;$(SolutionDir)externals\nitro\modules\c\nitf\include\;$(SolutionDir)externals\nitro\modules\c++\nitf\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -78,7 +78,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)six\modules\c++\scene\include\;$(SolutionDir)six\modules\c++\six\include\;$(SolutionDir)six\modules\c++\six.sidd\include\;$(SolutionDir)six\modules\c++\six.sicd\include\;$(SolutionDir)six\modules\c++\cphd\include\;$(SolutionDir)six\modules\c++\cphd03\include\;$(SolutionDir)externals\nitro\modules\c\nrt\include\;$(SolutionDir)externals\nitro\modules\c\nitf\include\;$(SolutionDir)externals\nitro\modules\c++\nitf\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/UnitTest/sicd_Test.h
+++ b/UnitTest/sicd_Test.h
@@ -32,6 +32,7 @@
 #include <six/sicd/SICDByteProvider.h>
 #include <six/VersionUpdater.h>
 #include <six/sicd/SICDVersionUpdater.h>
+#include <six/sicd/DataParser.h>
 
 #include "CppUnitTest.h"
 #include "TestCase.h"

--- a/externals/nitro/modules/c++/nitf-c++.vcxproj
+++ b/externals/nitro/modules/c++/nitf-c++.vcxproj
@@ -217,7 +217,7 @@
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)nitf\include\;$(ProjectDir)..\c\nrt\include\;$(ProjectDir)..\c\nitf\include\;$(ProjectDir)..\c\j2k\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -249,7 +249,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)nitf\include\;$(ProjectDir)..\c\nrt\include\;$(ProjectDir)..\c\nitf\include\;$(ProjectDir)..\c\j2k\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/externals/nitro/modules/c/nitf-c.vcxproj
+++ b/externals/nitro/modules/c/nitf-c.vcxproj
@@ -50,7 +50,7 @@
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);HAVE_OPENJPEG_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);HAVE_OPENJPEG_H;_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)nrt\include\;$(ProjectDir)nitf\include\;$(ProjectDir)jpeg\include\;$(ProjectDir)j2k\include\;$(ProjectDir)cgm\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -77,7 +77,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);HAVE_OPENJPEG_H</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);HAVE_OPENJPEG_H;_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)nrt\include\;$(ProjectDir)nitf\include\;$(ProjectDir)jpeg\include\;$(ProjectDir)j2k\include\;$(ProjectDir)cgm\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/externals/nitro/modules/c/nitf/XML_DATA_CONTENT.vcxproj
+++ b/externals/nitro/modules/c/nitf/XML_DATA_CONTENT.vcxproj
@@ -64,7 +64,7 @@
     <ClCompile>
       <WarningLevel>EnableAllWarnings</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);NRT_MODULE_EXPORTS;NITRO_PCH</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);NRT_MODULE_EXPORTS;NITRO_PCH;_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\nrt\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
@@ -88,7 +88,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);NRT_MODULE_EXPORTS;NITRO_PCH</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);NRT_MODULE_EXPORTS;NITRO_PCH;_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)include;$(ProjectDir)..\nrt\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>

--- a/six/modules/c++/cphd/cphd.vcxproj
+++ b/six/modules/c++/cphd/cphd.vcxproj
@@ -50,7 +50,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -78,7 +78,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/six/modules/c++/cphd03/cphd03.vcxproj
+++ b/six/modules/c++/cphd03/cphd03.vcxproj
@@ -50,7 +50,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -78,7 +78,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/six/modules/c++/samples/check_valid_six.dir/check_valid_six.vcxproj
+++ b/six/modules/c++/samples/check_valid_six.dir/check_valid_six.vcxproj
@@ -50,7 +50,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)six\modules\c++\scene\include\;$(SolutionDir)six\modules\c++\six\include\;$(SolutionDir)six\modules\c++\six.sidd\include\;$(SolutionDir)six\modules\c++\six.sicd\include\;$(SolutionDir)six\modules\c++\cphd\include\;$(SolutionDir)six\modules\c++\cphd03\include\;$(SolutionDir)externals\nitro\modules\c\nrt\include\;$(SolutionDir)externals\nitro\modules\c\nitf\include\;$(SolutionDir)externals\nitro\modules\c++\nitf\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -78,7 +78,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)six\modules\c++\scene\include\;$(SolutionDir)six\modules\c++\six\include\;$(SolutionDir)six\modules\c++\six.sidd\include\;$(SolutionDir)six\modules\c++\six.sicd\include\;$(SolutionDir)six\modules\c++\cphd\include\;$(SolutionDir)six\modules\c++\cphd03\include\;$(SolutionDir)externals\nitro\modules\c\nrt\include\;$(SolutionDir)externals\nitro\modules\c\nitf\include\;$(SolutionDir)externals\nitro\modules\c++\nitf\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/six/modules/c++/samples/crop_sicd.dir/crop_sicd.vcxproj
+++ b/six/modules/c++/samples/crop_sicd.dir/crop_sicd.vcxproj
@@ -50,7 +50,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)six\modules\c++\scene\include\;$(SolutionDir)six\modules\c++\six\include\;$(SolutionDir)six\modules\c++\six.sidd\include\;$(SolutionDir)six\modules\c++\six.sicd\include\;$(SolutionDir)six\modules\c++\cphd\include\;$(SolutionDir)six\modules\c++\cphd03\include\;$(SolutionDir)externals\nitro\modules\c\nrt\include\;$(SolutionDir)externals\nitro\modules\c\nitf\include\;$(SolutionDir)externals\nitro\modules\c++\nitf\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -78,7 +78,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)six\modules\c++\scene\include\;$(SolutionDir)six\modules\c++\six\include\;$(SolutionDir)six\modules\c++\six.sidd\include\;$(SolutionDir)six\modules\c++\six.sicd\include\;$(SolutionDir)six\modules\c++\cphd\include\;$(SolutionDir)six\modules\c++\cphd03\include\;$(SolutionDir)externals\nitro\modules\c\nrt\include\;$(SolutionDir)externals\nitro\modules\c\nitf\include\;$(SolutionDir)externals\nitro\modules\c++\nitf\include\;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include\;$(SolutionDir)externals\coda-oss\install-$(Configuration)-$(Platform).$(PlatformToolset)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/six/modules/c++/scene/scene.vcxproj
+++ b/six/modules/c++/scene/scene.vcxproj
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -80,7 +80,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/six/modules/c++/six.convert/include/six/convert/BaseConverter.h
+++ b/six/modules/c++/six.convert/include/six/convert/BaseConverter.h
@@ -20,11 +20,13 @@
  *
  */
 
-#ifndef __SIX_BASE_CONVERTER_H__
-#define __SIX_BASE_CONVERTER_H__
+#pragma once
+#ifndef SIX_six_convert_BaseConverter_h_INCLUDED_
+#define SIX_six_convert_BaseConverter_h_INCLUDED_
 
 #include <string>
 #include <memory>
+#include <std/filesystem>
 
 #include <six/sicd/ComplexData.h>
 #include <six/XMLParser.h>
@@ -56,6 +58,7 @@ struct BaseConverter : protected six::XMLParser
 protected:
     static std::unique_ptr<xml::lite::Document>
             readXML(const std::string& xmlPathname);
+    static std::unique_ptr<xml::lite::Document> readXML(const std::filesystem::path&, bool preserveCharacterData = false);
 
     XMLElem findUniqueElement(const xml::lite::Element* root,
             const std::string& xmlPath) const;
@@ -84,5 +87,4 @@ protected:
 
 }
 }
-#endif
-
+#endif // SIX_six_convert_BaseConverter_h_INCLUDED_

--- a/six/modules/c++/six.convert/six.convert.vcxproj
+++ b/six/modules/c++/six.convert/six.convert.vcxproj
@@ -50,7 +50,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -77,7 +77,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/six/modules/c++/six.convert/source/BaseConverter.cpp
+++ b/six/modules/c++/six.convert/source/BaseConverter.cpp
@@ -40,12 +40,20 @@ BaseConverter::BaseConverter() :
 std::unique_ptr<xml::lite::Document>
 BaseConverter::readXML(const std::string& xmlPathname)
 {
-    six::MinidomParser parser;
+    return readXML(std::filesystem::path(xmlPathname));
+}
+std::unique_ptr<xml::lite::Document>
+BaseConverter::readXML(const std::filesystem::path& xmlPathname, bool preserveCharacterData)
+{
     io::FileInputStream xmlInputStream(xmlPathname);
+
+    six::MinidomParser parser;
+    parser.preserveCharacterData(preserveCharacterData);
     parser.parse(xmlInputStream);
+
     std::unique_ptr<xml::lite::Document> pDocument;
     parser.getDocument(pDocument);
-    return std::unique_ptr<xml::lite::Document>(pDocument.release());
+    return pDocument;
 }
 
 BaseConverter::XMLElem BaseConverter::findUniqueElement(

--- a/six/modules/c++/six.sicd/CMakeLists.txt
+++ b/six/modules/c++/six.sicd/CMakeLists.txt
@@ -18,6 +18,7 @@ coda_add_module(
         source/ComplexXMLParser101.cpp
         source/ComplexXMLParser10x.cpp
         source/CropUtils.cpp
+        source/DataParser.cpp
         source/Functor.cpp
         source/GeoData.cpp
         source/GeoLocator.cpp

--- a/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
@@ -32,6 +32,7 @@
 #include <io/InputStream.h>
 #include <logging/NullLogger.h>
 
+#include "six/Utilities.h"
 #include "six/sicd/ComplexData.h"
 
 namespace six
@@ -40,15 +41,7 @@ namespace sicd
 {
 class DataParser final
 {
-    const std::vector<std::filesystem::path>* mpSchemaPaths = nullptr;
-    logging::NullLogger mNullLogger;
-    logging::Logger& mLog;
-
-    // The default is `true` because:
-    // * many (most?) other parts of SIX unconditionally set `preserveCharacterData(true)`.
-    // * this is new code; if you're using it, you likely want different behavior than that
-    //   of existing code; otherwise, why change?
-    bool mPreserveCharacterData = true;
+    six::DataParser mDataParser;
 
 public:
 
@@ -59,7 +52,8 @@ public:
     * \param schemaPaths Schema path(s)
     * \param log Logger
     */
-    DataParser(const std::vector<std::filesystem::path>* pSchemaPaths = nullptr, logging::Logger* pLog = nullptr);
+    DataParser(const std::vector<std::filesystem::path>* pSchemaPaths = nullptr, logging::Logger* pLog = nullptr)
+        : mDataParser(pSchemaPaths, pLog) {}
     DataParser(const std::vector<std::filesystem::path>& schemaPaths, logging::Logger* pLog = nullptr)
         : DataParser(&schemaPaths, pLog) { }
     DataParser(logging::Logger& log, const std::vector<std::filesystem::path>* pSchemaPaths = nullptr)

--- a/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
@@ -43,7 +43,6 @@ namespace sicd
 class DataParser final
 {
     six::DataParser mDataParser;
-    XMLControlRegistry mXmlRegistry;
 
 public:
 

--- a/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
@@ -80,7 +80,7 @@ public:
     *
     * \return Data representation of 'xmlStr'
     */
-    std::unique_ptr<ComplexData> fromXML(::io::InputStream& xmlStream);
+    std::unique_ptr<ComplexData> fromXML(::io::InputStream& xmlStream) const;
 
     /*
      * Parses the XML in 'pathname'.
@@ -89,7 +89,7 @@ public:
      *
      * \return Data representation of the contents of 'pathname'
      */
-    std::unique_ptr<ComplexData> fromXML(const std::filesystem::path&);
+    std::unique_ptr<ComplexData> fromXML(const std::filesystem::path&) const;
 
     /*
      * Parses the XML in 'xmlStr'.
@@ -98,7 +98,7 @@ public:
      *
      * \return Data representation of 'xmlStr'
      */
-    std::unique_ptr<ComplexData> fromXML(const std::u8string& xmlStr);
+    std::unique_ptr<ComplexData> fromXML(const std::u8string& xmlStr) const;
 
     /*
      * Converts 'data' back into a formatted XML string
@@ -107,7 +107,7 @@ public:
      *
      * \return XML string representation of 'data'
      */
-    std::u8string toXML(const ComplexData&);
+    std::u8string toXML(const ComplexData&) const;
 
 };
 }

--- a/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
@@ -59,13 +59,14 @@ public:
         : DataParser(&schemaPaths, pLog, preserveCharacterData) { }
     DataParser(const std::vector<std::filesystem::path>& schemaPaths, logging::Logger& log, bool preserveCharacterData = false)
         : DataParser(schemaPaths, &log, preserveCharacterData) { }
+    explicit DataParser(bool preserveCharacterData) : DataParser(nullptr, nullptr, preserveCharacterData) { }
 
     ~DataParser() = default;
 
     DataParser(const DataParser&) = delete;
     DataParser& operator=(const DataParser&) = delete;
-    DataParser(DataParser&&) = default;
-    DataParser& operator=(DataParser&&) = default;
+    DataParser(DataParser&&) = delete;
+    DataParser& operator=(DataParser&&) = delete;
 
     /* Parses the XML in 'xmlStream'.
     *

--- a/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
@@ -33,6 +33,7 @@
 #include <logging/NullLogger.h>
 
 #include "six/Utilities.h"
+#include "six/XMLControlFactory.h"
 #include "six/sicd/ComplexData.h"
 
 namespace six
@@ -42,6 +43,7 @@ namespace sicd
 class DataParser final
 {
     six::DataParser mDataParser;
+    XMLControlRegistry mXmlRegistry;
 
 public:
 
@@ -52,8 +54,7 @@ public:
     * \param schemaPaths Schema path(s)
     * \param log Logger
     */
-    DataParser(const std::vector<std::filesystem::path>* pSchemaPaths = nullptr, logging::Logger* pLog = nullptr)
-        : mDataParser(pSchemaPaths, pLog) {}
+    DataParser(const std::vector<std::filesystem::path>* pSchemaPaths = nullptr, logging::Logger* pLog = nullptr);
     DataParser(const std::vector<std::filesystem::path>& schemaPaths, logging::Logger* pLog = nullptr)
         : DataParser(&schemaPaths, pLog) { }
     DataParser(logging::Logger& log, const std::vector<std::filesystem::path>* pSchemaPaths = nullptr)

--- a/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
@@ -1,0 +1,98 @@
+/* =========================================================================
+ * This file is part of six.sicd-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * (C) Copyright 2023, Maxar Technologies, Inc.
+ *
+ * six.sicd-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+#ifndef SIX_six_sicd_DataParser_h_INCLUDED_
+#define SIX_six_sicd_DataParser_h_INCLUDED_
+
+#include <memory>
+#include <vector>
+#include <std/filesystem>
+#include <std/string>
+
+#include <io/InputStream.h>
+#include <logging/NullLogger.h>
+
+#include "six/sicd/ComplexData.h"
+
+namespace six
+{
+namespace sicd
+{
+class DataParser final
+{
+    const std::vector<std::filesystem::path>* mpSchemaPaths = nullptr;
+    logging::NullLogger mNullLogger;
+    logging::Logger& mLog;
+    bool mPreserveCharacterData = false;
+
+public:
+
+    /* Parses the XML and converts it into a ComplexData object.
+    * Throws if the underlying type is not complex.
+    *
+    * \param xmlStream Input stream containing XML
+    * \param schemaPaths Schema path(s)
+    * \param log Logger
+    */
+    DataParser(const std::vector<std::filesystem::path>* pSchemaPaths = nullptr, logging::Logger* pLog = nullptr, bool preserveCharacterData = false);
+    DataParser(const std::vector<std::filesystem::path>& schemaPaths, logging::Logger* pLog = nullptr, bool preserveCharacterData = false)
+        : DataParser(&schemaPaths, pLog, preserveCharacterData) { }
+    DataParser(const std::vector<std::filesystem::path>& schemaPaths, logging::Logger& log, bool preserveCharacterData = false)
+        : DataParser(schemaPaths, &log, preserveCharacterData) { }
+
+    ~DataParser() = default;
+
+    DataParser(const DataParser&) = delete;
+    DataParser& operator=(const DataParser&) = delete;
+    DataParser(DataParser&&) = default;
+    DataParser& operator=(DataParser&&) = default;
+
+    /* Parses the XML in 'xmlStream'.
+    *
+    * \param xmlStream Input stream containing XML
+    *
+    * \return Data representation of 'xmlStr'
+    */
+    std::unique_ptr<ComplexData> parseData(::io::InputStream& xmlStream);
+
+    /*
+     * Parses the XML in 'pathname'.
+     *
+     * \param pathname File containing plain text XML (not a NITF)
+     *
+     * \return Data representation of the contents of 'pathname'
+     */
+    std::unique_ptr<ComplexData> parseData(const std::filesystem::path&);
+
+    /*
+     * Parses the XML in 'xmlStr'.
+     *
+     * \param xmlStr XML document as a string
+     *
+     * \return Data representation of 'xmlStr'
+     */
+    std::unique_ptr<ComplexData> parseData(const std::u8string& xmlStr);
+};
+}
+}
+#endif // SIX_six_sicd_DataParser_h_INCLUDED_

--- a/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
@@ -99,6 +99,16 @@ public:
      * \return Data representation of 'xmlStr'
      */
     std::unique_ptr<ComplexData> fromXML(const std::u8string& xmlStr);
+
+    /*
+     * Converts 'data' back into a formatted XML string
+     *
+     * \param data Representation of SICD data
+     *
+     * \return XML string representation of 'data'
+     */
+    std::u8string toXML(const ComplexData&);
+
 };
 }
 }

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -381,8 +381,7 @@ struct Utilities final
             const std::vector<std::string>& schemaPaths,
             logging::Logger& log);
     static std::unique_ptr<ComplexData> parseData(::io::InputStream& xmlStream,
-        const std::vector<std::filesystem::path>*, logging::Logger&,
-        bool preserveCharacterData = false);
+        const std::vector<std::filesystem::path>*, logging::Logger&);
 
     /*
      * Parses the XML in 'pathname' and converts it into a ComplexData object.

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -381,7 +381,8 @@ struct Utilities final
             const std::vector<std::string>& schemaPaths,
             logging::Logger& log);
     static std::unique_ptr<ComplexData> parseData(::io::InputStream& xmlStream,
-        const std::vector<std::filesystem::path>*, logging::Logger&);
+        const std::vector<std::filesystem::path>*, logging::Logger&,
+        bool preserveCharacterData = false);
 
     /*
      * Parses the XML in 'pathname' and converts it into a ComplexData object.

--- a/six/modules/c++/six.sicd/six.sicd.vcxproj
+++ b/six/modules/c++/six.sicd/six.sicd.vcxproj
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -78,7 +78,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/six/modules/c++/six.sicd/six.sicd.vcxproj
+++ b/six/modules/c++/six.sicd/six.sicd.vcxproj
@@ -117,6 +117,7 @@
     <ClInclude Include="include\six\sicd\ComplexXMLParser101.h" />
     <ClInclude Include="include\six\sicd\ComplexXMLParser10x.h" />
     <ClInclude Include="include\six\sicd\CropUtils.h" />
+    <ClInclude Include="include\six\sicd\DataParser.h" />
     <ClInclude Include="include\six\sicd\Functor.h" />
     <ClInclude Include="include\six\sicd\GeoData.h" />
     <ClInclude Include="include\six\sicd\GeoLocator.h" />
@@ -160,6 +161,7 @@
     <ClCompile Include="source\ComplexXMLParser101.cpp" />
     <ClCompile Include="source\ComplexXMLParser10x.cpp" />
     <ClCompile Include="source\CropUtils.cpp" />
+    <ClCompile Include="source\DataParser.cpp" />
     <ClCompile Include="source\Functor.cpp" />
     <ClCompile Include="source\GeoData.cpp" />
     <ClCompile Include="source\GeoLocator.cpp" />

--- a/six/modules/c++/six.sicd/six.sicd.vcxproj.filters
+++ b/six/modules/c++/six.sicd/six.sicd.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="include\six\sicd\NITFReadComplexXMLControl.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\six\sicd\DataParser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -237,6 +240,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="source\ComplexToAMP8IPHS8I.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="source\DataParser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -39,14 +39,13 @@
 
 namespace fs = std::filesystem;
 
-six::sicd::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog, bool preserveCharacterData)
+six::sicd::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog)
 	: mpSchemaPaths(pSchemaPaths),
-	mLog(pLog == nullptr ? mNullLogger : *pLog),
-	mPreserveCharacterData(preserveCharacterData)
+	mLog(pLog == nullptr ? mNullLogger : *pLog)
 {
 }
 
-std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::parseData(::io::InputStream& xmlStream)
+std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(::io::InputStream& xmlStream)
 {
     XMLControlRegistry xmlRegistry;
     xmlRegistry.addCreator<ComplexXMLControl>();
@@ -55,15 +54,20 @@ std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::parse
     return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
 }
 
-std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::parseData(const std::filesystem::path& pathname)
+std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(const std::filesystem::path& pathname)
 {
     io::FileInputStream inStream(pathname.string());
-    return parseData(inStream);
+    return fromXML(inStream);
 }
 
-std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::parseData(const std::u8string& xmlStr)
+std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(const std::u8string& xmlStr)
 {
     io::U8StringStream inStream;
     inStream.write(xmlStr);
-    return parseData(inStream);
+    return fromXML(inStream);
+}
+
+void six::sicd::DataParser::DataParser::preserveCharacterData(bool preserve)
+{
+    mPreserveCharacterData = preserve;
 }

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -39,7 +39,7 @@
 
 namespace fs = std::filesystem;
 
-std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(::io::InputStream& xmlStream)
+std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(::io::InputStream& xmlStream) const
 {
     XMLControlRegistry xmlRegistry;
     xmlRegistry.addCreator<ComplexXMLControl>();
@@ -48,20 +48,20 @@ std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromX
     return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
 }
 
-std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(const std::filesystem::path& pathname)
+std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(const std::filesystem::path& pathname) const
 {
     io::FileInputStream inStream(pathname.string());
     return fromXML(inStream);
 }
 
-std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(const std::u8string& xmlStr)
+std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(const std::u8string& xmlStr) const
 {
     io::U8StringStream inStream;
     inStream.write(xmlStr);
     return fromXML(inStream);
 }
 
-std::u8string six::sicd::DataParser::DataParser::toXML(const six::sicd::ComplexData& data)
+std::u8string six::sicd::DataParser::DataParser::toXML(const six::sicd::ComplexData& data) const
 {
     auto& log = mDataParser.log();
 

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -39,21 +39,12 @@
 
 namespace fs = std::filesystem;
 
-six::sicd::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog)
-	: mpSchemaPaths(pSchemaPaths),
-	mLog(pLog == nullptr ? mNullLogger : *pLog)
-{
-}
-
 std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(::io::InputStream& xmlStream)
 {
     XMLControlRegistry xmlRegistry;
     xmlRegistry.addCreator<ComplexXMLControl>();
 
-    six::DataParser dataParser(xmlRegistry, mpSchemaPaths, &mLog);
-    dataParser.preserveCharacterData(mPreserveCharacterData);
-
-    auto pData = dataParser.fromXML(xmlStream, DataType::NOT_SET);
+    auto pData = mDataParser.fromXML(xmlStream, xmlRegistry, DataType::NOT_SET);
     return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
 }
 
@@ -72,5 +63,5 @@ std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromX
 
 void six::sicd::DataParser::DataParser::preserveCharacterData(bool preserve)
 {
-    mPreserveCharacterData = preserve;
+    mDataParser.preserveCharacterData(preserve);
 }

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -22,20 +22,16 @@
  */
 #include "six/sicd/DataParser.h"
 
-#include <assert.h>
-
 #include <string>
 #include <memory>
 
 #include <io/StringStream.h>
-#include <gsl/gsl.h>
 
 #include "six/Utilities.h"
 #include "six/XMLControlFactory.h"
 
 #include "six/sicd/ComplexXMLControl.h"
 #include "six/sicd/ImageData.h"
-#include "six/sicd/NITFReadComplexXMLControl.h"
 
 namespace fs = std::filesystem;
 

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -50,7 +50,10 @@ std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromX
     XMLControlRegistry xmlRegistry;
     xmlRegistry.addCreator<ComplexXMLControl>();
 
-    auto pData = six::parseData(xmlRegistry, xmlStream, mpSchemaPaths, mLog, mPreserveCharacterData);
+    six::DataParser dataParser(xmlRegistry, mpSchemaPaths, &mLog);
+    dataParser.preserveCharacterData(mPreserveCharacterData);
+
+    auto pData = dataParser.fromXML(xmlStream, DataType::NOT_SET);
     return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
 }
 

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -61,6 +61,16 @@ std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromX
     return fromXML(inStream);
 }
 
+std::u8string six::sicd::DataParser::DataParser::toXML(const six::sicd::ComplexData& data)
+{
+    auto& log = mDataParser.log();
+
+    XMLControlRegistry xmlRegistry;
+    xmlRegistry.addCreator<ComplexXMLControl>();
+
+    return ::six::toValidXMLString(data, mDataParser.schemaPaths(), &log, &xmlRegistry);
+}
+
 void six::sicd::DataParser::DataParser::preserveCharacterData(bool preserve)
 {
     mDataParser.preserveCharacterData(preserve);

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -39,12 +39,15 @@
 
 namespace fs = std::filesystem;
 
+six::sicd::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog)
+    : mDataParser(pSchemaPaths, pLog)
+{
+    mXmlRegistry.addCreator<ComplexXMLControl>();
+}
+
 std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(::io::InputStream& xmlStream) const
 {
-    XMLControlRegistry xmlRegistry;
-    xmlRegistry.addCreator<ComplexXMLControl>();
-
-    auto pData = mDataParser.fromXML(xmlStream, xmlRegistry, DataType::NOT_SET);
+    auto pData = mDataParser.fromXML(xmlStream, mXmlRegistry, DataType::NOT_SET);
     return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
 }
 
@@ -63,10 +66,7 @@ std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromX
 
 std::u8string six::sicd::DataParser::DataParser::toXML(const six::sicd::ComplexData& data) const
 {
-    XMLControlRegistry xmlRegistry;
-    xmlRegistry.addCreator<ComplexXMLControl>();
-
-    return mDataParser.toXML(data, xmlRegistry);
+    return mDataParser.toXML(data, mXmlRegistry);
 }
 
 void six::sicd::DataParser::DataParser::preserveCharacterData(bool preserve)

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -63,12 +63,10 @@ std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromX
 
 std::u8string six::sicd::DataParser::DataParser::toXML(const six::sicd::ComplexData& data) const
 {
-    auto& log = mDataParser.log();
-
     XMLControlRegistry xmlRegistry;
     xmlRegistry.addCreator<ComplexXMLControl>();
 
-    return ::six::toValidXMLString(data, mDataParser.schemaPaths(), &log, &xmlRegistry);
+    return mDataParser.toXML(data, xmlRegistry);
 }
 
 void six::sicd::DataParser::DataParser::preserveCharacterData(bool preserve)

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -1,0 +1,69 @@
+/* =========================================================================
+ * This file is part of six.sicd-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * (C) Copyright 2023, Maxar Technologies, Inc.
+ *
+ * six.sicd-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "six/sicd/DataParser.h"
+
+#include <assert.h>
+
+#include <string>
+#include <memory>
+
+#include <io/StringStream.h>
+#include <gsl/gsl.h>
+
+#include "six/Utilities.h"
+#include "six/XMLControlFactory.h"
+
+#include "six/sicd/ComplexXMLControl.h"
+#include "six/sicd/ImageData.h"
+#include "six/sicd/NITFReadComplexXMLControl.h"
+
+namespace fs = std::filesystem;
+
+six::sicd::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog, bool preserveCharacterData)
+	: mpSchemaPaths(pSchemaPaths),
+	mLog(pLog == nullptr ? mNullLogger : *pLog),
+	mPreserveCharacterData(preserveCharacterData)
+{
+}
+
+std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::parseData(::io::InputStream& xmlStream)
+{
+    XMLControlRegistry xmlRegistry;
+    xmlRegistry.addCreator<ComplexXMLControl>();
+
+    auto pData = six::parseData(xmlRegistry, xmlStream, mpSchemaPaths, mLog, mPreserveCharacterData);
+    return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
+}
+
+std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::parseData(const std::filesystem::path& pathname)
+{
+    io::FileInputStream inStream(pathname.string());
+    return parseData(inStream);
+}
+
+std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::parseData(const std::u8string& xmlStr)
+{
+    io::U8StringStream inStream;
+    inStream.write(xmlStr);
+    return parseData(inStream);
+}

--- a/six/modules/c++/six.sicd/source/DataParser.cpp
+++ b/six/modules/c++/six.sicd/source/DataParser.cpp
@@ -38,13 +38,12 @@ namespace fs = std::filesystem;
 six::sicd::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog)
     : mDataParser(pSchemaPaths, pLog)
 {
-    mXmlRegistry.addCreator<ComplexXMLControl>();
+    mDataParser.addCreator<ComplexXMLControl>();
 }
 
 std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(::io::InputStream& xmlStream) const
 {
-    auto pData = mDataParser.fromXML(xmlStream, mXmlRegistry, DataType::NOT_SET);
-    return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
+    return mDataParser.fromXML<ComplexData>(xmlStream);
 }
 
 std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromXML(const std::filesystem::path& pathname) const
@@ -62,7 +61,7 @@ std::unique_ptr<six::sicd::ComplexData> six::sicd::DataParser::DataParser::fromX
 
 std::u8string six::sicd::DataParser::DataParser::toXML(const six::sicd::ComplexData& data) const
 {
-    return mDataParser.toXML(data, mXmlRegistry);
+    return mDataParser.toXML(data);
 }
 
 void six::sicd::DataParser::DataParser::preserveCharacterData(bool preserve)

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -982,26 +982,25 @@ bool Utilities::isClockwise(const std::vector<RowColInt>& vertices,
     return (area > 0);
 }
 
-template<typename TReturn, typename TSchemaPaths>
-TReturn Utilities_parseData(::io::InputStream& xmlStream, const TSchemaPaths& schemaPaths, logging::Logger& log)
-{
-    XMLControlRegistry xmlRegistry;
-    xmlRegistry.addCreator<ComplexXMLControl>();
-
-    auto data(six::parseData(xmlRegistry, xmlStream, schemaPaths, log));
-    return TReturn(static_cast<ComplexData*>(data.release()));
-}
 std::unique_ptr<ComplexData> Utilities::parseData(
         ::io::InputStream& xmlStream,
         const std::vector<std::string>& schemaPaths,
         logging::Logger& log)
 {
-    return Utilities_parseData<std::unique_ptr<ComplexData>>(xmlStream, schemaPaths, log);
+    XMLControlRegistry xmlRegistry;
+    xmlRegistry.addCreator<ComplexXMLControl>();
+
+    auto pData = six::parseData(xmlRegistry, xmlStream, schemaPaths, log);
+    return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
 }
 std::unique_ptr<ComplexData> Utilities::parseData(::io::InputStream& xmlStream,
-    const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger& log)
+    const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger& log, bool preserveCharacterData)
 {
-    return Utilities_parseData<std::unique_ptr<ComplexData>>(xmlStream, pSchemaPaths, log);
+    XMLControlRegistry xmlRegistry;
+    xmlRegistry.addCreator<ComplexXMLControl>();
+
+    auto pData = six::parseData(xmlRegistry, xmlStream, pSchemaPaths, log, preserveCharacterData);
+    return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
 }
 
 std::unique_ptr<ComplexData> Utilities::parseDataFromFile(
@@ -1033,8 +1032,7 @@ std::unique_ptr<ComplexData> Utilities::parseDataFromString(
     std::transform(schemaPaths_.begin(), schemaPaths_.end(), std::back_inserter(schemaPaths),
         [](const std::string& s) { return s; });
 
-    auto result = parseDataFromString(xmlStr, &schemaPaths, &log);
-    return std::unique_ptr<ComplexData>(result.release());
+    return parseDataFromString(xmlStr, &schemaPaths, &log);
 }
 std::unique_ptr<ComplexData> Utilities::parseDataFromString(const std::u8string& xmlStr,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -1053,7 +1053,7 @@ std::string Utilities::toXMLString(const ComplexData& data,
 std::u8string Utilities::toXMLString(const ComplexData& data,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
-    DataParser dataParser(pSchemaPaths, pLogger);
+    const DataParser dataParser(pSchemaPaths, pLogger);
     return dataParser.toXML(data);
 }
 

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -57,6 +57,7 @@
 #include <six/sicd/GeoLocator.h>
 #include <six/sicd/ImageData.h>
 #include <six/sicd/NITFReadComplexXMLControl.h>
+#include <six/sicd/DataParser.h>
 
 namespace fs = std::filesystem;
 
@@ -996,11 +997,8 @@ std::unique_ptr<ComplexData> Utilities::parseData(
 std::unique_ptr<ComplexData> Utilities::parseData(::io::InputStream& xmlStream,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger& log, bool preserveCharacterData)
 {
-    XMLControlRegistry xmlRegistry;
-    xmlRegistry.addCreator<ComplexXMLControl>();
-
-    auto pData = six::parseData(xmlRegistry, xmlStream, pSchemaPaths, log, preserveCharacterData);
-    return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
+    DataParser parser(pSchemaPaths, &log, preserveCharacterData);
+    return parser.parseData(xmlStream);
 }
 
 std::unique_ptr<ComplexData> Utilities::parseDataFromFile(
@@ -1014,11 +1012,8 @@ std::unique_ptr<ComplexData> Utilities::parseDataFromFile(
 std::unique_ptr<ComplexData> Utilities::parseDataFromFile(const std::filesystem::path& pathname,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
-    logging::NullLogger nullLogger;
-    logging::Logger* const logger = (pLogger == nullptr) ? &nullLogger : pLogger;
-
-    io::FileInputStream inStream(pathname.string());
-    return parseData(inStream, pSchemaPaths, *logger);
+    DataParser parser(pSchemaPaths, pLogger);
+    return parser.parseData(pathname);
 }
 
 std::unique_ptr<ComplexData> Utilities::parseDataFromString(
@@ -1037,12 +1032,8 @@ std::unique_ptr<ComplexData> Utilities::parseDataFromString(
 std::unique_ptr<ComplexData> Utilities::parseDataFromString(const std::u8string& xmlStr,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
-    logging::NullLogger nullLogger;
-    logging::Logger* log = (pLogger == nullptr) ? &nullLogger : pLogger;
-
-    io::U8StringStream inStream;
-    inStream.write(xmlStr);
-    return parseData(inStream, pSchemaPaths, *log);
+    DataParser parser(pSchemaPaths, pLogger);
+    return parser.parseData(xmlStr);
 }
 
 std::string Utilities::toXMLString(const ComplexData& data,

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -1225,6 +1225,20 @@ static std::unique_ptr<ComplexData> createFakeComplexData_(const std::string& st
     data->collectionInformation->setClassificationLevel("UNCLASSIFIED");
     data->collectionInformation->radarMode = six::RadarModeType::SPOTLIGHT;
 
+    auto& parameters = data->collectionInformation->parameters;
+    six::Parameter param;
+    param.setName("TestParameter");
+    param.setValue("setValue() for TestParameter");
+    parameters.push_back(param);
+
+    // By default, XML parsing in CODA-OSS trims whitespace, see preserveCharacterData
+    param.setName("TestParameterEmpty");
+    param.setValue("");
+    parameters.push_back(param);
+    param.setName("TestParameterThreeSpaces");
+    param.setValue("   ");
+    parameters.push_back(param);
+
     if (!strVersion.empty()) // TODO: better check for version; this avoid changing any existing test code
     {
         update_for_SICD_130(*data);

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -995,10 +995,11 @@ std::unique_ptr<ComplexData> Utilities::parseData(
     return std::unique_ptr<ComplexData>(static_cast<ComplexData*>(pData.release()));
 }
 std::unique_ptr<ComplexData> Utilities::parseData(::io::InputStream& xmlStream,
-    const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger& log, bool preserveCharacterData)
+    const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger& log)
 {
-    DataParser parser(pSchemaPaths, &log, preserveCharacterData);
-    return parser.parseData(xmlStream);
+    DataParser parser(pSchemaPaths, &log);
+    parser.preserveCharacterData(false); // existing behavior
+    return parser.fromXML(xmlStream);
 }
 
 std::unique_ptr<ComplexData> Utilities::parseDataFromFile(
@@ -1013,7 +1014,8 @@ std::unique_ptr<ComplexData> Utilities::parseDataFromFile(const std::filesystem:
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
     DataParser parser(pSchemaPaths, pLogger);
-    return parser.parseData(pathname);
+    parser.preserveCharacterData(false); // existing behavior
+    return parser.fromXML(pathname);
 }
 
 std::unique_ptr<ComplexData> Utilities::parseDataFromString(
@@ -1033,7 +1035,8 @@ std::unique_ptr<ComplexData> Utilities::parseDataFromString(const std::u8string&
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
     DataParser parser(pSchemaPaths, pLogger);
-    return parser.parseData(xmlStr);
+    parser.preserveCharacterData(false); // existing behavior
+    return parser.fromXML(xmlStr);
 }
 
 std::string Utilities::toXMLString(const ComplexData& data,

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -1053,13 +1053,8 @@ std::string Utilities::toXMLString(const ComplexData& data,
 std::u8string Utilities::toXMLString(const ComplexData& data,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
-    XMLControlRegistry xmlRegistry;
-    xmlRegistry.addCreator<ComplexXMLControl>();
-
-    logging::NullLogger nullLogger;
-    logging::Logger* const pLogger_ = (pLogger == nullptr) ? &nullLogger : pLogger;
-
-    return ::six::toValidXMLString(data, pSchemaPaths, pLogger_, &xmlRegistry);
+    DataParser dataParser(pSchemaPaths, pLogger);
+    return dataParser.toXML(data);
 }
 
 static void update_for_SICD_130(ComplexData& data)

--- a/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
@@ -51,8 +51,18 @@ TEST_CASE(DummyData)
 {
     const auto data = createData<six::zfloat>(types::RowCol<size_t>(10, 10));
 
-    const std::vector<std::string> schemaPaths;
-    const auto result = six::sicd::Utilities::toXMLString(*data, schemaPaths);
+    const auto& parameters = data->collectionInformation->parameters;
+    // <Parameter name="TestParameter">setValue() for TestParameter</Parameter>
+    const auto& testParameter = parameters.findParameter("TestParameter");
+    TEST_ASSERT_EQ(testParameter.str(), "setValue() for TestParameter");
+
+    // Check whitepspace in parameters
+    const auto& emptyParameter = parameters.findParameter("TestParameterEmpty");
+    TEST_ASSERT_EQ(emptyParameter.str(), "");
+    const auto& threeSpacesParameter = parameters.findParameter("TestParameterThreeSpaces");
+    TEST_ASSERT_EQ(threeSpacesParameter.str(), "   ");
+
+    const auto result = six::sicd::Utilities::toXMLString(*data);
     TEST_ASSERT_FALSE(result.empty());
 }
 

--- a/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
@@ -77,20 +77,20 @@ TEST_CASE(DummyData)
     test_DummyData_parameters(testName, data->collectionInformation->parameters);
 
     const std::vector<std::filesystem::path>* pSchemaPaths = nullptr;
-    const auto xmlStr = six::sicd::Utilities::toXMLString(*data, pSchemaPaths);
+    six::sicd::DataParser parser(pSchemaPaths);
+
+    const auto xmlStr = parser.toXML(*data);
     TEST_ASSERT_FALSE(xmlStr.empty());
 
     // Parse the XML we just made.
-    bool preserveCharacterData = false;
     {
-        six::sicd::DataParser parser;
+        constexpr bool preserveCharacterData = false;
         parser.preserveCharacterData(preserveCharacterData);
         const auto pComplexData = parser.fromXML(xmlStr);
         test_DummyData_parameters(testName, pComplexData->collectionInformation->parameters, preserveCharacterData);
     }
-    preserveCharacterData = true;
     {
-        six::sicd::DataParser parser;
+        constexpr bool preserveCharacterData = true;
         parser.preserveCharacterData(preserveCharacterData);
         const auto pComplexData = parser.fromXML(xmlStr);
         test_DummyData_parameters(testName, pComplexData->collectionInformation->parameters, preserveCharacterData);

--- a/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
@@ -47,23 +47,30 @@
 #define U8(s) static_cast<const std::char8_t*>(static_cast<const void*>(s))
 #endif
 
-TEST_CASE(DummyData)
+static void test_DummyData_parameters(const std::string& testName, const six::ParameterCollection& parameters)
 {
-    const auto data = createData<six::zfloat>(types::RowCol<size_t>(10, 10));
-
-    const auto& parameters = data->collectionInformation->parameters;
-    // <Parameter name="TestParameter">setValue() for TestParameter</Parameter>
     const auto& testParameter = parameters.findParameter("TestParameter");
     TEST_ASSERT_EQ(testParameter.str(), "setValue() for TestParameter");
 
     // Check whitepspace in parameters
     const auto& emptyParameter = parameters.findParameter("TestParameterEmpty");
     TEST_ASSERT_EQ(emptyParameter.str(), "");
-    const auto& threeSpacesParameter = parameters.findParameter("TestParameterThreeSpaces");
-    TEST_ASSERT_EQ(threeSpacesParameter.str(), "   ");
+    //const auto& threeSpacesParameter = parameters.findParameter("TestParameterThreeSpaces");
+    //TEST_ASSERT_EQ(threeSpacesParameter.str(), "   "); // TODO
+}
+TEST_CASE(DummyData)
+{
+    const auto data = createData<six::zfloat>(types::RowCol<size_t>(10, 10));
 
-    const auto result = six::sicd::Utilities::toXMLString(*data);
-    TEST_ASSERT_FALSE(result.empty());
+    test_DummyData_parameters(testName, data->collectionInformation->parameters);
+
+    const std::vector<std::filesystem::path>* pSchemaPaths = nullptr;
+    const auto xmlStr = six::sicd::Utilities::toXMLString(*data, pSchemaPaths);
+    TEST_ASSERT_FALSE(xmlStr.empty());
+
+    // Parse the XML we just made.
+    const auto pComplexData = six::sicd::Utilities::parseDataFromString(xmlStr, pSchemaPaths);
+    test_DummyData_parameters(testName, pComplexData->collectionInformation->parameters);
 }
 
 TEST_CASE(FakeComplexData)

--- a/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
@@ -83,14 +83,16 @@ TEST_CASE(DummyData)
     // Parse the XML we just made.
     bool preserveCharacterData = false;
     {
-        six::sicd::DataParser parser(preserveCharacterData);
-        const auto pComplexData = parser.parseData(xmlStr);
+        six::sicd::DataParser parser;
+        parser.preserveCharacterData(preserveCharacterData);
+        const auto pComplexData = parser.fromXML(xmlStr);
         test_DummyData_parameters(testName, pComplexData->collectionInformation->parameters, preserveCharacterData);
     }
     preserveCharacterData = true;
     {
-        six::sicd::DataParser parser(preserveCharacterData);
-        const auto pComplexData = parser.parseData(xmlStr);
+        six::sicd::DataParser parser;
+        parser.preserveCharacterData(preserveCharacterData);
+        const auto pComplexData = parser.fromXML(xmlStr);
         test_DummyData_parameters(testName, pComplexData->collectionInformation->parameters, preserveCharacterData);
     }
 }

--- a/six/modules/c++/six.sidd/CMakeLists.txt
+++ b/six/modules/c++/six.sidd/CMakeLists.txt
@@ -5,6 +5,7 @@ coda_add_module(
         source/CompressedSIDDByteProvider.cpp
         source/Compression.cpp
         source/CropUtils.cpp
+        source/DataParser.cpp
         source/DerivedClassification.cpp
         source/DerivedData.cpp
         source/DerivedDataBuilder.cpp

--- a/six/modules/c++/six.sidd/include/six/sidd/DataParser.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/DataParser.h
@@ -70,6 +70,12 @@ public:
     DataParser(DataParser&&) = delete;
     DataParser& operator=(DataParser&&) = delete;
 
+    /*!
+     * If set to true, whitespaces will be preserved in the parsed
+     * character data. Otherwise, it will be trimmed.
+     */
+    void preserveCharacterData(bool preserve);
+
     /* Parses the XML in 'xmlStream'.
     *
     * \param xmlStream Input stream containing XML

--- a/six/modules/c++/six.sidd/include/six/sidd/DataParser.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/DataParser.h
@@ -1,0 +1,111 @@
+/* =========================================================================
+ * This file is part of six.sidd-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * (C) Copyright 2023, Maxar Technologies, Inc.
+ *
+ * six.sidd-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+#ifndef SIX_six_sidd_DataParser_h_INCLUDED_
+#define SIX_six_sidd_DataParser_h_INCLUDED_
+
+#include <memory>
+#include <vector>
+#include <std/filesystem>
+#include <std/string>
+
+#include <io/InputStream.h>
+#include <logging/NullLogger.h>
+
+#include "six/Utilities.h"
+#include "six/XMLControlFactory.h"
+#include "six/sidd/DerivedData.h"
+
+namespace six
+{
+namespace sidd
+{
+class DataParser final
+{
+    std::vector<std::filesystem::path> mAdjustedSchemaPaths; // used to initialized six::DataParser
+    six::DataParser mDataParser;
+    XMLControlRegistry mXmlRegistry;
+
+public:
+
+    /* Parses the XML and converts it into a DerivedData object.
+    * Throws if the underlying type is not complex.
+    *
+    * \param xmlStream Input stream containing XML
+    * \param schemaPaths Schema path(s)
+    * \param log Logger
+    */
+    DataParser(const std::vector<std::filesystem::path>* pSchemaPaths = nullptr, logging::Logger* pLog = nullptr);
+    DataParser(const std::vector<std::filesystem::path>& schemaPaths, logging::Logger* pLog = nullptr)
+        : DataParser(&schemaPaths, pLog) { }
+    DataParser(logging::Logger& log, const std::vector<std::filesystem::path>* pSchemaPaths = nullptr)
+        : DataParser(pSchemaPaths, &log) { }
+    DataParser(const std::vector<std::filesystem::path>& schemaPaths, logging::Logger& log)
+        : DataParser(schemaPaths, &log) { }
+
+    ~DataParser() = default;
+
+    DataParser(const DataParser&) = delete;
+    DataParser& operator=(const DataParser&) = delete;
+    DataParser(DataParser&&) = delete;
+    DataParser& operator=(DataParser&&) = delete;
+
+    /* Parses the XML in 'xmlStream'.
+    *
+    * \param xmlStream Input stream containing XML
+    *
+    * \return Data representation of 'xmlStr'
+    */
+    std::unique_ptr<DerivedData> fromXML(::io::InputStream& xmlStream) const;
+
+    /*
+     * Parses the XML in 'pathname'.
+     *
+     * \param pathname File containing plain text XML (not a NITF)
+     *
+     * \return Data representation of the contents of 'pathname'
+     */
+    std::unique_ptr<DerivedData> fromXML(const std::filesystem::path&) const;
+
+    /*
+     * Parses the XML in 'xmlStr'.
+     *
+     * \param xmlStr XML document as a string
+     *
+     * \return Data representation of 'xmlStr'
+     */
+    std::unique_ptr<DerivedData> fromXML(const std::u8string& xmlStr) const;
+
+    /*
+     * Converts 'data' back into a formatted XML string
+     *
+     * \param data Representation of SIDD data
+     *
+     * \return XML string representation of 'data'
+     */
+    std::u8string toXML(const DerivedData&) const;
+
+};
+}
+}
+#endif // SIX_six_sidd_DataParser_h_INCLUDED_

--- a/six/modules/c++/six.sidd/include/six/sidd/DataParser.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/DataParser.h
@@ -44,7 +44,6 @@ class DataParser final
 {
     std::vector<std::filesystem::path> mAdjustedSchemaPaths; // used to initialized six::DataParser
     six::DataParser mDataParser;
-    XMLControlRegistry mXmlRegistry;
 
 public:
 

--- a/six/modules/c++/six.sidd/six.sidd.vcxproj
+++ b/six/modules/c++/six.sidd/six.sidd.vcxproj
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -78,7 +78,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/six/modules/c++/six.sidd/six.sidd.vcxproj
+++ b/six/modules/c++/six.sidd/six.sidd.vcxproj
@@ -106,6 +106,7 @@
     <ClInclude Include="include\six\sidd\CompressedSIDDByteProvider.h" />
     <ClInclude Include="include\six\sidd\Compression.h" />
     <ClInclude Include="include\six\sidd\CropUtils.h" />
+    <ClInclude Include="include\six\sidd\DataParser.h" />
     <ClInclude Include="include\six\sidd\DerivedClassification.h" />
     <ClInclude Include="include\six\sidd\DerivedData.h" />
     <ClInclude Include="include\six\sidd\DerivedDataBuilder.h" />
@@ -144,6 +145,7 @@
     <ClCompile Include="source\CompressedSIDDByteProvider.cpp" />
     <ClCompile Include="source\Compression.cpp" />
     <ClCompile Include="source\CropUtils.cpp" />
+    <ClCompile Include="source\DataParser.cpp" />
     <ClCompile Include="source\DerivedClassification.cpp" />
     <ClCompile Include="source\DerivedData.cpp" />
     <ClCompile Include="source\DerivedDataBuilder.cpp" />

--- a/six/modules/c++/six.sidd/six.sidd.vcxproj.filters
+++ b/six/modules/c++/six.sidd/six.sidd.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClInclude Include="include\six\sidd\DerivedXMLParser300.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\six\sidd\DataParser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -189,6 +192,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="source\DerivedXMLParser300.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="source\DataParser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/six/modules/c++/six.sidd/source/DataParser.cpp
+++ b/six/modules/c++/six.sidd/source/DataParser.cpp
@@ -1,0 +1,98 @@
+/* =========================================================================
+ * This file is part of six.sidd-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * (C) Copyright 2023, Maxar Technologies, Inc.
+ *
+ * six.sidd-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "six/sidd/DataParser.h"
+
+#include <string>
+#include <memory>
+#include <set>
+
+#include <io/StringStream.h>
+
+#include "six/Utilities.h"
+#include "six/XMLControlFactory.h"
+
+#include "six/sidd/DerivedXMLControl.h"
+#include "six/sidd/DerivedDataBuilder.h"
+
+namespace fs = std::filesystem;
+
+static void prependISMSchemaPaths(const std::vector<std::filesystem::path>*& pSchemaPaths,
+    std::vector<std::filesystem::path>& adjustedSchemaPaths)
+{
+    if (pSchemaPaths == nullptr)
+    {
+        return;
+    }
+
+    // Get directories for XSDs that appear to be SIDD schemas
+    const auto xsd_files = six::sidd300::find_SIDD_schema_V_files(*pSchemaPaths);
+    std::set<std::string> xsd_dirs; // easy way to make directories unique
+    for (auto&& xsd : xsd_files)
+    {
+        xsd_dirs.insert(xsd.parent_path().string());
+    }
+    for (const auto& dir : xsd_dirs)
+    {
+        adjustedSchemaPaths.push_back(dir);
+    }
+
+    // Include all the original schema paths; these will be AFTER the adjusted paths, above
+    adjustedSchemaPaths.insert(adjustedSchemaPaths.end(), pSchemaPaths->begin(), pSchemaPaths->end());
+
+    pSchemaPaths = &adjustedSchemaPaths;
+}
+static auto adjustSchemaPaths(const std::vector<std::filesystem::path>* pSchemaPaths, std::vector<std::filesystem::path>& adjustedSchemaPaths)
+{
+    prependISMSchemaPaths(pSchemaPaths, adjustedSchemaPaths);
+    return pSchemaPaths;
+}
+
+six::sidd::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog)
+    : mDataParser(adjustSchemaPaths(pSchemaPaths, mAdjustedSchemaPaths), pLog)
+{
+    mXmlRegistry.addCreator<DerivedXMLControl>();
+}
+
+std::unique_ptr<six::sidd::DerivedData> six::sidd::DataParser::DataParser::fromXML(::io::InputStream& xmlStream) const
+{
+    auto pData = mDataParser.fromXML(xmlStream, mXmlRegistry, DataType::NOT_SET);
+    return std::unique_ptr<DerivedData>(static_cast<DerivedData*>(pData.release()));
+}
+
+std::unique_ptr<six::sidd::DerivedData> six::sidd::DataParser::DataParser::fromXML(const std::filesystem::path& pathname) const
+{
+    io::FileInputStream inStream(pathname.string());
+    return fromXML(inStream);
+}
+
+std::unique_ptr<six::sidd::DerivedData> six::sidd::DataParser::DataParser::fromXML(const std::u8string& xmlStr) const
+{
+    io::U8StringStream inStream;
+    inStream.write(xmlStr);
+    return fromXML(inStream);
+}
+
+std::u8string six::sidd::DataParser::DataParser::toXML(const six::sidd::DerivedData& data) const
+{
+    return mDataParser.toXML(data, mXmlRegistry);
+}

--- a/six/modules/c++/six.sidd/source/DataParser.cpp
+++ b/six/modules/c++/six.sidd/source/DataParser.cpp
@@ -70,13 +70,12 @@ static auto adjustSchemaPaths(const std::vector<std::filesystem::path>* pSchemaP
 six::sidd::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog)
     : mDataParser(adjustSchemaPaths(pSchemaPaths, mAdjustedSchemaPaths), pLog)
 {
-    mXmlRegistry.addCreator<DerivedXMLControl>();
+    mDataParser.addCreator<DerivedXMLControl>();
 }
 
 std::unique_ptr<six::sidd::DerivedData> six::sidd::DataParser::DataParser::fromXML(::io::InputStream& xmlStream) const
 {
-    auto pData = mDataParser.fromXML(xmlStream, mXmlRegistry, DataType::NOT_SET);
-    return std::unique_ptr<DerivedData>(static_cast<DerivedData*>(pData.release()));
+    return mDataParser.fromXML<DerivedData>(xmlStream);
 }
 
 std::unique_ptr<six::sidd::DerivedData> six::sidd::DataParser::DataParser::fromXML(const std::filesystem::path& pathname) const
@@ -94,7 +93,7 @@ std::unique_ptr<six::sidd::DerivedData> six::sidd::DataParser::DataParser::fromX
 
 std::u8string six::sidd::DataParser::DataParser::toXML(const six::sidd::DerivedData& data) const
 {
-    return mDataParser.toXML(data, mXmlRegistry);
+    return mDataParser.toXML(data);
 }
 
 void six::sidd::DataParser::DataParser::preserveCharacterData(bool preserve)

--- a/six/modules/c++/six.sidd/source/DataParser.cpp
+++ b/six/modules/c++/six.sidd/source/DataParser.cpp
@@ -96,3 +96,8 @@ std::u8string six::sidd::DataParser::DataParser::toXML(const six::sidd::DerivedD
 {
     return mDataParser.toXML(data, mXmlRegistry);
 }
+
+void six::sidd::DataParser::DataParser::preserveCharacterData(bool preserve)
+{
+    mDataParser.preserveCharacterData(preserve);
+}

--- a/six/modules/c++/six.sidd/source/Utilities.cpp
+++ b/six/modules/c++/six.sidd/source/Utilities.cpp
@@ -29,6 +29,7 @@
 #include "six/Utilities.h"
 #include "six/sidd/DerivedXMLControl.h"
 #include "six/sidd/DerivedDataBuilder.h"
+#include "six/sidd/DataParser.h"
 
 namespace
 {
@@ -526,53 +527,21 @@ std::unique_ptr<scene::ProjectionModel> Utilities::getProjectionModel(
     return projModel;
 }
 
-template<typename TReturn, typename TSchemaPaths>
-TReturn Utilities_parseData(::io::InputStream& xmlStream, const TSchemaPaths& schemaPaths, logging::Logger& log)
+std::unique_ptr<DerivedData> Utilities::parseData(::io::InputStream& xmlStream,
+        const std::vector<std::string>& schemaPaths, logging::Logger& log)
 {
     XMLControlRegistry xmlRegistry;
     xmlRegistry.addCreator<DerivedXMLControl>();
 
     auto data(six::parseData(xmlRegistry, xmlStream, schemaPaths, log));
-    return TReturn(static_cast<DerivedData*>(data.release()));
-}
-std::unique_ptr<DerivedData> Utilities::parseData(::io::InputStream& xmlStream,
-        const std::vector<std::string>& schemaPaths, logging::Logger& log)
-{
-    return Utilities_parseData<std::unique_ptr<DerivedData>>(xmlStream, schemaPaths, log);
-}
-
-static void prependISMSchemaPaths(const std::vector<std::filesystem::path>* &pSchemaPaths,
-    std::vector<std::filesystem::path>& adjustedSchemaPaths)
-{
-    if (pSchemaPaths == nullptr)
-    {
-        return;
-    }
-
-    // Get directories for XSDs that appear to be SIDD schemas
-    const auto xsd_files = six::sidd300::find_SIDD_schema_V_files(*pSchemaPaths);
-    std::set<std::string> xsd_dirs; // easy way to make directories unique
-    for (auto&& xsd : xsd_files)
-    {
-        xsd_dirs.insert(xsd.parent_path().string());
-    }
-    for (const auto& dir : xsd_dirs)
-    {
-        adjustedSchemaPaths.push_back(dir);
-    }
-
-    // Include all the original schema paths; these will be AFTER the adjusted paths, above
-    adjustedSchemaPaths.insert(adjustedSchemaPaths.end(), pSchemaPaths->begin(), pSchemaPaths->end());
-
-    pSchemaPaths = &adjustedSchemaPaths;
+    return std::unique_ptr<DerivedData>(static_cast<DerivedData*>(data.release()));
 }
 
 std::unique_ptr<DerivedData> Utilities::parseData(::io::InputStream& xmlStream,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger& log)
 {
-    std::vector<std::filesystem::path> adjustedSchemaPaths; // keep in-scope
-    prependISMSchemaPaths(pSchemaPaths, adjustedSchemaPaths);
-    return Utilities_parseData<std::unique_ptr<DerivedData>>(xmlStream, pSchemaPaths, log);
+    DataParser dataParser(log, pSchemaPaths);
+    return dataParser.fromXML(xmlStream);
 }
 
 std::unique_ptr<DerivedData> Utilities::parseDataFromFile(const std::string& pathname,
@@ -584,11 +553,8 @@ std::unique_ptr<DerivedData> Utilities::parseDataFromFile(const std::string& pat
 std::unique_ptr<DerivedData> Utilities::parseDataFromFile(const std::filesystem::path& pathname,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
-    logging::NullLogger nullLogger;
-    logging::Logger* const logger = (pLogger == nullptr) ? &nullLogger : pLogger;
-
-    io::FileInputStream inStream(pathname.string());
-    return parseData(inStream, pSchemaPaths, *logger);
+    DataParser dataParser(pSchemaPaths, pLogger);
+    return dataParser.fromXML(pathname);
 }
 
 std::unique_ptr<DerivedData> Utilities::parseDataFromString(const std::string& xmlStr_,
@@ -606,12 +572,8 @@ std::unique_ptr<DerivedData> Utilities::parseDataFromString(const std::string& x
 std::unique_ptr<DerivedData> Utilities::parseDataFromString(const std::u8string& xmlStr,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
-    logging::NullLogger nullLogger;
-    logging::Logger* log = (pLogger == nullptr) ? &nullLogger : pLogger;
-
-    io::U8StringStream inStream;
-    inStream.write(xmlStr);
-    return parseData(inStream, pSchemaPaths, *log);
+    DataParser dataParser(pSchemaPaths, pLogger);
+    return dataParser.fromXML(xmlStr);
 }
 
 std::string Utilities::toXMLString(const DerivedData& data,
@@ -627,16 +589,8 @@ std::string Utilities::toXMLString(const DerivedData& data,
 std::u8string Utilities::toXMLString(const DerivedData& data,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
-    XMLControlRegistry xmlRegistry;
-    xmlRegistry.addCreator<DerivedXMLControl>();
-
-    logging::NullLogger nullLogger;
-    logging::Logger* const pLogger_ = (pLogger == nullptr) ? &nullLogger : pLogger;
-
-    std::vector<std::filesystem::path> adjustedSchemaPaths; // keep in-scope
-    prependISMSchemaPaths(pSchemaPaths, adjustedSchemaPaths);
-
-    return ::six::toValidXMLString(data, pSchemaPaths, pLogger_, &xmlRegistry);
+    DataParser dataParser(pSchemaPaths, pLogger);
+    return dataParser.toXML(data);
 }
 
 static void createPredefinedFilter(six::sidd::Filter& filter)

--- a/six/modules/c++/six.sidd/source/Utilities.cpp
+++ b/six/modules/c++/six.sidd/source/Utilities.cpp
@@ -541,6 +541,7 @@ std::unique_ptr<DerivedData> Utilities::parseData(::io::InputStream& xmlStream,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger& log)
 {
     DataParser dataParser(log, pSchemaPaths);
+    dataParser.preserveCharacterData(false); // existing behavior
     return dataParser.fromXML(xmlStream);
 }
 
@@ -554,6 +555,7 @@ std::unique_ptr<DerivedData> Utilities::parseDataFromFile(const std::filesystem:
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
     DataParser dataParser(pSchemaPaths, pLogger);
+    dataParser.preserveCharacterData(false); // existing behavior
     return dataParser.fromXML(pathname);
 }
 
@@ -573,6 +575,7 @@ std::unique_ptr<DerivedData> Utilities::parseDataFromString(const std::u8string&
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
     DataParser dataParser(pSchemaPaths, pLogger);
+    dataParser.preserveCharacterData(false); // existing behavior
     return dataParser.fromXML(xmlStr);
 }
 
@@ -590,6 +593,7 @@ std::u8string Utilities::toXMLString(const DerivedData& data,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)
 {
     DataParser dataParser(pSchemaPaths, pLogger);
+    dataParser.preserveCharacterData(false); // existing behavior
     return dataParser.toXML(data);
 }
 

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -207,7 +207,8 @@ std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
                               logging::Logger& log);
 std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
     ::io::InputStream& xmlStream, DataType dataType,
-    const std::vector<std::filesystem::path>*, logging::Logger&);
+    const std::vector<std::filesystem::path>*, logging::Logger&,
+    bool preserveCharacterData = false);
 
 /*
  * Parses the XML in 'xmlStream' and converts it into a Data object.  Same as
@@ -225,7 +226,8 @@ std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
                               const std::vector<std::string>& schemaPaths,
                               logging::Logger& log);
 std::unique_ptr<Data> parseData(const XMLControlRegistry&, ::io::InputStream&,
-    const std::vector<std::filesystem::path>*, logging::Logger&);
+    const std::vector<std::filesystem::path>*, logging::Logger&,
+    bool preserveCharacterData = false);
 
 /*
  * Parses the XML in 'pathname' and converts it into a Data object.

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -323,6 +323,7 @@ class DataParser final
     const std::vector<std::filesystem::path>* mpSchemaPaths = nullptr;
     logging::NullLogger mNullLogger;
     logging::Logger& mLog;
+    XMLControlRegistry mXmlRegistry;
 
     // The default is `true` because:
     // * many (most?) other parts of SIX unconditionally set `preserveCharacterData(true)`.
@@ -353,6 +354,12 @@ public:
     */
     void preserveCharacterData(bool preserve);
 
+    template<typename TXMLControlCreator>
+    void addCreator()
+    {
+        mXmlRegistry.addCreator<TXMLControlCreator>();
+    }
+
     /* Parses the XML in 'xmlStream'.
     *
     * \param xmlStream Input stream containing XML
@@ -360,6 +367,12 @@ public:
     * \return Data representation of 'xmlStr'
     */
     std::unique_ptr<Data> fromXML(::io::InputStream& xmlStream, const XMLControlRegistry&, DataType) const;
+    template<typename TData>
+    std::unique_ptr<TData> fromXML(::io::InputStream& xmlStream) const
+    {
+        auto pData = fromXML(xmlStream, mXmlRegistry, DataType::NOT_SET);
+        return std::unique_ptr<TData>(static_cast<TData*>(pData.release()));
+    }
 
     /*
     * Parses the XML in 'pathname'.
@@ -383,6 +396,7 @@ public:
      *  Additionally performs schema validation --
      */
     std::u8string toXML(const Data&, const XMLControlRegistry&) const;
+    std::u8string toXML(const Data&) const;
 };
 
 namespace testing

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -359,7 +359,7 @@ public:
     *
     * \return Data representation of 'xmlStr'
     */
-    std::unique_ptr<Data> fromXML(::io::InputStream& xmlStream, const XMLControlRegistry&, DataType dataType);
+    std::unique_ptr<Data> fromXML(::io::InputStream& xmlStream, const XMLControlRegistry&, DataType dataType) const;
 
     /*
         * Parses the XML in 'pathname'.
@@ -368,7 +368,7 @@ public:
         *
         * \return Data representation of the contents of 'pathname'
         */
-    std::unique_ptr<Data> fromXML(const std::filesystem::path&, const XMLControlRegistry&, DataType dataType);
+    std::unique_ptr<Data> fromXML(const std::filesystem::path&, const XMLControlRegistry&, DataType dataType) const;
 
     /*
         * Parses the XML in 'xmlStr'.
@@ -377,7 +377,7 @@ public:
         *
         * \return Data representation of 'xmlStr'
         */
-    std::unique_ptr<Data> fromXML(const std::u8string& xmlStr, const XMLControlRegistry&, DataType dataType);
+    std::unique_ptr<Data> fromXML(const std::u8string& xmlStr, const XMLControlRegistry&, DataType dataType) const;
 
     const std::vector<std::filesystem::path>* schemaPaths() const { return mpSchemaPaths; }
     logging::Logger& log() const { return mLog; }

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -348,9 +348,9 @@ public:
     DataParser& operator=(DataParser&&) = delete;
 
     /*!
-        * If set to true, whitespaces will be preserved in the parsed
-        * character data. Otherwise, it will be trimmed.
-        */
+    * If set to true, whitespaces will be preserved in the parsed
+    * character data. Otherwise, it will be trimmed.
+    */
     void preserveCharacterData(bool preserve);
 
     /* Parses the XML in 'xmlStream'.
@@ -359,28 +359,30 @@ public:
     *
     * \return Data representation of 'xmlStr'
     */
-    std::unique_ptr<Data> fromXML(::io::InputStream& xmlStream, const XMLControlRegistry&, DataType dataType) const;
+    std::unique_ptr<Data> fromXML(::io::InputStream& xmlStream, const XMLControlRegistry&, DataType) const;
 
     /*
-        * Parses the XML in 'pathname'.
-        *
-        * \param pathname File containing plain text XML (not a NITF)
-        *
-        * \return Data representation of the contents of 'pathname'
-        */
-    std::unique_ptr<Data> fromXML(const std::filesystem::path&, const XMLControlRegistry&, DataType dataType) const;
+    * Parses the XML in 'pathname'.
+    *
+    * \param pathname File containing plain text XML (not a NITF)
+    *
+    * \return Data representation of the contents of 'pathname'
+    */
+    std::unique_ptr<Data> fromXML(const std::filesystem::path&, const XMLControlRegistry&, DataType) const;
 
     /*
-        * Parses the XML in 'xmlStr'.
-        *
-        * \param xmlStr XML document as a string
-        *
-        * \return Data representation of 'xmlStr'
-        */
-    std::unique_ptr<Data> fromXML(const std::u8string& xmlStr, const XMLControlRegistry&, DataType dataType) const;
+    * Parses the XML in 'xmlStr'.
+    *
+    * \param xmlStr XML document as a string
+    *
+    * \return Data representation of 'xmlStr'
+    */
+    std::unique_ptr<Data> fromXML(const std::u8string& xmlStr, const XMLControlRegistry&, DataType) const;
 
-    const std::vector<std::filesystem::path>* schemaPaths() const { return mpSchemaPaths; }
-    logging::Logger& log() const { return mLog; }
+    /*!
+     *  Additionally performs schema validation --
+     */
+    std::u8string toXML(const Data&, const XMLControlRegistry&) const;
 };
 
 namespace testing

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -378,6 +378,9 @@ public:
         * \return Data representation of 'xmlStr'
         */
     std::unique_ptr<Data> fromXML(const std::u8string& xmlStr, const XMLControlRegistry&, DataType dataType);
+
+    const std::vector<std::filesystem::path>* schemaPaths() const { return mpSchemaPaths; }
+    logging::Logger& log() const { return mLog; }
 };
 
 namespace testing

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -19,8 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-#ifndef __SIX_UTILITIES_H__
-#define __SIX_UTILITIES_H__
+#pragma once
+#ifndef SIX_six_Utilities_h_INCLUDED_
+#define SIX_six_Utilities_h_INCLUDED_
 
 #include <vector>
 #include <memory>
@@ -319,7 +320,6 @@ std::string findSchemaPath(const std::string& progname);
 
 class DataParser final
 {
-    const XMLControlRegistry& mXmlReg;
     const std::vector<std::filesystem::path>* mpSchemaPaths = nullptr;
     logging::NullLogger mNullLogger;
     logging::Logger& mLog;
@@ -339,8 +339,7 @@ public:
     * \param schemaPaths Schema path(s)
     * \param log Logger
     */
-    DataParser(const XMLControlRegistry&, 
-        const std::vector<std::filesystem::path>* pSchemaPaths = nullptr, logging::Logger* pLog = nullptr);
+    DataParser(const std::vector<std::filesystem::path>* pSchemaPaths = nullptr, logging::Logger* pLog = nullptr);
     ~DataParser() = default;
 
     DataParser(const DataParser&) = delete;
@@ -360,7 +359,7 @@ public:
     *
     * \return Data representation of 'xmlStr'
     */
-    std::unique_ptr<Data> fromXML(::io::InputStream& xmlStream, DataType dataType);
+    std::unique_ptr<Data> fromXML(::io::InputStream& xmlStream, const XMLControlRegistry&, DataType dataType);
 
     /*
         * Parses the XML in 'pathname'.
@@ -369,7 +368,7 @@ public:
         *
         * \return Data representation of the contents of 'pathname'
         */
-    std::unique_ptr<Data> fromXML(const std::filesystem::path&, DataType dataType);
+    std::unique_ptr<Data> fromXML(const std::filesystem::path&, const XMLControlRegistry&, DataType dataType);
 
     /*
         * Parses the XML in 'xmlStr'.
@@ -378,7 +377,7 @@ public:
         *
         * \return Data representation of 'xmlStr'
         */
-    std::unique_ptr<Data> fromXML(const std::u8string& xmlStr, DataType dataType);
+    std::unique_ptr<Data> fromXML(const std::u8string& xmlStr, const XMLControlRegistry&, DataType dataType);
 };
 
 namespace testing
@@ -396,4 +395,4 @@ namespace testing
 
 }
 
-#endif
+#endif // SIX_six_Utilities_h_INCLUDED_

--- a/six/modules/c++/six/include/six/XmlLite.h
+++ b/six/modules/c++/six/include/six/XmlLite.h
@@ -49,8 +49,8 @@ struct MinidomParser final
     ~MinidomParser();
     MinidomParser(const MinidomParser&) = delete;
     MinidomParser& operator=(const MinidomParser&) = delete;
-    MinidomParser(MinidomParser&&) = default;
-    MinidomParser& operator=(MinidomParser&&) = default;
+    MinidomParser(MinidomParser&&);
+    MinidomParser& operator=(MinidomParser&&);
 
      /*!
      *  Present our parsing interface.  Similar to DOM, the input

--- a/six/modules/c++/six/six.vcxproj
+++ b/six/modules/c++/six/six.vcxproj
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -79,7 +79,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/six/modules/c++/six/source/Utilities.cpp
+++ b/six/modules/c++/six/source/Utilities.cpp
@@ -584,9 +584,9 @@ std::unique_ptr<Data> six::parseData(const XMLControlRegistry& xmlReg,
     const std::vector<std::filesystem::path>* pSchemaPaths,
     logging::Logger& log)
 {
-    DataParser dataParser(xmlReg, pSchemaPaths, &log);
+    DataParser dataParser(pSchemaPaths, &log);
     dataParser.preserveCharacterData(false); // existing behavior
-    return dataParser.fromXML(xmlStream, DataType::NOT_SET);
+    return dataParser.fromXML(xmlStream, xmlReg, DataType::NOT_SET);
 }
 
 inline std::unique_ptr<Data> fromXML_(const xml::lite::Document& doc, XMLControl& xmlControl, const std::vector<std::string>& schemaPaths)
@@ -657,9 +657,9 @@ std::unique_ptr<Data> six::parseData(const XMLControlRegistry& xmlReg,
     const std::vector<std::filesystem::path>* pSchemaPaths,
     logging::Logger& log)
 {
-    DataParser dataParser(xmlReg, pSchemaPaths, &log);
+    DataParser dataParser(pSchemaPaths, &log);
     dataParser.preserveCharacterData(false); // existing behavior
-    return dataParser.fromXML(xmlStream, dataType);
+    return dataParser.fromXML(xmlStream, xmlReg, dataType);
 }
 
 std::unique_ptr<Data>  six::parseDataFromFile(const XMLControlRegistry& xmlReg,
@@ -685,9 +685,9 @@ std::unique_ptr<Data> six::parseDataFromString(const XMLControlRegistry& xmlReg,
     const std::vector<std::filesystem::path>* pSchemaPaths,
     logging::Logger* pLogger)
 {
-    DataParser dataParser(xmlReg, pSchemaPaths, pLogger);
+    DataParser dataParser(pSchemaPaths, pLogger);
     dataParser.preserveCharacterData(false); // existing behavior
-    return dataParser.fromXML(xmlStr, DataType::NOT_SET);
+    return dataParser.fromXML(xmlStr, xmlReg, DataType::NOT_SET);
 }
 std::unique_ptr<Data> six::parseDataFromString(const XMLControlRegistry& xmlReg,
     const std::string& xmlStr,
@@ -704,9 +704,9 @@ std::unique_ptr<Data> six::parseDataFromString(
         const std::vector<std::filesystem::path>* pSchemaPaths,
         logging::Logger* pLogger)
 {
-    DataParser dataParser(xmlReg, pSchemaPaths, pLogger);
+    DataParser dataParser(pSchemaPaths, pLogger);
     dataParser.preserveCharacterData(false); // existing behavior
-    return dataParser.fromXML(xmlStr, dataType);
+    return dataParser.fromXML(xmlStr, xmlReg, dataType);
 }
 std::unique_ptr<Data> six::parseDataFromString(const XMLControlRegistry& xmlReg,
     const std::string& xmlStr,
@@ -924,31 +924,32 @@ std::filesystem::path six::testing::getSampleXmlPath(const std::filesystem::path
     return getModuleFile(modulePath, filename);
 }
 
-six::DataParser::DataParser(const XMLControlRegistry& xmlReg,
-    const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog)
-    : mXmlReg(xmlReg), 
-    mpSchemaPaths(pSchemaPaths),
+six::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLog)
+    : mpSchemaPaths(pSchemaPaths),
     mLog(pLog == nullptr ? mNullLogger : *pLog)
 {
 }
 
-std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(::io::InputStream& xmlStream, DataType dataType)
+std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(::io::InputStream& xmlStream,
+    const XMLControlRegistry& xmlReg, DataType dataType)
 {
     auto xmlParser = parseInputStream(xmlStream, mPreserveCharacterData);
-    return six_parseData<std::unique_ptr<Data>>(mXmlReg, xmlParser, dataType, mpSchemaPaths, mLog);
+    return six_parseData<std::unique_ptr<Data>>(xmlReg, xmlParser, dataType, mpSchemaPaths, mLog);
 }
 
-std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(const std::filesystem::path& pathname, DataType dataType)
+std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(const std::filesystem::path& pathname, 
+    const XMLControlRegistry& xmlReg, DataType dataType)
 {
     io::FileInputStream inStream(pathname.string());
-    return fromXML(inStream, dataType);
+    return fromXML(inStream, xmlReg, dataType);
 }
 
-std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(const std::u8string& xmlStr, DataType dataType)
+std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(const std::u8string& xmlStr,
+    const XMLControlRegistry& xmlReg, DataType dataType)
 {
     io::U8StringStream inStream;
     inStream.write(xmlStr);
-    return fromXML(inStream, dataType);
+    return fromXML(inStream, xmlReg, dataType);
 }
 
 void six::DataParser::DataParser::preserveCharacterData(bool preserve)

--- a/six/modules/c++/six/source/Utilities.cpp
+++ b/six/modules/c++/six/source/Utilities.cpp
@@ -931,21 +931,21 @@ six::DataParser::DataParser(const std::vector<std::filesystem::path>* pSchemaPat
 }
 
 std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(::io::InputStream& xmlStream,
-    const XMLControlRegistry& xmlReg, DataType dataType)
+    const XMLControlRegistry& xmlReg, DataType dataType) const
 {
     auto xmlParser = parseInputStream(xmlStream, mPreserveCharacterData);
     return six_parseData<std::unique_ptr<Data>>(xmlReg, xmlParser, dataType, mpSchemaPaths, mLog);
 }
 
 std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(const std::filesystem::path& pathname, 
-    const XMLControlRegistry& xmlReg, DataType dataType)
+    const XMLControlRegistry& xmlReg, DataType dataType) const
 {
     io::FileInputStream inStream(pathname.string());
     return fromXML(inStream, xmlReg, dataType);
 }
 
 std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(const std::u8string& xmlStr,
-    const XMLControlRegistry& xmlReg, DataType dataType)
+    const XMLControlRegistry& xmlReg, DataType dataType) const
 {
     io::U8StringStream inStream;
     inStream.write(xmlStr);

--- a/six/modules/c++/six/source/Utilities.cpp
+++ b/six/modules/c++/six/source/Utilities.cpp
@@ -952,6 +952,11 @@ std::unique_ptr<six::Data> six::DataParser::DataParser::fromXML(const std::u8str
     return fromXML(inStream, xmlReg, dataType);
 }
 
+std::u8string  six::DataParser::DataParser::toXML(const Data& data, const XMLControlRegistry& xmlReg) const
+{
+    return ::six::toValidXMLString(data, mpSchemaPaths, &mLog, &xmlReg);
+}
+
 void six::DataParser::DataParser::preserveCharacterData(bool preserve)
 {
     mPreserveCharacterData = preserve;

--- a/six/modules/c++/six/source/Utilities.cpp
+++ b/six/modules/c++/six/source/Utilities.cpp
@@ -956,6 +956,10 @@ std::u8string  six::DataParser::DataParser::toXML(const Data& data, const XMLCon
 {
     return ::six::toValidXMLString(data, mpSchemaPaths, &mLog, &xmlReg);
 }
+std::u8string  six::DataParser::DataParser::toXML(const Data& data) const
+{
+    return toXML(data, mXmlRegistry);
+}
 
 void six::DataParser::DataParser::preserveCharacterData(bool preserve)
 {

--- a/six/modules/c++/six/source/XmlLite.cpp
+++ b/six/modules/c++/six/source/XmlLite.cpp
@@ -50,6 +50,8 @@ namespace six
     {
     }
     MinidomParser::~MinidomParser() = default;
+    MinidomParser::MinidomParser(MinidomParser&&) = default;
+    MinidomParser& MinidomParser::operator=(MinidomParser&&) = default;
 
     void MinidomParser::parse(io::InputStream& is, int size)
     {

--- a/six/projects/csm/csm.vcxproj
+++ b/six/projects/csm/csm.vcxproj
@@ -149,7 +149,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);CSM_LIBRARY</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);CSM_LIBRARY;_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -178,7 +178,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);CSM_LIBRARY</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);CSM_LIBRARY;_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>


### PR DESCRIPTION
Allow SICD XML to be parsed with `preserveCharacterData` set to `true`; this enables whitespace to be preserved (and it also what most other parts of SIX already do).