### PR TITLE
clean MSBUILD output to avoid filling up disk

### DIFF
--- a/.github/workflows/frequent_check.yml
+++ b/.github/workflows/frequent_check.yml
@@ -40,6 +40,7 @@ jobs:
     - name: msbuild
       run: |
         msbuild six.sln /p:configuration=${{ matrix.configuration }}
+        msbuild six.sln /p:configuration=${{ matrix.configuration }} /t:Clean
 
   build-msbuild-windows:
     strategy:
@@ -69,6 +70,7 @@ jobs:
     - name: msbuild
       run: |
         msbuild six.sln /p:configuration=${{ matrix.configuration }}
+        msbuild six.sln /p:configuration=${{ matrix.configuration }} /t:Clean
     #- name: vstest 
     #  uses: microsoft/vstest-action@v1.0.0 # https://github.com/marketplace/actions/vstest-action
     #  with:

--- a/six/modules/c++/cpp_pch.h
+++ b/six/modules/c++/cpp_pch.h
@@ -43,6 +43,8 @@
 #include <atomic>
 #include <future>
 
+#pragma warning(disable: 5105) // macro expansion producing '...' has undefined behavior
+
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
 #define NOMINMAX
 #include <windows.h>


### PR DESCRIPTION
Clean **msbuild** output to avoid filling up disk.