### PR TITLE
account for toString changes in CODA-OSS

### DIFF
--- a/externals/coda-oss/.github/workflows/build_unittest.yml
+++ b/externals/coda-oss/.github/workflows/build_unittest.yml
@@ -89,7 +89,7 @@ jobs:
     #      searchFolder: D:\a\nitro\nitro\${{ matrix.platform }}\${{ matrix.configuration }}
     #      runInParallel: true  
 
-  build-linux-cmake:
+  build-linux-cmake-default:
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -109,8 +109,7 @@ jobs:
       run: |
         env
         which python
-        mkdir target
-        cd target
+        mkdir target && cd target
         cmake .. -DCMAKE_INSTALL_PREFIX=install${{ matrix.os }}CMake-Github -DPYTHON_VERSION=${{ matrix.python-version }} -DENABLE_SWIG=ON
     - name: build
       run: |
@@ -126,6 +125,30 @@ jobs:
       run: |
         cd target
         cmake --build . --target install
+
+  build-linux-cmake:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        configuration: [Debug, Release]
+    name: ${{ matrix.os }}-${{ matrix.configuration }}-CMake
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: configure
+      run: |
+        mkdir out && cd out
+        cmake .. -DENABLE_PYTHON=OFF
+    - name: build
+      run: |
+        cd out
+        # "-j" spawns too many processes causing GCC to crash
+        cmake --build . --config ${{ matrix.configuration }} -j 12
+    - name: test
+    # should run w/o install
+      run: |
+        cd out
+        ctest -C ${{ matrix.configuration }} --output-on-failure
 
   build-waf:
     strategy:

--- a/externals/coda-oss/modules/c++/include/TestCase.h
+++ b/externals/coda-oss/modules/c++/include/TestCase.h
@@ -20,9 +20,9 @@
  *
  */
 
-#ifndef __TEST_CASE_H__
-#define __TEST_CASE_H__
 #pragma once
+#ifndef CODA_OSS_TestCase_h_INCLUDED_
+#define CODA_OSS_TestCase_h_INCLUDED_
 
 #ifdef __cplusplus
 
@@ -74,6 +74,10 @@ template <typename TX>
 inline std::string toString(const TX& X)
 {
     return str::toString(X);
+}
+inline std::string toString(const coda_oss::u8string& X)
+{
+    return str::to_native(X);
 }
 
 template<typename TX>
@@ -276,4 +280,4 @@ inline int main(TFunc f)
 
 #endif
 
-#endif
+#endif  // CODA_OSS_TestCase_h_INCLUDED_

--- a/externals/coda-oss/modules/c++/include/UnitTest.h
+++ b/externals/coda-oss/modules/c++/include/UnitTest.h
@@ -132,7 +132,7 @@ inline void assert_almost_eq(const std::string& testName, long double X1, long d
 #define TEST_ASSERT_EQ_MSG(msg, X1, X2) testName, Microsoft::VisualStudio::CppUnitTestFramework::Logger::WriteMessage(msg.c_str()); TEST_ASSERT_EQ(X1, X2)
 
 #undef TEST_FAIL_MSG
-#define TEST_FAIL_MSG(msg) { (void)testName; Microsoft::VisualStudio::CppUnitTestFramework::Assert::Fail(str::toWString(msg).c_str()); }
+#define TEST_FAIL_MSG(msg) { (void)testName; Microsoft::VisualStudio::CppUnitTestFramework::Assert::Fail(str::details::to_wstring(msg).c_str()); }
 
 #undef TEST_EXCEPTION
 #undef TEST_THROWS

--- a/externals/coda-oss/modules/c++/str/include/str/Convert.h
+++ b/externals/coda-oss/modules/c++/str/include/str/Convert.h
@@ -85,27 +85,25 @@ inline std::string toString(const std::string& value)
 {
     return value;
 }
-// can't be a template; `bool` overload above is a better match
+// Prevent the template above from getting used; instead, use routines from **Encoding.h**.
+std::string toString(const std::wstring&) = delete;
+std::string toString(const std::u16string&) = delete;
+std::string toString(const std::u32string&) = delete;
+std::string toString(const coda_oss::u8string&) = delete;
+std::string toString(const str::W1252string&) = delete;
+
 inline std::string toString(std::string::const_pointer pStr)
 {
     return toString(std::string(pStr));
 }
-
-// The resultant `std::string`s have "native" encoding (which is lost) depending
-// on the platform: UTF-8 on Linux and Windows-1252 on Windows.
-CODA_OSS_API std::string toString(const coda_oss::u8string&);
-CODA_OSS_API std::string toString(const str::W1252string&);
-CODA_OSS_API std::string toString(const std::wstring&); // input is UTF-16 or UTF-32 depending on the platform
 // can't be a template; `bool` overload above is a better match
 std::string toString(std::wstring::const_pointer) = delete; // only used in unittests
 std::string toString(std::u16string::const_pointer) = delete; // only used in unittests
 std::string toString(std::u32string::const_pointer) = delete; // only used in unittests
 
-CODA_OSS_API coda_oss::u8string u8FromString(const std::string&); // platform determines Windows-1252 or UTF-8 input
-
 inline std::ostream& operator<<(std::ostream& os, const coda_oss::u8string& s)
 {
-    os << toString(s);
+    os << to_native(s);
     return os;
 }
 
@@ -126,13 +124,6 @@ inline std::string toString(const T& real, const T& imag)
 {
     return toString(std::complex<T>(real, imag));
 }
-
-CODA_OSS_API std::wstring toWString(const std::string&); // platform determines Windows-1252 or UTF-8 input and output encoding
-CODA_OSS_API std::wstring toWString(const coda_oss::u8string&); // platform determines UTF-16 or UTF-32 output encoding
-CODA_OSS_API std::wstring toWString(const str::W1252string&); // platform determines UTF-16 or UTF-32 output encoding
-
-CODA_OSS_API coda_oss::u8string u8FromWString(const std::wstring&); // platform determines UTF16 or UTF-32 input
-
 
 template <typename T>
 T toType(const std::string& s)

--- a/externals/coda-oss/modules/c++/str/include/str/Convert.h
+++ b/externals/coda-oss/modules/c++/str/include/str/Convert.h
@@ -89,7 +89,7 @@ inline std::string toString(const std::string& value)
 std::string toString(const std::wstring&) = delete;
 std::string toString(const std::u16string&) = delete;
 std::string toString(const std::u32string&) = delete;
-//std::string toString(const coda_oss::u8string&) = delete;
+std::string toString(const coda_oss::u8string&) = delete;
 std::string toString(const str::W1252string&) = delete;
 
 inline std::string toString(std::string::const_pointer pStr)

--- a/externals/coda-oss/modules/c++/str/include/str/Convert.h
+++ b/externals/coda-oss/modules/c++/str/include/str/Convert.h
@@ -89,7 +89,7 @@ inline std::string toString(const std::string& value)
 std::string toString(const std::wstring&) = delete;
 std::string toString(const std::u16string&) = delete;
 std::string toString(const std::u32string&) = delete;
-std::string toString(const coda_oss::u8string&) = delete;
+//std::string toString(const coda_oss::u8string&) = delete;
 std::string toString(const str::W1252string&) = delete;
 
 inline std::string toString(std::string::const_pointer pStr)

--- a/externals/coda-oss/modules/c++/str/include/str/Encoding.h
+++ b/externals/coda-oss/modules/c++/str/include/str/Encoding.h
@@ -40,6 +40,8 @@
 
 namespace str
 {
+namespace details
+{
 template <typename TReturn, typename TChar>
 inline auto cast(const TChar* s)
 {
@@ -52,24 +54,26 @@ inline auto cast(const TChar* s)
     static_assert(sizeof(*retval) == sizeof(*s), "sizeof(*TReturn) != sizeof(*TChar)"); 
     return retval;
 }
+}
 template <typename TBasicStringT, typename TChar>
 inline auto c_str(const std::basic_string<TChar>& s)
 {
     using return_t = typename TBasicStringT::const_pointer;
-    return cast<return_t>(s.c_str());
+    return details::cast<return_t>(s.c_str());
 }
 template <typename TBasicStringT, typename TChar>
-inline TBasicStringT str(const std::basic_string<TChar>& s)
+inline auto str(const std::basic_string<TChar>& s)
 {
     return TBasicStringT(c_str<TBasicStringT>(s), s.length()); // avoid extra strlen() call
 }
 template <typename TBasicStringT, typename TChar>
 inline TBasicStringT make_string(TChar* p)
 {
-    using return_t = typename TBasicStringT::const_pointer;
-    return cast<return_t>(p); // copy into RV
+    using const_pointer = typename TBasicStringT::const_pointer;
+    return details::cast<const_pointer>(p);  // copy into RV
 }
 
+/************************************************************************/
 // When the encoding is important, we want to "traffic" in coda_oss::u8string (UTF-8), not
 // str::W1252string (Windows-1252) or std::string (unknown).  Make it easy to get those from other encodings.
 CODA_OSS_API coda_oss::u8string to_u8string(str::W1252string::const_pointer, size_t);
@@ -79,16 +83,70 @@ inline coda_oss::u8string to_u8string(coda_oss::u8string::const_pointer p, size_
 {
     return coda_oss::u8string(p, sz);
 }
+// Explicit overloads so template can be used for a different purpose.
+inline auto to_u8string(const coda_oss::u8string& s)
+{
+    return to_u8string(s.c_str(), s.length());
+}
+inline auto to_u8string(const str::W1252string& s)
+{
+    return to_u8string(s.c_str(), s.length());
+}
+inline auto to_u8string(const std::u16string& s)
+{
+    return to_u8string(s.c_str(), s.length());
+}
+inline auto to_u8string(const std::u32string& s)
+{
+    return to_u8string(s.c_str(), s.length());
+}
+// These two routines are "dangerous" as they make it easy to convert
+// a `char*` **already** in UTF-8 encoding to UTF-8; the result is garbage.
+// Use u8FromNative() or u8FromNative() which is a bit more explicit.
+coda_oss::u8string to_u8string(std::string::const_pointer, size_t) = delete;
+coda_oss::u8string to_u8string(std::wstring::const_pointer, size_t) = delete;
 
+// Template parameter specifies how `std::string` is encoded.  As opposed
+// to figuring it out a run-time based on the platform.
+template <typename TBasicString>
+inline auto to_u8string(const std::string& s)  // UTF-8 or Windows-1252
+{
+    return to_u8string(str::c_str<TBasicString>(s), s.length());
+}
+template <typename TBasicString>
+inline auto to_u8string(const std::wstring& s)  // UTF-16 or UTF-32
+{
+    return to_u8string(str::c_str<TBasicString>(s), s.length());
+}
+
+/************************************************************************/
 // UTF-16 is the default on Windows.
 CODA_OSS_API std::u16string to_u16string(coda_oss::u8string::const_pointer, size_t);
 CODA_OSS_API std::u16string to_u16string(str::W1252string::const_pointer, size_t);
+inline auto to_u16string(const coda_oss::u8string& s)
+{
+    return to_u16string(s.c_str(), s.length());
+}
+inline auto to_u16string(const str::W1252string& s)
+{
+    return to_u16string(s.c_str(), s.length());
+}
 
+/************************************************************************/
 // UTF-32 is convenient because each code-point is a single 32-bit integer.
 // It's typically std::wstring::value_type on Linux, but NOT Windows.
 CODA_OSS_API std::u32string to_u32string(coda_oss::u8string::const_pointer, size_t);
 CODA_OSS_API std::u32string to_u32string(str::W1252string::const_pointer, size_t);
+inline auto to_u32string(const coda_oss::u8string& s)
+{
+    return to_u32string(s.c_str(), s.length());
+}
+inline auto to_u32string(const str::W1252string& s)
+{
+    return to_u32string(s.c_str(), s.length());
+}
 
+/************************************************************************/
 // Windows-1252 (almost the same as ISO8859-1) is the default single-byte encoding on Windows.
 CODA_OSS_API str::W1252string to_w1252string(coda_oss::u8string::const_pointer p, size_t sz);
 inline auto to_w1252string(const coda_oss::u8string& s)
@@ -96,26 +154,58 @@ inline auto to_w1252string(const coda_oss::u8string& s)
     return to_w1252string(s.c_str(), s.length());
 }
 
-// These two routines are "dangerous" as they make it easy to convert
-// a `char*` **already** in UTF-8 encoding to UTF-8; the result is garbage.
-// Use u8FromString() or u8FromWString() which is a bit more explicit.
-coda_oss::u8string to_u8string(std::string::const_pointer, size_t) = delete;
-coda_oss::u8string to_u8string(std::wstring::const_pointer, size_t) = delete;
+/************************************************************************/
 
-template<typename CharT>
-inline auto to_u8string(const std::basic_string<CharT>& s)
+inline auto u8FromNative(const std::string& s)  // platform determines Windows-1252 or UTF-8 input
 {
-    return to_u8string(s.c_str(), s.length());
+    #if _WIN32
+    const auto p = str::c_str<str::W1252string>(s); // std::string is Windows-1252 on Windows
+    #else
+    const auto p = str::c_str<coda_oss::u8string>(s); // assume std::string is UTF-8 on any non-Windows platform
+    #endif   
+    return str::to_u8string(p, s.length());
 }
-template <typename CharT>
-inline auto to_u16string(const std::basic_string<CharT>& s)
+
+namespace details
 {
-    return to_u16string(s.c_str(), s.length());
+inline auto c_str(const std::wstring& s)
+{
+    #if _WIN32
+    return str::c_str<std::u16string>(s); // std::wstring is UTF-16 on Windows
+    #else
+    return str::c_str<std::u32string>(s); // assume std::wstring is UTF-32 on any non-Windows platform
+    #endif   
 }
-template <typename CharT>
-inline auto to_u32string(const std::basic_string<CharT>& s)
+}
+inline auto u8FromNative(const std::wstring& s) // platform determines UTF16 or UTF-32 input
 {
-    return to_u32string(s.c_str(), s.length());
+    return str::to_u8string(details::c_str(s), s.length());
+}
+
+/************************************************************************/
+
+// The resultant `std::string`s have "native" encoding (which is lost) depending
+// on the platform: UTF-8 on Linux and Windows-1252 on Windows.
+namespace details
+{
+  inline std::string to_string(const std::string& s)
+  {
+    return s;
+  }
+CODA_OSS_API std::string to_string(const coda_oss::u8string&);
+CODA_OSS_API std::string to_string(const std::wstring&); // input is UTF-16 or UTF-32 depending on the platform
+CODA_OSS_API std::wstring to_wstring(const std::string&); // platform determines Windows-1252 or UTF-8 input and output encoding
+CODA_OSS_API std::wstring to_wstring(const coda_oss::u8string&); // platform determines UTF-16 or UTF-32 output encoding
+}
+namespace testing
+{
+CODA_OSS_API std::string to_string(const str::W1252string&);    
+CODA_OSS_API std::wstring to_wstring(const str::W1252string&); // platform determines UTF-16 or UTF-32 output encoding
+}
+
+inline std::string to_native(const coda_oss::u8string& s) // cf., std::filesystem::native(), https://en.cppreference.com/w/cpp/filesystem/path/native
+{
+    return details::to_string(s);
 }
 
 }

--- a/externals/coda-oss/modules/c++/str/include/str/Encoding.h
+++ b/externals/coda-oss/modules/c++/str/include/str/Encoding.h
@@ -165,6 +165,10 @@ inline auto u8FromNative(const std::string& s)  // platform determines Windows-1
     #endif   
     return str::to_u8string(p, s.length());
 }
+inline auto u8FromString(const std::string& s)  // existing code
+{
+  return u8FromNative(s);
+}
 
 namespace details
 {
@@ -207,6 +211,11 @@ inline std::string to_native(const coda_oss::u8string& s) // cf., std::filesyste
 {
     return details::to_string(s);
 }
+inline std::string toString(const coda_oss::u8string& s) // existing code
+{
+  return to_native(s);
+}
+
 
 }
 

--- a/externals/coda-oss/modules/c++/str/include/str/Encoding.h
+++ b/externals/coda-oss/modules/c++/str/include/str/Encoding.h
@@ -207,11 +207,6 @@ inline std::string to_native(const coda_oss::u8string& s) // cf., std::filesyste
 {
     return details::to_string(s);
 }
-inline std::string toString(const coda_oss::u8string& s) // existing code
-{
-  return to_native(s);
-}
-
 
 }
 

--- a/externals/coda-oss/modules/c++/str/include/str/Encoding.h
+++ b/externals/coda-oss/modules/c++/str/include/str/Encoding.h
@@ -165,10 +165,6 @@ inline auto u8FromNative(const std::string& s)  // platform determines Windows-1
     #endif   
     return str::to_u8string(p, s.length());
 }
-inline auto u8FromString(const std::string& s)  // existing code
-{
-  return u8FromNative(s);
-}
 
 namespace details
 {

--- a/externals/coda-oss/modules/c++/str/unittests/test_base_convert.cpp
+++ b/externals/coda-oss/modules/c++/str/unittests/test_base_convert.cpp
@@ -78,25 +78,16 @@ TEST_CASE(testCharToString)
 template<typename T>
 static constexpr std::u8string::value_type cast8(T ch)
 {
-    static_assert(sizeof(std::u8string::value_type) == sizeof(char), "sizeof(Char8_T) != sizeof(char)");
-    return static_cast<std::u8string::value_type>(ch);
-}
-template <typename TChar>
-static inline constexpr std::u32string::value_type U(TChar ch)
-{
-    return static_cast<std::u32string::value_type>(ch);
-}
-
-static auto from_windows1252(const std::string& w1252)
-{
-    return to_u8string(str::c_str<str::W1252string>(w1252), w1252.length());
+    using u8ch_t = std::u8string::value_type;
+    static_assert(sizeof(u8ch_t) == sizeof(char), "sizeof(Char8_T) != sizeof(char)");
+    return static_cast<u8ch_t>(ch);
 }
 
 TEST_CASE(test_string_to_u8string_ascii)
 {
     {
         const std::string input = "|\x00";  //  ASCII, "|<NULL>"
-        const auto actual = from_windows1252(input);
+        const auto actual = str::to_u8string<str::W1252string>(input);
         const std::u8string expected{cast8('|')}; // '\x00' is the end of the string in C/C++
         TEST_ASSERT_EQ(actual, expected);
     }
@@ -105,10 +96,10 @@ TEST_CASE(test_string_to_u8string_ascii)
     for (uint8_t ch = start_of_heading; ch <= delete_character; ch++)  // ASCII
     {
         const std::string input { '|', static_cast<std::string::value_type>(ch), '|'};
-        const auto actual = from_windows1252(input);
+        const auto actual = str::to_u8string<str::W1252string>(input);
         const std::u8string expected8{cast8('|'), cast8(ch), cast8('|')}; 
         TEST_ASSERT_EQ(actual, expected8);
-        const std::u32string expected{U'|', U(ch), U'|'};
+        const std::u32string expected{U'|', ch, U'|'};
         test_assert_eq(testName, actual, expected);
     }
 }
@@ -130,7 +121,7 @@ TEST_CASE(test_string_to_u8string_windows_1252)
     // Windows-1252 only characters must be mapped to UTF-8
     {
         const std::string input = "|\x80|";  // Windows-1252, "|€|"
-        const auto actual = from_windows1252(input);
+        const auto actual = str::to_u8string<str::W1252string>(input);
         const std::u8string expected8{cast8('|'), cast8('\xE2'), cast8('\x82'), cast8('\xAC'), cast8('|')};  // UTF-8,  "|€|"
         TEST_ASSERT_EQ(actual, expected8);
         const std::u32string expected{U"|\u20AC|"};  // UTF-32,  "|€|"
@@ -138,7 +129,7 @@ TEST_CASE(test_string_to_u8string_windows_1252)
     }
     {
         const std::string input = "|\x9F|";  // Windows-1252, "|Ÿ|"
-        const auto actual = from_windows1252(input);
+        const auto actual = str::to_u8string<str::W1252string>(input);
         const std::u8string expected8{cast8('|'), cast8('\xC5'), cast8('\xB8'), cast8('|')};  // UTF-8,  "|Ÿ|"
         TEST_ASSERT_EQ(actual, expected8);
         const std::u32string expected{U"|\u0178|"};  // UTF-32,  "|Ÿ|"
@@ -149,7 +140,7 @@ TEST_CASE(test_string_to_u8string_windows_1252)
         for (const auto& ch : undefined)
         {
             const std::string input{'|', ch, '|'};
-            const auto actual = from_windows1252(input);
+            const auto actual = str::to_u8string<str::W1252string>(input);
             TEST_ASSERT_TRUE(!actual.empty());
             //const std::u8string expected8{cast8('|'), cast8('\xEF'), cast8('\xBF'), cast8('\xBD'), cast8('|')};  // UTF-8,  "|<REPLACEMENT CHARACTER>|"
             const std::u8string expected8{cast8('|'), cast8(194), cast8(ch), cast8('|')};
@@ -217,7 +208,7 @@ TEST_CASE(test_string_to_u8string_iso8859_1)
         const std::string input_ { '|', static_cast<std::string::value_type>(ch), '|'};
         const auto input(str::str<str::W1252string>(input_));
         const auto actual = to_u8string(input);
-        const std::u32string expected{U'|', U(ch), U'|'};
+        const std::u32string expected{U'|', ch, U'|'};
         test_assert_eq(testName, actual, expected);
 
         TEST_ASSERT(str::to_u8string(input) == actual);
@@ -276,34 +267,39 @@ static const str::W1252string& classificationText_w1252()
     return retval;
  }
 
+ static auto toString(const coda_oss::u8string& s)
+ {
+     return str::to_native(s);
+ }
+
 // UTF-16 on Windows, UTF-32 on Linux
-static const wchar_t* classificationText_wide_() { return L"A\xc9IOU"; } // UTF-8 "AÉIOU"
-static std::u16string classificationText_u16() { return u"A\xc9IOU"; } // UTF-16 "AÉIOU"
-static std::u32string classificationText_u32() { return U"A\xc9IOU"; } // UTF-32 "AÉIOU"
+static const wchar_t* classificationText_wide_() { return L"A\x00c9IOU"; } // "wide characters" "AÉIOU"
+static std::u16string classificationText_u16() { return u"A\u00c9IOU"; } // UTF-16 "AÉIOU"
+static std::u32string classificationText_u32() { return U"A\u00c9IOU"; } // UTF-32 "AÉIOU"
 
 static std::string classificationText_platform() { return 
-    sys::Platform == sys::PlatformType::Linux ? str::toString(classificationText_u8()) : str::toString(classificationText_w1252()); }
+    sys::Platform == sys::PlatformType::Linux ? toString(classificationText_u8()) : str::testing::to_string(classificationText_w1252()); }
 
 TEST_CASE(test_u8string_to_string)
 {
-    auto actual = str::toString(classificationText_u8());
+    auto actual = toString(classificationText_u8());
     TEST_ASSERT_EQ(classificationText_platform(), actual);
 
-    actual = str::toString(classificationText_w1252()); 
+    actual = str::testing::to_string(classificationText_w1252()); 
     TEST_ASSERT_EQ(classificationText_platform(), actual);
 }
 
-static auto to_w1252string(const std::wstring& s)
+static auto w1252FromNative(const std::wstring& s)
 {
-    return str::to_w1252string(str::u8FromWString(s));
+    return str::to_w1252string(str::u8FromNative(s));
 }
-static auto to_u16string(const str::W1252string& s)
+static auto toWString(const str::W1252string& s)
 {
-    return str::to_u16string(s.c_str(), s.length());
+    return str::testing::to_wstring(s);
 }
-static auto to_u32string(const str::W1252string& s)
+static auto toWString(const coda_oss::u8string& s)
 {
-    return str::to_u32string(s.c_str(), s.length());
+    return str::details::to_wstring(s);
 }
 
 TEST_CASE(test_u8string_to_u16string)
@@ -316,12 +312,12 @@ TEST_CASE(test_u8string_to_u16string)
     #endif
 
     const auto u8 = classificationText_u8();
-    TEST_ASSERT(str::u8FromWString(wide) == u8);
-    TEST_ASSERT(wide == str::toWString(u8));
+    TEST_ASSERT(str::u8FromNative(wide) == u8);
+    TEST_ASSERT(wide == toWString(u8));
     
     const auto w1252 = str::c_str<str::W1252string>(classificationText_w1252());
-    TEST_ASSERT(to_w1252string(wide) == w1252);
-    TEST_ASSERT(wide == str::toWString(w1252));
+    TEST_ASSERT(w1252FromNative(wide) == w1252);
+    TEST_ASSERT(wide == toWString(w1252));
 
     TEST_ASSERT(classificationText_u16() == actual);  // _EQ wants to do toString()
     TEST_ASSERT(classificationText_u16() == to_u16string(w1252)); // _EQ wants to do toString()
@@ -337,37 +333,28 @@ TEST_CASE(test_u8string_to_u32string)
     
     const std::wstring wide(classificationText_wide_());
     const auto u8 = classificationText_u8();
-    TEST_ASSERT(str::u8FromWString(wide) == u8);
-    TEST_ASSERT(wide == str::toWString(u8));
+    TEST_ASSERT(str::u8FromNative(wide) == u8);
+    TEST_ASSERT(wide == toWString(u8));
 
     const auto w1252 = str::c_str<str::W1252string>(classificationText_w1252());
-    TEST_ASSERT(to_w1252string(wide) == w1252);
-    TEST_ASSERT(wide == str::toWString(w1252));
+    TEST_ASSERT(w1252FromNative(wide) == w1252);
+    TEST_ASSERT(wide == toWString(w1252));
 
     TEST_ASSERT(classificationText_u32() == actual);  // _EQ wants to do toString()
     TEST_ASSERT(classificationText_u32() == to_u32string(w1252)); // _EQ wants to do toString()
 }
 
-static auto as_windows1252(const coda_oss::u8string& s)
-{
-    const auto w1252 = str::to_w1252string(s.c_str(), s.length());
-    return str::toString(w1252);
-}
-static auto from_utf8(const std::string& utf8)
-{
-    return str::str<coda_oss::u8string>(utf8);
-}
-static auto as_utf8(const coda_oss::u8string& s)
-{
-    return str::str<std::string>(s);
-}
 static auto toWString(const std::u16string& s)
 {
-    return str::toWString(str::to_u8string(s));
+    return toWString(str::to_u8string(s));
+}
+static auto toWString(const std::string& s)
+{
+    return str::details::to_wstring(s);
 }
 static auto toString(const std::u16string& s)
 {
-    return str::toString(str::to_u8string(s));
+    return str::details::to_string(str::to_u8string(s));
 }
 
 static void test_wide_(const std::string& testName, const char* pStr, std::u16string::const_pointer pUtf16,
@@ -379,14 +366,14 @@ static void test_wide_(const std::string& testName, const char* pStr, std::u16st
 
     #if _WIN32
     // Since we're using UTF-16, on Windows that can be cast to wchar_t
-    auto pWide = str::cast<std::wstring::const_pointer>(pUtf16);
+    const auto wide = str::make_string<std::wstring>(pUtf16);
 
     const _bstr_t str(pStr);
     const std::wstring std_wstr(static_cast<const wchar_t*>(str)); // Windows-1252 -> UTF-16
     TEST_ASSERT(wstring == std_wstr);
-    TEST_ASSERT(std_wstr == pWide);
+    TEST_ASSERT(std_wstr == wide);
 
-    const _bstr_t wide_str(pWide);
+    const _bstr_t wide_str(wide.c_str());
     const std::string std_str(static_cast<const char*>(wide_str)); //  UTF-16 -> Windows-1252
     TEST_ASSERT_EQ(native, std_str);
     TEST_ASSERT_EQ(std_str, pStr);
@@ -399,18 +386,19 @@ static void test_wide_(const std::string& testName, const char* pStr, std::u16st
 static void test_Windows1252_ascii(const std::string& testName, const char* pStr, std::u16string::const_pointer pUtf16)
 {
     // For both UTF-8 and Windows-1252, ASCII is the same (they only differ for 0x80-0xff).
-    const auto u8 = as_utf8(from_utf8(pStr));
+    const auto u8 =  str::str<std::string>(str::to_u8string<coda_oss::u8string>(pStr));
     TEST_ASSERT_EQ(pStr, u8); // native() is the same on all platforms/encodings for ASCII
     {
-        const auto w1252 = as_windows1252(from_windows1252(pStr));
-        TEST_ASSERT_EQ(pStr, w1252);  // native() is the same on all platforms/encodings for ASCII
+        const auto w1252 = str::make_string<str::W1252string>(pStr);
+        const auto str1252 = str::testing::to_string(w1252);
+        TEST_ASSERT_EQ(pStr, str1252);  // native() is the same on all platforms/encodings for ASCII
     }
 
-    const auto u16 = str::to_u16string(str::u8FromString(pStr));
+    const auto u16 = str::to_u16string(str::u8FromNative(pStr));
     TEST_ASSERT(u16 == pUtf16);
-    auto wstring = str::toWString(pStr);
+    auto wstring = toWString(pStr);
     std::string native = pStr;
-    auto w1252 = str::cast<str::W1252string::const_pointer>(pStr);
+    auto w1252 = str::make_string<str::W1252string>(pStr);
     test_wide_(testName, pStr, pUtf16, wstring, native, w1252);
 
     native = toString(pUtf16);
@@ -442,13 +430,17 @@ static auto to_w1252string(const std::u16string& s)
 {
     return str::to_w1252string(str::to_u8string(s));
 }
+inline static auto toString(const std::wstring& s)
+{
+    return str::details::to_string(s);
+}
 
 static void test_Windows1252_(const std::string& testName, const char* pStr, std::u16string::const_pointer pUtf16)
 {
-    const auto u16 = str::to_u16string(from_windows1252(pStr));
+    const auto u16 = str::to_u16string(str::to_u8string<str::W1252string>(pStr));
     TEST_ASSERT(u16 == pUtf16);
-    auto wstring = str::toWString(from_windows1252(pStr));
-    auto s = str::toString(from_windows1252(pStr));
+    auto wstring = toWString(str::to_u8string<str::W1252string>(pStr));
+    auto s = toString(str::to_u8string<str::W1252string>(pStr));
     auto w1252 = str::make_string<str::W1252string>(pStr);
     test_wide_(testName, pStr, pUtf16, wstring, s, w1252);
 
@@ -550,7 +542,7 @@ TEST_CASE(test_Windows1252)
     {
         const std::string expected(1, ch.first);
         const std::wstring input(1, ch.second); // `std::wstring` is UTF-16 on Windows
-        const auto actual = str::toString(input);
+        const auto actual = toString(input);
         TEST_ASSERT_EQ(expected, actual);
     }
     #endif
@@ -572,14 +564,14 @@ static void test_Encodeding_(const std::string& testName, const coda_oss::u8stri
     TEST_ASSERT_EQ(utf_8_view, expected);
     TEST_ASSERT_EQ(iso8859_1_view, expected);
 }
-TEST_CASE(test_Encodeding)
+TEST_CASE(test_Encoding)
 {
-    const auto utf_8 = str::toString(classificationText_u8());
-    const auto iso8859_1 = str::toString(classificationText_w1252());
+    const auto utf_8 = toString(classificationText_u8());
+    const auto iso8859_1 = str::testing::to_string(classificationText_w1252());
     const auto utf_8_u8 = classificationText_u8();
     const auto iso8859_1_u8 = str::to_u8string(classificationText_w1252());
-    const auto utf_8_view = as_utf8(classificationText_u8());
-    const auto iso8859_1_view = as_utf8(from_windows1252(str::c_str<std::string>(classificationText_w1252())));
+    const auto utf_8_view = str::str<std::string>(classificationText_u8());
+    const auto iso8859_1_view =  str::str<std::string>(str::to_u8string(classificationText_w1252()));
 
     test_Encodeding_(testName, classificationText_u8(),
         utf_8, iso8859_1,
@@ -606,5 +598,5 @@ TEST_MAIN(
     TEST_CHECK(test_ASCII);
     TEST_CHECK(test_Windows1252_WIN32);
     TEST_CHECK(test_Windows1252);
-    TEST_CHECK(test_Encodeding);
+    TEST_CHECK(test_Encoding);
     )

--- a/externals/coda-oss/modules/c++/sys/include/sys/AbstractOS.h
+++ b/externals/coda-oss/modules/c++/sys/include/sys/AbstractOS.h
@@ -63,6 +63,20 @@ enum class SIMDInstructionSet
     AVX512F, // https://en.wikipedia.org/wiki/AVX-512
 };
 
+constexpr auto getSIMDInstructionSet() { return SIMDInstructionSet::
+    // https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170
+
+    #if __AVX512F__
+            AVX512F
+    #elif __AVX2__
+            AVX2
+    #elif _M_X64 /*MSVC*/ || __SSE2__ /*GCC*/
+            SSE2
+    #else
+        #error "Can't determine SIMDInstructionSet'"
+    #endif
+; }
+
 /*!
  *  \class AbstractOS
  *  \brief Interface for system independent function calls

--- a/externals/coda-oss/modules/c++/sys/source/CppUnitTestAssert_.cpp_
+++ b/externals/coda-oss/modules/c++/sys/source/CppUnitTestAssert_.cpp_
@@ -35,5 +35,5 @@ void test::Assert::FailOnCondition(bool condition, const unsigned short* message
 std::wstring GetAssertMessage(bool equality, const std::wstring& expected, const std::wstring& actual, const wchar_t *message); // declare caller
 std::wstring test::Assert::GetAssertMessage(bool equality, const std::string& expected, const std::string& actual, const wchar_t *message)
 {
-    return ::GetAssertMessage(equality, str::toWString(expected), str::toWString(actual), message); // and call!
+    return ::GetAssertMessage(equality, str::details::to_wstring(expected), str::details::to_wstring(actual), message); // and call!
 }

--- a/externals/coda-oss/modules/c++/sys/source/sys_filesystem.cpp
+++ b/externals/coda-oss/modules/c++/sys/source/sys_filesystem.cpp
@@ -48,7 +48,7 @@ fs::path::string_type fs::path::to_native(const std::string& s_)
 {
    
 #ifdef _WIN32
-    return str::toWString(s_);
+    return str::details::to_wstring(s_);
 #else
     return s_;
 #endif
@@ -103,7 +103,7 @@ fs::path::operator string_type() const
 
 std::string fs::path::string() const
 {
-    return str::toString(p_);
+    return str::details::to_string(p_);
 }
 
 fs::path fs::path::root_path() const

--- a/externals/coda-oss/modules/c++/xml.lite/include/xml/lite/Element.h
+++ b/externals/coda-oss/modules/c++/xml.lite/include/xml/lite/Element.h
@@ -319,7 +319,7 @@ struct CODA_OSS_API Element  // SOAPElement derives :-(
      *  \return the charater data
      */
     std::string getCharacterData() const;
-    coda_oss::u8string& getCharacterData(coda_oss::u8string& result) const;
+    const coda_oss::u8string& getCharacterData(coda_oss::u8string& result) const;
     //explicit operator coda_oss::u8string() const
     //{
     //    coda_oss::u8string result;

--- a/externals/coda-oss/modules/c++/xml.lite/source/Element.cpp
+++ b/externals/coda-oss/modules/c++/xml.lite/source/Element.cpp
@@ -259,9 +259,9 @@ void xml::lite::Element::prettyConsoleOutput_(io::OutputStream& stream,
 
 std::string xml::lite::Element::getCharacterData() const
 {
-    return str::toString(mCharacterData);
+    return str::to_native(mCharacterData);
 }
-coda_oss::u8string& xml::lite::Element::getCharacterData(coda_oss::u8string& result) const
+const coda_oss::u8string& xml::lite::Element::getCharacterData(coda_oss::u8string& result) const
 {
     result = mCharacterData;
     return result;
@@ -278,7 +278,7 @@ static void writeCharacterData_utf8(io::OutputStream& stream, const std::u8strin
 }
 static void writeCharacterData_native(io::OutputStream& stream, const std::u8string& characterData)
 {
-    stream.write(str::toString(characterData));
+    stream.write(str::to_native(characterData));
 }
 
 static void depthPrint_(const xml::lite::Element& element,
@@ -465,7 +465,7 @@ void xml::lite::Element::setNamespaceURI(
 
 void xml::lite::Element::setCharacterData(const std::string& characters)
 {
-    mCharacterData = str::u8FromString(characters);
+    mCharacterData = str::u8FromNative(characters);
 }
 xml::lite::Element& xml::lite::Element::operator=(const std::string& characterData)
 {
@@ -506,7 +506,7 @@ xml::lite::Element& xml::lite::addChild(Element& e, const QName& qname, const co
 }
 xml::lite::Element& xml::lite::addChild(Element& e, const QName& qname, const std::string& characterData)
 {
-    return addChild(e, qname, str::u8FromString(characterData));
+    return addChild(e, qname, str::u8FromNative(characterData));
 }
 xml::lite::Element& xml::lite::addChild(Element& e, const QName& qname)
 {

--- a/externals/coda-oss/modules/c++/xml.lite/source/MinidomHandler.cpp
+++ b/externals/coda-oss/modules/c++/xml.lite/source/MinidomHandler.cpp
@@ -73,7 +73,7 @@ void xml::lite::MinidomHandler::characters(const char *value, int length)
     // If we're still here despite use_char() being "false" then the
     // wide-character routine "failed."  On Windows, that means the char* value
     // is encoded as Windows-1252 (more-or-less ISO8859-1).
-    characters(str::u8FromString(std::string(value, length)));
+    characters(str::u8FromNative(std::string(value, length)));
 }
 
 bool xml::lite::MinidomHandler::vcharacters(const void /*XMLCh*/* chars_, size_t length)

--- a/externals/coda-oss/modules/c++/xml.lite/source/ValidatorXerces.cpp
+++ b/externals/coda-oss/modules/c++/xml.lite/source/ValidatorXerces.cpp
@@ -207,7 +207,7 @@ using XMLCh_t = wchar_t;
 static_assert(std::is_same<::XMLCh, XMLCh_t>::value, "XMLCh should be wchar_t");
 inline void reset(const std::u8string& xml, std::unique_ptr<std::wstring>& pWString)
 {
-    pWString = std::make_unique<std::wstring>(str::toWString(xml));
+    pWString = std::make_unique<std::wstring>(str::details::to_wstring(xml));
 }
 #else
 using XMLCh_t = char16_t;
@@ -283,8 +283,8 @@ static coda_oss::u8string encodeXml(const std::string& xml)
         return to_u8string(str::str<str::W1252string>(xml));
     }
 
-    // No "... encoding= ..."; let u8FromString() deal with it   
-    return str::u8FromString(xml);
+    // No "... encoding= ..."; let u8FromNative() deal with it   
+    return str::u8FromNative(xml);
 }
 
 bool ValidatorXerces::validate(const std::string& xml,

--- a/externals/coda-oss/modules/c++/xml.lite/unittests/test_xmlcreate.cpp
+++ b/externals/coda-oss/modules/c++/xml.lite/unittests/test_xmlcreate.cpp
@@ -115,11 +115,11 @@ TEST_CASE(testXmlCreateWhitespace)
     xml::lite::MinidomParser xmlParser;
     auto& document = getDocument(xmlParser);
 
-    const auto text = str::u8FromString("     ");
+    const auto text = str::u8FromNative("     ");
     auto documents_ = document.createElement(xml::lite::QName(""_u, "text"), text);
     auto& documents = *documents_;
-    auto strXml = str::u8FromString(print(documents));
-    const auto expected = str::u8FromString("<text>") + text + str::u8FromString("</text>");
+    auto strXml = str::u8FromNative(print(documents));
+    const auto expected = str::u8FromNative("<text>") + text + str::u8FromNative("</text>");
     TEST_ASSERT(strXml == expected);
 
     {

--- a/externals/coda-oss/modules/c++/xml.lite/unittests/test_xmlparser.cpp
+++ b/externals/coda-oss/modules/c++/xml.lite/unittests/test_xmlparser.cpp
@@ -59,7 +59,7 @@ static const std::u8string& text8()
 
 static const auto& iso88591Text1252()
 {
-    static const str::W1252string retval = str::cast<str::W1252string::const_pointer>("T\xc9XT");  // ISO8859-1, "TÉXT"
+    static const auto retval = str::make_string<str::W1252string>("T\xc9XT");  // ISO8859-1, "TÉXT"
     return retval;
 }
 static auto pIso88591Text_()
@@ -70,7 +70,7 @@ static auto pIso88591Text_()
 
 static const auto& utf8Text8()
 {
-    static const coda_oss::u8string retval = str::cast<coda_oss::u8string::const_pointer>("T\xc3\x89XT"); // UTF-8,  "TÉXT"
+    static const auto retval = str::make_string<coda_oss::u8string>("T\xc3\x89XT"); // UTF-8,  "TÉXT"
     return retval;
 } 
 static const auto pUtf8Text_()

--- a/six/modules/c++/cphd/source/CPHDXMLControl.cpp
+++ b/six/modules/c++/cphd/source/CPHDXMLControl.cpp
@@ -90,7 +90,7 @@ std::string CPHDXMLControl::toXMLString_(
     bool prettyPrint)
 {
     const auto result = toXMLString(metadata, schemaPaths, prettyPrint);
-    return str::toString(result);
+    return str::to_native(result);
 }
 
 std::unique_ptr<xml::lite::Document> CPHDXMLControl::toXML(

--- a/six/modules/c++/cphd/source/CPHDXMLControl.cpp
+++ b/six/modules/c++/cphd/source/CPHDXMLControl.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<Metadata> CPHDXMLControl::fromXML(const std::string& xmlString,
     std::transform(schemaPaths_.begin(), schemaPaths_.end(), std::back_inserter(schemaPaths),
         [](const std::string& s) { return s; });
 
-    return fromXML(str::u8FromString(xmlString), schemaPaths);
+    return fromXML(str::u8FromNative(xmlString), schemaPaths);
 }
 std::unique_ptr<Metadata> CPHDXMLControl::fromXML(const std::u8string& xmlString,
     const std::vector<std::filesystem::path>& schemaPaths)

--- a/six/modules/c++/cphd/unittests/test_cphd_xml_control.cpp
+++ b/six/modules/c++/cphd/unittests/test_cphd_xml_control.cpp
@@ -893,7 +893,7 @@ std::string testCPHDXML_(cphd::Version version)
 }
 std::u8string testCPHDXML(cphd::Version version)
 {
-    return str::u8FromString(testCPHDXML_(version));
+    return str::u8FromNative(testCPHDXML_(version));
 }
 
 void runTest(const std::string& testName, cphd::Version version)

--- a/six/modules/c++/cphd03/source/CPHDXMLControl.cpp
+++ b/six/modules/c++/cphd03/source/CPHDXMLControl.cpp
@@ -70,7 +70,7 @@ std::u8string CPHDXMLControl::toXMLString(const Metadata& metadata)
     io::U8StringStream ss;
     doc->getRootElement()->print(ss);
 
-    return str::u8FromString("<?xml version=\"1.0\"?>") + ss.stream().str();
+    return str::u8FromNative("<?xml version=\"1.0\"?>") + ss.stream().str();
 }
 std::string CPHDXMLControl::toXMLString_(const Metadata& metadata)
 {
@@ -493,7 +493,7 @@ XMLElem CPHDXMLControl::areaSampleDirectionParametersToXML(
 
 std::unique_ptr<Metadata> CPHDXMLControl::fromXML(const std::string& xmlString)
 {
-    auto result = fromXML(str::u8FromString(xmlString));
+    auto result = fromXML(str::u8FromNative(xmlString));
     return std::unique_ptr<Metadata>(result.release());
 }
 std::unique_ptr<Metadata> CPHDXMLControl::fromXML(const std::u8string& xmlString)

--- a/six/modules/c++/cphd03/source/CPHDXMLControl.cpp
+++ b/six/modules/c++/cphd03/source/CPHDXMLControl.cpp
@@ -74,7 +74,7 @@ std::u8string CPHDXMLControl::toXMLString(const Metadata& metadata)
 }
 std::string CPHDXMLControl::toXMLString_(const Metadata& metadata)
 {
-    return str::toString(toXMLString(metadata));
+    return str::to_native(toXMLString(metadata));
 }
 
 size_t CPHDXMLControl::getXMLsize(const Metadata& metadata)

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -1049,7 +1049,7 @@ std::string Utilities::toXMLString(const ComplexData& data,
         [](const std::string& s) { return s; });
 
     const auto result = toXMLString(data, &schemaPaths, logger);
-    return str::toString(result);
+    return str::to_native(result);
 }
 std::u8string Utilities::toXMLString(const ComplexData& data,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -1024,7 +1024,7 @@ std::unique_ptr<ComplexData> Utilities::parseDataFromString(
         const std::vector<std::string>& schemaPaths_,
         logging::Logger& log)
 {
-    const auto xmlStr = str::u8FromString(xmlStr_);
+    const auto xmlStr = str::u8FromNative(xmlStr_);
 
     std::vector<std::filesystem::path> schemaPaths;
     std::transform(schemaPaths_.begin(), schemaPaths_.end(), std::back_inserter(schemaPaths),

--- a/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_CollectionInfo.cpp
@@ -125,10 +125,10 @@ TEST_CASE(ClassificationCanada)
 {
 #ifdef _WIN32
     const std::string classificationText("NON CLASSIFI\xc9 / UNCLASSIFIED"); // ISO8859-1 "NON CLASSIFIÉ / UNCLASSIFIED"
-    const auto E_ = str::u8FromString("\xc9"); // ISO8859-1  "É"
+    const auto E_ = str::u8FromNative("\xc9"); // ISO8859-1  "É"
 #else
     const std::string classificationText("NON CLASSIFI\xc3\x89 / UNCLASSIFIED"); // UTF-8 "NON CLASSIFIÉ / UNCLASSIFIED"
-    const auto E_ = str::u8FromString("\xc3\x89"); // UTF-8  "É"
+    const auto E_ = str::u8FromNative("\xc3\x89"); // UTF-8  "É"
 #endif
 
     auto data = createData<six::zfloat>(types::RowCol<size_t>(10, 10));
@@ -137,9 +137,9 @@ TEST_CASE(ClassificationCanada)
 
     const auto strXml = six::sicd::Utilities::toXMLString(*data, nullptr /*pSchemaPaths*/);
 
-    const auto NON_CLASSIFI = strXml.find(str::u8FromString("NON CLASSIFI"));
+    const auto NON_CLASSIFI = strXml.find(str::u8FromNative("NON CLASSIFI"));
     TEST_ASSERT(NON_CLASSIFI != std::string::npos);
-    const auto UNCLASSIFIED = strXml.find(str::u8FromString(" / UNCLASSIFIED"));
+    const auto UNCLASSIFIED = strXml.find(str::u8FromNative(" / UNCLASSIFIED"));
     TEST_ASSERT(UNCLASSIFIED != std::string::npos);
     const auto utf8 = strXml.substr(NON_CLASSIFI, UNCLASSIFIED - NON_CLASSIFI);
     TEST_ASSERT_EQ(utf8.size(), std::string("NON CLASSIFI\xc3\x89").size()); // UTF-8, "NON CLASSIFIÉ"

--- a/six/modules/c++/six.sidd/source/GeoTIFFReadControl.cpp
+++ b/six/modules/c++/six.sidd/source/GeoTIFFReadControl.cpp
@@ -59,7 +59,7 @@ void parseXMLEntry(const tiff::IFDEntry *entry,
                     str::trim(curStr);
                     if (!curStr.empty())
                     {
-                        entries.emplace_back(str::u8FromString(curStr));
+                        entries.emplace_back(str::u8FromNative(curStr));
                         curStr.clear();
                     }
                 }
@@ -75,7 +75,7 @@ void parseXMLEntry(const tiff::IFDEntry *entry,
         str::trim(curStr);
         if (!curStr.empty())
         {
-           entries.emplace_back(str::u8FromString(curStr));
+           entries.emplace_back(str::u8FromNative(curStr));
         }
     }
 }

--- a/six/modules/c++/six.sidd/source/GeoTIFFWriteControl.cpp
+++ b/six/modules/c++/six.sidd/source/GeoTIFFWriteControl.cpp
@@ -234,12 +234,12 @@ void GeoTIFFWriteControl::setupIFD(const DerivedData* data,
     tiff::IFDEntry* const xmlEntry = (*ifd)[Constants::GT_XML_TAG];
 
     auto xml = six::toValidXMLString(data, schemaPaths, mLog);
-    xmlEntry->addValues(str::toString(xml));
+    xmlEntry->addValues(str::to_native(xml));
 
     for (size_t jj = 0; jj < mComplexData.size(); ++jj)
     {
         xml = six::toValidXMLString(mComplexData[jj], schemaPaths, mLog);
-        xmlEntry->addValues(str::toString(xml));
+        xmlEntry->addValues(str::to_native(xml));
     }
 }
 

--- a/six/modules/c++/six.sidd/source/Utilities.cpp
+++ b/six/modules/c++/six.sidd/source/Utilities.cpp
@@ -563,7 +563,7 @@ std::unique_ptr<DerivedData> Utilities::parseDataFromFile(const std::filesystem:
 std::unique_ptr<DerivedData> Utilities::parseDataFromString(const std::string& xmlStr_,
         const std::vector<std::string>& schemaPaths_, logging::Logger& log)
 {
-    const auto xmlStr = str::u8FromString(xmlStr_);
+    const auto xmlStr = str::u8FromNative(xmlStr_);
 
     std::vector<std::filesystem::path> schemaPaths;
     std::transform(schemaPaths_.begin(), schemaPaths_.end(), std::back_inserter(schemaPaths),

--- a/six/modules/c++/six.sidd/source/Utilities.cpp
+++ b/six/modules/c++/six.sidd/source/Utilities.cpp
@@ -588,7 +588,7 @@ std::string Utilities::toXMLString(const DerivedData& data,
         [](const std::string& s) { return s; });
 
     const auto result = toXMLString(data, &schemaPaths, logger);
-    return str::toString(result);
+    return str::to_native(result);
 }
 std::u8string Utilities::toXMLString(const DerivedData& data,
     const std::vector<std::filesystem::path>* pSchemaPaths, logging::Logger* pLogger)

--- a/six/modules/c++/six.sidd/unittests/test_valid_sixsidd.cpp
+++ b/six/modules/c++/six.sidd/unittests/test_valid_sixsidd.cpp
@@ -74,7 +74,7 @@ static std::unique_ptr<six::sidd::DerivedData> test_assert_round_trip(const std:
     const auto strXML = six::sidd::Utilities::toXMLString(derivedData, pSchemaPaths);
     TEST_ASSERT_FALSE(strXML.empty());
 
-    const auto xml_ = str::toString(strXML); // for debugging
+    const auto xml_ = str::to_native(strXML); // for debugging
     TEST_ASSERT_FALSE(xml_.empty());
 
     return six::sidd::Utilities::parseDataFromString(strXML, pSchemaPaths);

--- a/six/modules/c++/six/include/six/CollectionInformation.h
+++ b/six/modules/c++/six/include/six/CollectionInformation.h
@@ -118,7 +118,7 @@ struct CollectionInformation
     virtual std::string getClassificationLevel() const;
     inline virtual void setClassificationLevel(const std::string& classification)
     {
-        mClassification = str::u8FromString(classification);
+        mClassification = str::u8FromNative(classification);
     }
 
     virtual void getClassificationLevel(std::u8string&) const;

--- a/six/modules/c++/six/include/six/XsElement.h
+++ b/six/modules/c++/six/include/six/XsElement.h
@@ -149,7 +149,7 @@ inline std::ostream& operator<<(std::ostream& os, const XsElement<T>& v)
 template <>
 inline std::ostream& operator<<(std::ostream& os, const XsElement<std::u8string>& v)
 {
-    os << "\t" << v.tag() << "\t: " << str::toString(value(v));
+    os << "\t" << v.tag() << "\t: " << str::to_native(value(v));
     return os;
 }
 

--- a/six/modules/c++/six/source/CollectionInformation.cpp
+++ b/six/modules/c++/six/source/CollectionInformation.cpp
@@ -48,7 +48,7 @@ CollectionInformation* CollectionInformation::clone() const
 
 std::string CollectionInformation::getClassificationLevel() const
 {
-    return str::toString(mClassification);
+    return str::to_native(mClassification);
 }
 void CollectionInformation::getClassificationLevel(std::u8string& result) const
 {

--- a/six/modules/c++/six/source/NITFWriteControl.cpp
+++ b/six/modules/c++/six/source/NITFWriteControl.cpp
@@ -568,7 +568,7 @@ void NITFWriteControl::addDataAndWrite(const std::vector<std::string>& schemaPat
         const Data* data = getContainer()->getData(ii);
 
         const auto xml = six::toValidXMLString(data, schemaPaths, mLog, mXMLRegistry);
-        desStrs[ii] = str::toString(xml);
+        desStrs[ii] = str::to_native(xml);
         nitf::SegmentWriter deWriter = mWriter.newDEWriter(gsl::narrow<int>(ii));
         nitf::SegmentMemorySource segSource(desStrs[ii], 0, 0, false);
         deWriter.attachSource(segSource);

--- a/six/modules/c++/six/source/Utilities.cpp
+++ b/six/modules/c++/six/source/Utilities.cpp
@@ -716,7 +716,7 @@ std::unique_ptr<Data> six::parseDataFromString(const XMLControlRegistry& xmlReg,
     std::transform(schemaPaths_.begin(), schemaPaths_.end(), std::back_inserter(schemaPaths),
         [](const std::string& s) { return s; });
 
-    auto result = parseDataFromString(xmlReg, str::u8FromString(xmlStr), dataType, &schemaPaths, &log);
+    auto result = parseDataFromString(xmlReg, str::u8FromNative(xmlStr), dataType, &schemaPaths, &log);
     return std::unique_ptr<Data>(result.release());
 }
 

--- a/six/modules/c++/six/source/XMLControlFactory.cpp
+++ b/six/modules/c++/six/source/XMLControlFactory.cpp
@@ -82,7 +82,7 @@ std::string six::toXMLString_(const Data* data,
     const six::XMLControlRegistry* xmlRegistry)
 {
     const auto result = toXMLString(data, xmlRegistry);
-    return str::toString(result);
+    return str::to_native(result);
 }
 
 template<typename TSchemaPaths>

--- a/six/modules/c++/six/source/XmlLite.cpp
+++ b/six/modules/c++/six/source/XmlLite.cpp
@@ -195,6 +195,11 @@ inline std::string toString_(const xml::lite::QName& name, const T& v, const xml
 {
     return toString(name, v, parent);
 }
+template<>
+inline std::string toString_(const xml::lite::QName& name, const std::u8string& v, const xml::lite::Element& parent)
+{
+    return toString(name, str::to_native(v), parent);
+}
 
 template<typename T, typename ToString>
 static xml::lite::Element& createValue(const xml::lite::QName& name,

--- a/six/projects/csm/tests/utilities.h
+++ b/six/projects/csm/tests/utilities.h
@@ -137,7 +137,7 @@ inline std::unique_ptr<csm::Nitf21Isd> constructIsd(const std::string& pathname,
 
     // The DES's data is just the XML string
     const auto xml = six::toXMLString(data, &registry);
-    des.setData(str::toString(xml));
+    des.setData(str::to_native(xml));
     nitfIsd->addFileDes(des);
 
     return nitfIsd;


### PR DESCRIPTION
**coda-oss** makes it harder to inadvertently lose a string's encoding my using the word "native" to signal what's going on.