### PR TITLE
build components as DLLs in Visual Studio

### DIFF
--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -59,7 +59,6 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)six\modules\c++\scene\include;$(SolutionDir)six\modules\c++\six\include;$(SolutionDir)six\modules\c++\six.sidd\include;$(SolutionDir)six\modules\c++\six.sicd\include;$(SolutionDir)six\modules\c++\cphd\include;$(SolutionDir)six\modules\c++\cphd03\include;$(SolutionDir)externals\nitro\modules\c\nrt\include;$(SolutionDir)externals\nitro\modules\c\nitf\include;$(SolutionDir)externals\nitro\modules\c++\nitf\include;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration);$(SolutionDir)out\install\$(Platform)-$(Configuration)\include;$(SolutionDir)out\install\$(Platform)-$(Configuration);$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
-      <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
@@ -85,7 +84,6 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)six\modules\c++\scene\include;$(SolutionDir)six\modules\c++\six\include;$(SolutionDir)six\modules\c++\six.sidd\include;$(SolutionDir)six\modules\c++\six.sicd\include;$(SolutionDir)six\modules\c++\cphd\include;$(SolutionDir)six\modules\c++\cphd03\include;$(SolutionDir)externals\nitro\modules\c\nrt\include;$(SolutionDir)externals\nitro\modules\c\nitf\include;$(SolutionDir)externals\nitro\modules\c++\nitf\include;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration)\include;$(SolutionDir)externals\coda-oss\out\install\$(Platform)-$(Configuration);$(SolutionDir)out\install\$(Platform)-$(Configuration)\include;$(SolutionDir)out\install\$(Platform)-$(Configuration);$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
-      <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
@@ -93,6 +91,7 @@
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <ConformanceMode>true</ConformanceMode>
       <ControlFlowGuard>Guard</ControlFlowGuard>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/externals/coda-oss/modules/c++/coda-oss.vcxproj
+++ b/externals/coda-oss/modules/c++/coda-oss.vcxproj
@@ -609,6 +609,7 @@
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
       <WarningLevel>Level3</WarningLevel>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/externals/coda-oss/modules/c++/io/include/io/Serializable.h
+++ b/externals/coda-oss/modules/c++/io/include/io/Serializable.h
@@ -19,9 +19,11 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __IO_SERIALIZABLE_H__
 #define __IO_SERIALIZABLE_H__
+
+#include "config/Exports.h"
 
 #include "io/InputStream.h"
 #include "io/OutputStream.h"
@@ -46,7 +48,7 @@ namespace io
  *  This object has a known derived type SOAPMessage, which is concretely
  *  defined to handle SOAP objects
  */
-struct Serializable
+struct CODA_OSS_API Serializable
 {
     Serializable() = default;
     virtual ~Serializable() noexcept(false) {}

--- a/externals/coda-oss/modules/c++/plugin/include/plugin/ErrorHandler.h
+++ b/externals/coda-oss/modules/c++/plugin/include/plugin/ErrorHandler.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __PLUGIN_ERROR_HANDLER_H__
 #define __PLUGIN_ERROR_HANDLER_H__
 
@@ -27,9 +27,11 @@
 #include <import/sys.h>
 #include <import/logging.h>
 
+#include "config/Exports.h"
+
 namespace plugin
 {
-class ErrorHandler
+class CODA_OSS_API ErrorHandler
 {
 public:
     ErrorHandler() {}
@@ -47,7 +49,7 @@ public:
     virtual void onPluginError(except::Context& c) = 0;
 };
 
-class DefaultErrorHandler : public ErrorHandler
+class CODA_OSS_API DefaultErrorHandler final : public ErrorHandler
 {
 public:
     DefaultErrorHandler(logging::LoggerPtr logger = logging::LoggerPtr());

--- a/externals/coda-oss/modules/c++/sys/include/sys/DLL.h
+++ b/externals/coda-oss/modules/c++/sys/include/sys/DLL.h
@@ -20,7 +20,7 @@
  *
  */
 
-
+#pragma once
 #ifndef __SYS_DLL_H__
 #define __SYS_DLL_H__
 
@@ -52,6 +52,7 @@ typedef void* DLL_FUNCTION_PTR;
 
 #include "except/Exception.h"
 #include "sys/Err.h"
+#include "config/Exports.h"
 
 
 namespace sys
@@ -124,7 +125,7 @@ struct DLLException : public except::Exception
  */
 
 
-struct DLL
+struct CODA_OSS_API DLL
 {
     /*!
      *  Construct a library object, but dont populate or load it

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/FileReader.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/FileReader.h
@@ -20,9 +20,9 @@
  *
  */
 
+#pragma once 
 #ifndef CODA_OSS_tiff_FileReader_h_INCLUDED_
 #define CODA_OSS_tiff_FileReader_h_INCLUDED_
-#pragma once
 
 #include "tiff/TiffFileReader.h"
 

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/FileWriter.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/FileWriter.h
@@ -20,9 +20,9 @@
  *
  */
 
+#pragma once 
 #ifndef CODA_OSS_tiff_FileWriter_h_INCLUDED_
 #define CODA_OSS_tiff_FileWriter_h_INCLUDED_
-#pragma once
 
 #include "tiff/TiffFileWriter.h"
 

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/Header.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/Header.h
@@ -19,11 +19,13 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __TIFF_HEADER_H__
 #define __TIFF_HEADER_H__
 
 #include <import/io.h>
+#include <config/Exports.h>
+
 #include "tiff/Common.h"
 
 namespace tiff
@@ -34,7 +36,7 @@ namespace tiff
  * @class Header
  * @brief Contains TIFF header information
  *********************************************************************/
-class Header : public io::Serializable
+class CODA_OSS_API Header : public io::Serializable
 {
 public:
     enum ByteOrder { MM, II };

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/IFD.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/IFD.h
@@ -19,14 +19,16 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __TIFF_IFD_H__
 #define __TIFF_IFD_H__
 
 #include <map>
 #include <string>
+
 #include <import/io.h>
 #include <import/except.h>
+#include <config/Exports.h>
 
 #include "tiff/IFDEntry.h"
 #include "tiff/KnownTags.h"
@@ -45,7 +47,7 @@ namespace tiff
  * Contains functions for adding new entries to the IFD or adding
  * values to a specific IFD entry.
  *********************************************************************/
-class IFD : public io::Serializable
+class CODA_OSS_API IFD : public io::Serializable
 {
 public:
     //! The IFDType

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/IFDEntry.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/IFDEntry.h
@@ -20,17 +20,19 @@
  *
  */
 
-
+#pragma once
 #ifndef __TIFF_IFD_ENTRY_H__
 #define __TIFF_IFD_ENTRY_H__
-#pragma once
 
 #include <memory>
 #include <string>
 #include <vector>
+
 #include <import/io.h>
-#include "tiff/GenericType.h"
 #include "sys/Conf.h"
+#include "config/Exports.h"
+
+#include "tiff/GenericType.h"
 
 namespace tiff
 {
@@ -47,7 +49,7 @@ namespace tiff
  * functions for printing out the entry, reading and writing it to a
  * file, and accessing the data.
  *********************************************************************/
-class IFDEntry : public io::Serializable
+class CODA_OSS_API IFDEntry : public io::Serializable
 {
 public:
     //! Constructor

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/ImageReader.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/ImageReader.h
@@ -19,11 +19,12 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __TIFF_IMAGE_READER_H__
 #define __TIFF_IMAGE_READER_H__
 
 #include <import/io.h>
+#include <config/Exports.h>
 
 #include "tiff/IFDEntry.h"
 #include "tiff/IFD.h"
@@ -39,7 +40,7 @@ namespace tiff
  * Reads a TIFF image and parses out the IFD.  Contains functions for
  * getting data from the image and retrieving the TIFF IFD.
  *********************************************************************/
-class ImageReader
+class CODA_OSS_API ImageReader
 {
 public:
     /**

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/ImageWriter.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/ImageWriter.h
@@ -19,11 +19,12 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __TIFF_IMAGE_WRITER_H__
 #define __TIFF_IMAGE_WRITER_H__
 
 #include <import/io.h>
+#include <config/Exports.h>
 
 #include "tiff/Common.h"
 #include "tiff/IFDEntry.h"
@@ -40,7 +41,7 @@ namespace tiff
  * Writes a TIFF image to a stream.  Contains functions for writing
  * the image's IFD, and for putting data to a stream.
  *********************************************************************/
-class ImageWriter
+class CODA_OSS_API ImageWriter
 {
 public:
     //! The ideal tile size if a tiled file.

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/KnownTags.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/KnownTags.h
@@ -19,13 +19,14 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __TIFF_KNOWN_TAGS_H__
 #define __TIFF_KNOWN_TAGS_H__
 
 #include <map>
 #include <string>
 #include <import/mt.h>
+#include <config/Exports.h>
 
 #include "tiff/IFDEntry.h"
 
@@ -35,10 +36,8 @@ namespace tiff
 /**
  * This class is a container for known TIFF tags.
  */
-class KnownTags
+struct CODA_OSS_API KnownTags final
 {
-public:
-
     KnownTags();
 
     //! Destructor
@@ -71,14 +70,13 @@ public:
     tiff::IFDEntry *operator[](const unsigned short tagKey);
 
     //! Some common tags
-    static const char IMAGE_WIDTH[];
-    static const char IMAGE_LENGTH[];
-    static const char BITS_PER_SAMPLE[];
-    static const char COMPRESSION[];
-    static const char SAMPLES_PER_PIXEL[];
-    static const char PHOTOMETRIC_INTERPRETATION[];
-    static const char SAMPLE_FORMAT[];
-
+    static constexpr auto IMAGE_WIDTH = "ImageWidth";
+    static constexpr auto IMAGE_LENGTH = "ImageLength";
+    static constexpr auto BITS_PER_SAMPLE = "BitsPerSample";
+    static constexpr auto COMPRESSION = "Compression";
+    static constexpr auto SAMPLES_PER_PIXEL = "SamplesPerPixel";
+    static constexpr auto PHOTOMETRIC_INTERPRETATION = "PhotometricInterpretation";
+    static constexpr auto SAMPLE_FORMAT = "SampleFormat";
 
     /**
      *****************************************************************

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/TiffFileReader.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/TiffFileReader.h
@@ -19,13 +19,15 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __TIFF_FILE_READER_H__
 #define __TIFF_FILE_READER_H__
 
 #include <string>
 #include <vector>
+
 #include <import/io.h>
+#include <config/Exports.h>
 
 #include "tiff/Header.h"
 #include "tiff/ImageReader.h"
@@ -42,7 +44,7 @@ namespace tiff
  * to access a specific image within the file, and to read data from
  * a specific image in the file.
  *********************************************************************/
-struct FileReader
+struct CODA_OSS_API FileReader
 {
     FileReader() = default;
 

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/TiffFileWriter.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/TiffFileWriter.h
@@ -19,13 +19,16 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __TIFF_FILE_WRITER_H__
 #define __TIFF_FILE_WRITER_H__
 
 #include <string>
 #include <vector>
+
 #include <import/io.h>
+#include <config/Exports.h>
+
 #include "tiff/Header.h"
 #include "tiff/ImageWriter.h"
 
@@ -41,7 +44,7 @@ namespace tiff
  * to the same file.  Contains function for manipulating each 
  * sub-image and for writing data.
  *********************************************************************/
-struct FileWriter
+struct CODA_OSS_API FileWriter
 {
     //! Constructor
     FileWriter() :

--- a/externals/coda-oss/modules/c++/tiff/include/tiff/TypeFactory.h
+++ b/externals/coda-oss/modules/c++/tiff/include/tiff/TypeFactory.h
@@ -19,9 +19,11 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __TIFF_TYPE_FACTORY_H__
 #define __TIFF_TYPE_FACTORY_H__
+
+#include "config/Exports.h"
 
 #include "tiff/GenericType.h"
 
@@ -38,7 +40,7 @@ namespace tiff
  * assume a specific size for the data, see tiff::Const for the size
  * of each TIFF type.
  *********************************************************************/
-class TypeFactory
+class CODA_OSS_API TypeFactory final
 {
 public:
     //! Default constructor

--- a/externals/coda-oss/modules/c++/tiff/source/KnownTags.cpp
+++ b/externals/coda-oss/modules/c++/tiff/source/KnownTags.cpp
@@ -28,14 +28,6 @@
 #include "tiff/IFDEntry.h"
 #include <import/mt.h>
 
-const char tiff::KnownTags::IMAGE_WIDTH[]                   = "ImageWidth";
-const char tiff::KnownTags::IMAGE_LENGTH[]                  = "ImageLength";
-const char tiff::KnownTags::BITS_PER_SAMPLE[]               = "BitsPerSample";
-const char tiff::KnownTags::COMPRESSION[]                   = "Compression";
-const char tiff::KnownTags::SAMPLES_PER_PIXEL[]             = "SamplesPerPixel";
-const char tiff::KnownTags::PHOTOMETRIC_INTERPRETATION[]    = "PhotometricInterpretation";
-const char tiff::KnownTags::SAMPLE_FORMAT[]                 = "SampleFormat";
-
 tiff::KnownTags::KnownTags()
 {
     addEntry(254, tiff::Const::Type::LONG, "NewSubfileType");

--- a/externals/nitro/modules/c/nitf/XML_DATA_CONTENT.vcxproj
+++ b/externals/nitro/modules/c/nitf/XML_DATA_CONTENT.vcxproj
@@ -100,6 +100,7 @@
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
       <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/six/modules/c++/cphd/cphd.vcxproj
+++ b/six/modules/c++/cphd/cphd.vcxproj
@@ -19,12 +19,12 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -50,7 +50,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_CPHD_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -79,7 +79,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_CPHD_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -108,6 +108,9 @@
     <ProjectReference Include="..\..\..\..\externals\nitro\modules\c++\nitf-c++.vcxproj">
       <Project>{8f357a19-799e-4971-850e-3f28485c130b}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\scene\scene.vcxproj">
+      <Project>{1cfcde59-6410-4037-95eb-b37d31e10820}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\six.sicd\six.sicd.vcxproj">
       <Project>{34ac2314-fbd1-42ad-aaf4-0cebc6bf737e}</Project>
     </ProjectReference>
@@ -130,6 +133,7 @@
     <ClInclude Include="include\cphd\Dwell.h" />
     <ClInclude Include="include\cphd\Enums.h" />
     <ClInclude Include="include\cphd\ErrorParameters.h" />
+    <ClInclude Include="include\cphd\Exports.h" />
     <ClInclude Include="include\cphd\FileHeader.h" />
     <ClInclude Include="include\cphd\Global.h" />
     <ClInclude Include="include\cphd\Metadata.h" />

--- a/six/modules/c++/cphd/cphd.vcxproj.filters
+++ b/six/modules/c++/cphd/cphd.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClInclude Include="include\cphd\DataWriter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\cphd\Exports.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/six/modules/c++/cphd/include/cphd/BaseFileHeader.h
+++ b/six/modules/c++/cphd/include/cphd/BaseFileHeader.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD_BASE_FILE_HEADER_H__
 #define __CPHD_BASE_FILE_HEADER_H__
 
@@ -31,6 +31,7 @@
 #include <io/SeekableStreams.h>
 
 #include "cphd/Types.h"
+#include "cphd/Exports.h"
 
 namespace cphd
 {
@@ -42,7 +43,7 @@ namespace cphd
  *
  *  Stores file header parsing information
  */
-class BaseFileHeader
+class SIX_CPHD_API BaseFileHeader
 {
 public:
     //! Type of file is CPHD

--- a/six/modules/c++/cphd/include/cphd/ByteSwap.h
+++ b/six/modules/c++/cphd/include/cphd/ByteSwap.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD_BYTE_SWAP_H__
 #define __CPHD_BYTE_SWAP_H__
 
@@ -30,6 +30,7 @@
 #include <scene/sys_Conf.h>
 
 #include "cphd/Types.h"
+#include "cphd/Exports.h"
 
 namespace cphd
 {
@@ -42,7 +43,7 @@ namespace cphd
  *  \param numElements Number of elements in 'buffer'
  *  \param numThreads Number of threads to use for byte-swapping
  */
-void byteSwap(void* buffer,
+SIX_CPHD_API void byteSwap(void* buffer,
               size_t elemSize,
               size_t numElements,
               size_t numThreads);

--- a/six/modules/c++/cphd/include/cphd/CPHDReader.h
+++ b/six/modules/c++/cphd/include/cphd/CPHDReader.h
@@ -32,6 +32,7 @@
 #include <cphd/PVPBlock.h>
 #include <cphd/Wideband.h>
 #include <cphd/SupportBlock.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -42,7 +43,7 @@ namespace cphd
  *  Requires a valid CPHD file,and optional schemas
  *  for XML format verification
  */
-struct CPHDReader final
+struct SIX_CPHD_API CPHDReader final
 {
     /*
      *  \func CPHDReader constructor

--- a/six/modules/c++/cphd/include/cphd/CPHDWriter.h
+++ b/six/modules/c++/cphd/include/cphd/CPHDWriter.h
@@ -45,6 +45,7 @@
 #include <cphd/PVP.h>
 #include <cphd/PVPBlock.h>
 #include <cphd/DataWriter.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -56,7 +57,7 @@ namespace cphd
  *  Used to write a CPHD file. You must be able to provide the
  *  appropriate metadata and vector based metadata.
  */
-struct CPHDWriter final
+struct SIX_CPHD_API CPHDWriter final
 {
     /*
      *  \func Constructor
@@ -280,7 +281,7 @@ struct CPHDWriter final
      *  \param channel For selecting channel of compressed signal block
      */
     template <typename T>
-    void writeCPHDData(DataWriter&,
+    SIX_CPHD_API void writeCPHDData(DataWriter&,
         const T* data,
         size_t numElements,
         size_t channel = 1);

--- a/six/modules/c++/cphd/include/cphd/CPHDXMLControl.h
+++ b/six/modules/c++/cphd/include/cphd/CPHDXMLControl.h
@@ -19,10 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD_CPHD_XML_CONTROL_H__
 #define __CPHD_CPHD_XML_CONTROL_H__
-#pragma once
 
 #include <memory>
 #include <unordered_map>
@@ -36,6 +35,7 @@
 #include <xml/lite/Document.h>
 #include <cphd/CPHDXMLParser.h>
 #include <cphd/Types.h>
+#include <cphd/Exports.h>
 #include <six/Logger.h>
 
 namespace cphd
@@ -46,7 +46,7 @@ namespace cphd
  *  \brief This class converts a Metadata object into a CPHD XML
  *  Document Object Model (DOM) and vice-versa.
  */
-class CPHDXMLControl
+class SIX_CPHD_API CPHDXMLControl
 {
 public:
     /*!

--- a/six/modules/c++/cphd/include/cphd/Channel.h
+++ b/six/modules/c++/cphd/include/cphd/Channel.h
@@ -33,6 +33,7 @@
 #include <cphd/Types.h>
 #include <cphd/Enums.h>
 #include <cphd/SceneCoordinates.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -42,7 +43,7 @@ namespace cphd
 *  \brief Polarization parameters for the pulse for the reference signal vector.
 * (New in CPHD 1.1.0)
 */
-struct PolRef final
+struct SIX_CPHD_API PolRef final
 {
     bool operator==(const PolRef& other) const
     {
@@ -70,7 +71,7 @@ struct PolRef final
  *
  *  \brief Polarization of the signals that formed the signal array.
  */
-struct Polarization final
+struct SIX_CPHD_API Polarization final
 {
     //! Equality operator
     bool operator==(const Polarization& other) const
@@ -103,7 +104,7 @@ struct Polarization final
  *
  *  \brief (Optional) TOA extended swath information
  */
-struct TOAExtended
+struct SIX_CPHD_API TOAExtended
 {
     /*
      *  \struct LFMEclipse
@@ -180,7 +181,7 @@ struct TOAExtended
  *
  *  See section 6.3 and section 7.2.6
  */
-struct DwellTimes
+struct SIX_CPHD_API DwellTimes
 {
     //! COD Time & Dwell Time polynomials over the
     //! image area
@@ -223,7 +224,7 @@ struct DwellTimes
  *  located at the SRP for reference signal vector (v_CH_REF)
  *  See section 4.6 and section 7.2.9
  */
-struct TgtRefLevel
+struct SIX_CPHD_API TgtRefLevel
 {
     // Constructor
     TgtRefLevel();
@@ -248,7 +249,7 @@ struct TgtRefLevel
  *
  *  \brief Points that describe the noise profile
  */
-struct Point
+struct SIX_CPHD_API Point
 {
     //! Constructor
     Point();
@@ -276,7 +277,7 @@ struct Point
  *
  *  \brief (Optional) Power level for thermal noise (PN) vs FX freq values
  */
-struct FxNoiseProfile
+struct SIX_CPHD_API FxNoiseProfile
 {
     //! Equality operators
     bool operator==(const FxNoiseProfile& other) const
@@ -297,7 +298,7 @@ struct FxNoiseProfile
  *
  *  \brief (Optional) Thermal noise level for the reference signal vector
  */
-struct NoiseLevel
+struct SIX_CPHD_API NoiseLevel
 {
     //! Thermal noise level for the reference signal
     //! vector (v_CH_REF).
@@ -335,7 +336,7 @@ struct NoiseLevel
  *  channel. Channels referenced by their unique
  *  Channel ID (Ch_ID). See Section 7.2.
 */
-struct ChannelParameter
+struct SIX_CPHD_API ChannelParameter
 {
     /*
      *  \struct TxRcv
@@ -378,7 +379,7 @@ struct ChannelParameter
      *  form the signal array data.
      */
     // Hiding Antenna struct here because of naming clash
-    struct Antenna
+    struct SIX_CPHD_API Antenna
     {
         // Constructor
         Antenna();
@@ -525,7 +526,7 @@ struct ChannelParameter
  *  contained in the product.
  *  See section 7.
  */
-struct Channel
+struct SIX_CPHD_API Channel
 {
     //! Constructor
     Channel();

--- a/six/modules/c++/cphd/include/cphd/Data.h
+++ b/six/modules/c++/cphd/include/cphd/Data.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD_DATA_H__
 #define __CPHD_DATA_H__
 
@@ -34,6 +34,7 @@
 #include <six/Init.h>
 #include <cphd/Enums.h>
 #include <cphd/Utilities.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -45,7 +46,7 @@ namespace cphd
  *
  *  See section 2.3 through 2.6
  */
-struct Data
+struct SIX_CPHD_API Data
 {
     /*
      *  \struct SupportArray
@@ -58,7 +59,7 @@ struct Data
      */
     // There's another SupportArray type in the Metadata,
     // so hiding this inside Data
-    struct SupportArray
+    struct SIX_CPHD_API SupportArray
     {
 
         /*
@@ -135,7 +136,7 @@ struct Data
      */
     // There's another Channel type in the Metadata,
     // so hiding this inside Data
-    struct Channel
+    struct SIX_CPHD_API Channel
     {
         /*
          *  \func Channel

--- a/six/modules/c++/cphd/include/cphd/DataWriter.h
+++ b/six/modules/c++/cphd/include/cphd/DataWriter.h
@@ -33,6 +33,8 @@
 #include <sys/OS.h>
 #include <sys/Span.h>
 
+#include "cphd/Exports.h"
+
 namespace cphd
 {
 
@@ -41,7 +43,7 @@ namespace cphd
  *
  *  \brief Class to handle writing to file and byte swapping
  */
-struct DataWriter
+struct SIX_CPHD_API DataWriter
 {
     /*
      *  \func DataWriter
@@ -93,7 +95,7 @@ protected:
  *
  *  For little endian to big endian storage
  */
-struct DataWriterLittleEndian final : public DataWriter
+struct SIX_CPHD_API DataWriterLittleEndian final : public DataWriter
 {
     /*
      *  \func DataWriterLittleEndian
@@ -139,7 +141,7 @@ private:
  *
  *  No byte swap. Already big endian.
  */
-struct DataWriterBigEndian final : public DataWriter
+struct SIX_CPHD_API DataWriterBigEndian final : public DataWriter
 {
     /*
      *  \func DataWriter

--- a/six/modules/c++/cphd/include/cphd/Dwell.h
+++ b/six/modules/c++/cphd/include/cphd/Dwell.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD_DWELL_H__
 #define __CPHD_DWELL_H__
 
@@ -28,6 +28,7 @@
 
 #include <cphd/Enums.h>
 #include <cphd/Types.h>
+#include <cphd/Exports.h>
 
 #include <mem/ScopedCopyablePtr.h>
 
@@ -39,7 +40,7 @@ namespace cphd
  *
  *  \brief Dwell Time Polynomial
  */
-struct DwellTime
+struct SIX_CPHD_API DwellTime
 {
     //! Constructor
     DwellTime();
@@ -66,7 +67,7 @@ struct DwellTime
  *
  *  \brief Center of Dwell Time Polynomial
  */
-struct COD
+struct SIX_CPHD_API COD
 {
     //! Constructor
     COD();
@@ -97,7 +98,7 @@ struct COD
  *  contained in the CPHD product
  *  See section 7.3
  */
-struct Dwell
+struct SIX_CPHD_API Dwell
 {
     //! Constructor
     Dwell();

--- a/six/modules/c++/cphd/include/cphd/Exports.h
+++ b/six/modules/c++/cphd/include/cphd/Exports.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "config/compiler_extensions.h"
+
+// Need to specify how this code will be consumed, either SIX_CPHD_LIB_ (static library)
+// or SIX_CPHD_DLL_ (aka "shared" library).  For DLLs, it needs to be set for BOTH
+// "exporting" (building this code) and "importing" (consuming).
+//
+// Use Windows naming conventions (DLL, LIB) because this really only matters for _MSC_VER, see below.
+#if !defined(SIX_CPHD_LIB_) && !defined(SIX_CPHD_DLL_)
+    #if CODA_OSS_LIBRARY_SHARED
+        #if CODA_OSS_LIBRARY_STATIC
+            #error "CODA_OSS_LIBRARY_SHARED already #define'd'"
+        #endif
+        #define SIX_CPHD_DLL_ 1  // Symbols must be exported and imported (see below).
+    #else
+        // CODA_OSS_LIBRARY_STATIC doesn't have to be defined
+        #define SIX_CPHD_LIB_ 1  // Static library, all symbols visible.
+    #endif
+#endif
+#if !defined(SIX_CPHD_LIB_) && !defined(SIX_CPHD_DLL_)
+    #error "One of SIX_CPHD_LIB_ pr SIX_CPHD_DLL_ must be #define'd'"
+#endif
+#if defined(SIX_CPHD_LIB_) && defined(SIX_CPHD_DLL_)
+    #error "Both SIX_CPHD_LIB_ and SIX_CPHD_DLL_ are #define'd'"
+#endif
+#if defined(SIX_CPHD_EXPORTS) && defined(SIX_CPHD_LIB_)
+    #error "Can't export from a LIB'"
+#endif
+
+// The following ifdef block is the standard way of creating macros which make exporting
+// from a DLL simpler. All files within this DLL are compiled with the SIX_CPHD_EXPORTS
+// symbol defined on the command line. This symbol should not be defined on any project
+// that uses this DLL. This way any other project whose source files include this file see
+// SIX_CPHD_API functions as being imported from a DLL, whereas this DLL sees symbols
+// defined with this macro as being exported.
+// https://www.gnu.org/software/gnulib/manual/html_node/Exported-Symbols-of-Shared-Libraries.html
+#ifdef SIX_CPHD_EXPORTS
+    #define SIX_CPHD_API CODA_OSS_library_export
+#else
+    // Either building a static library (no SIX_CPHD_EXPORTS) or
+    // importing (not building) a shared library.
+
+    // We need to know whether we're consuming (importing) a DLL or static LIB
+    // The default is a static LIB as that's what existing code/builds expect.
+    #ifdef SIX_CPHD_DLL_
+        // Actually, it seems that the linker is able to figure this out from the .LIB, so 
+        // there doesn't seem to be a need for __declspec(dllimport).  Clients don't
+        // need to #define SIX_CPHD_DLL_ ... ?  Well, almost ... it looks
+        // like __declspec(dllimport) is needed to get virtual "inline"s (e.g., 
+        // destructors) correct.
+        #define SIX_CPHD_API CODA_OSS_library_import
+    #else
+        #define SIX_CPHD_API /* "importing" a static LIB */
+    #endif
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4251) // '...' : class '...' needs to have dll-interface to be used by clients of struct '...'
+#endif

--- a/six/modules/c++/cphd/include/cphd/FileHeader.h
+++ b/six/modules/c++/cphd/include/cphd/FileHeader.h
@@ -30,6 +30,7 @@
 #include <io/SeekableStreams.h>
 #include <cphd/BaseFileHeader.h>
 #include <cphd/Types.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -38,7 +39,7 @@ namespace cphd
  *
  *  \brief Stores CPHD file header information
  */
-class FileHeader final : public BaseFileHeader
+class SIX_CPHD_API FileHeader final : public BaseFileHeader
 {
     static Version defaultVersion;
 public:

--- a/six/modules/c++/cphd/include/cphd/Metadata.h
+++ b/six/modules/c++/cphd/include/cphd/Metadata.h
@@ -41,6 +41,7 @@
 #include <cphd/SupportArray.h>
 #include <cphd/TxRcv.h>
 #include <cphd/Utilities.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -56,7 +57,7 @@ namespace cphd
  *  This object contains all of the sub-blocks for CPHD.
  *
  */
-struct Metadata final : MetadataBase
+struct SIX_CPHD_API Metadata final : MetadataBase
 {
     //! Default constructor
     //! Initializes CPHD version to default version specified in FileHeader

--- a/six/modules/c++/cphd/include/cphd/MetadataBase.h
+++ b/six/modules/c++/cphd/include/cphd/MetadataBase.h
@@ -19,13 +19,14 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD_METADATA_BASE_H__
 #define __CPHD_METADATA_BASE_H__
 
 #include <ostream>
 #include <six/Init.h>
 #include <cphd/Enums.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -38,7 +39,7 @@ namespace cphd
  *  to interact with the signal block reader Wideband, currently in CPHD
  *
  */
-struct MetadataBase
+struct SIX_CPHD_API MetadataBase
 {
     //! Default constructor
     MetadataBase()

--- a/six/modules/c++/cphd/include/cphd/PVP.h
+++ b/six/modules/c++/cphd/include/cphd/PVP.h
@@ -37,6 +37,7 @@
 #include <six/XsElement.h>
 
 #include "cphd/Types.h"
+#include "cphd/Exports.h"
 
 namespace cphd
 {
@@ -50,7 +51,7 @@ namespace cphd
  *  the binary parameter in the set of Per Vector
  *  parameters provided for each vector.
  */
-struct PVPType
+struct SIX_CPHD_API PVPType
 {
     static constexpr size_t WORD_BYTE_SIZE = 8;
 
@@ -133,7 +134,7 @@ std::ostream& operator<< (std::ostream& os, const PVPType& p);
  *
  *  Specifies additional (or custom) per vector parameters
  */
-struct APVPType : PVPType
+struct SIX_CPHD_API APVPType : PVPType
 {
     //! Constructor
     APVPType();
@@ -191,7 +192,7 @@ private:
 /*!
  *  \struct PerVectorParameterXYZ
  */
-struct PerVectorParameterXYZ final
+struct SIX_CPHD_API PerVectorParameterXYZ final
 {
     PerVectorParameterXYZ();
     ~PerVectorParameterXYZ() = default;
@@ -223,7 +224,7 @@ inline std::ostream& operator<<(std::ostream& os, const PerVectorParameterXYZ& v
  *
  *  \brief Per vector parameters for Electrical Boresight
  */
-struct PerVectorParameterEB final
+struct SIX_CPHD_API PerVectorParameterEB final
 {
     PerVectorParameterEB();
     ~PerVectorParameterEB() = default;
@@ -257,7 +258,7 @@ inline std::ostream& operator<<(std::ostream& os, const PerVectorParameterEB& v)
  * Parameters included that specify the Transmit Antenna ACF orientation and the EB Steering vector.
  * (New in CPHD 1.1.0)
  */
-struct TxAntenna final
+struct SIX_CPHD_API TxAntenna final
 {
     bool operator==(const TxAntenna& other) const
     {
@@ -294,7 +295,7 @@ inline std::ostream& operator<<(std::ostream& os, const TxAntenna& v)
  * Parameters included that specify the Receive Antenna ACF orientation and the EB Steering vector.
  * (New in CPHD 1.1.0)
  */
-struct RcvAntenna final
+struct SIX_CPHD_API RcvAntenna final
 {
     bool operator==(const RcvAntenna& other) const
     {
@@ -332,7 +333,7 @@ inline std::ostream& operator<<(std::ostream& os, const RcvAntenna& v)
  *
  *  Provided for each channel of a given product.
  */
-struct Pvp final
+struct SIX_CPHD_API Pvp final
 {
     /*!
      *  Transmit time for the center of the transmitted pulse relative to the
@@ -626,7 +627,7 @@ private:
 };
 
 //! Ostream operators
-std::ostream& operator<< (std::ostream& os, const APVPType& a);
-std::ostream& operator<< (std::ostream& os, const Pvp& p);
+SIX_CPHD_API std::ostream& operator<< (std::ostream& os, const APVPType& a);
+SIX_CPHD_API std::ostream& operator<< (std::ostream& os, const Pvp& p);
 }
 #endif // SIX_cphd_PVP_h_INCLUDED_

--- a/six/modules/c++/cphd/include/cphd/PVPBlock.h
+++ b/six/modules/c++/cphd/include/cphd/PVPBlock.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD_PVP_BLOCK_H__
 #define __CPHD_PVP_BLOCK_H__
 
@@ -37,6 +37,7 @@
 #include <cphd/PVP.h>
 #include <cphd/Metadata.h>
 #include <cphd/ByteSwap.h>
+#include <cphd/Exports.h>
 #include <six/Parameter.h>
 
 namespace cphd
@@ -92,7 +93,7 @@ struct AddedPVP<std::string>
  *
  *  PVPBlock handles reading PVPBlock from CPHD file, and loading the data structure
  */
-struct PVPBlock
+struct SIX_CPHD_API PVPBlock
 {
     PVPBlock() = default;
 
@@ -453,7 +454,7 @@ protected:
         //! (Optional) Additional parameters
         std::unordered_map<std::string,six::Parameter> addedPVP;
     };
-    friend std::ostream& operator<< (std::ostream& os, const PVPSet& p);
+    SIX_CPHD_API friend std::ostream& operator<< (std::ostream& os, const PVPSet& p);
 
 private:
     //! The PVP Block [Num Channles][Num Parameters]
@@ -475,7 +476,7 @@ private:
     bool mSignalEnabled;
 
     //! Ostream operator
-    friend std::ostream& operator<< (std::ostream& os, const PVPBlock& p);
+    SIX_CPHD_API friend std::ostream& operator<< (std::ostream& os, const PVPBlock& p);
 };
 }
 #endif

--- a/six/modules/c++/cphd/include/cphd/ReferenceGeometry.h
+++ b/six/modules/c++/cphd/include/cphd/ReferenceGeometry.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD_REFERENCE_GEOMETRY_H__
 #define __CPHD_REFERENCE_GEOMETRY_H__
 
@@ -27,6 +27,7 @@
 
 #include <cphd/Enums.h>
 #include <cphd/Types.h>
+#include <cphd/Exports.h>
 #include <mem/ScopedCopyablePtr.h>
 
 namespace cphd
@@ -38,7 +39,7 @@ namespace cphd
  *  \brief The SRP position for the reference vector of the
  *  reference channel
  */
-struct SRP
+struct SIX_CPHD_API SRP
 {
     //! Constructor
     SRP();
@@ -68,7 +69,7 @@ struct SRP
  *  \brief Base class for both Monostatic and
  *   Bistatic imaging types
  */
-struct ImagingType
+struct SIX_CPHD_API ImagingType
 {
     //! Constructor
     ImagingType();
@@ -121,7 +122,7 @@ struct ImagingType
  *   Single radar platform that is both the transmitter
  *   and the receiver
  */
-struct Monostatic : public ImagingType
+struct SIX_CPHD_API Monostatic : public ImagingType
 {
     //! Constructor
     Monostatic();
@@ -180,7 +181,7 @@ struct Monostatic : public ImagingType
  *  Pair of radar platforms, with a seperate transmitter
  *  and a passive receiver.
  */
-struct Bistatic : public ImagingType
+struct SIX_CPHD_API Bistatic : public ImagingType
 {
     /*!
      *  \struct PlatformParams
@@ -296,7 +297,7 @@ struct Bistatic : public ImagingType
  *
  *  \brief Parameters that describe the collection geometry
  */
-struct ReferenceGeometry
+struct SIX_CPHD_API ReferenceGeometry
 {
     //! Constructor
     ReferenceGeometry();
@@ -339,12 +340,12 @@ struct ReferenceGeometry
 };
 
 //! Ostream operators
-std::ostream& operator<< (std::ostream& os, const SRP& s);
-std::ostream& operator<< (std::ostream& os, const ImagingType& i);
-std::ostream& operator<< (std::ostream& os, const Monostatic& m);
-std::ostream& operator<< (std::ostream& os, const Bistatic::PlatformParams& p);
-std::ostream& operator<< (std::ostream& os, const Bistatic& b);
-std::ostream& operator<< (std::ostream& os, const ReferenceGeometry& r);
+SIX_CPHD_API std::ostream& operator<< (std::ostream& os, const SRP& s);
+SIX_CPHD_API std::ostream& operator<< (std::ostream& os, const ImagingType& i);
+SIX_CPHD_API std::ostream& operator<< (std::ostream& os, const Monostatic& m);
+SIX_CPHD_API std::ostream& operator<< (std::ostream& os, const Bistatic::PlatformParams& p);
+SIX_CPHD_API std::ostream& operator<< (std::ostream& os, const Bistatic& b);
+SIX_CPHD_API std::ostream& operator<< (std::ostream& os, const ReferenceGeometry& r);
 }
 
 #endif

--- a/six/modules/c++/cphd/include/cphd/SupportBlock.h
+++ b/six/modules/c++/cphd/include/cphd/SupportBlock.h
@@ -38,6 +38,7 @@
 
 #include <cphd/Data.h>
 #include <cphd/Utilities.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -50,7 +51,7 @@ namespace cphd
  *  \brief This class contains information about the SupportBlock CPHD data.
  */
 //  Provides methods to read support block data from CPHD file/stream
-struct SupportBlock final
+struct SIX_CPHD_API SupportBlock final
 {
     /*
      *  \func SupportBlock

--- a/six/modules/c++/cphd/include/cphd/TestDataGenerator.h
+++ b/six/modules/c++/cphd/include/cphd/TestDataGenerator.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD_TEST_DATA_GENERATOR_H__
 #define __CPHD_TEST_DATA_GENERATOR_H__
 
@@ -33,6 +33,7 @@
 #include <cphd/PVPBlock.h>
 #include <cphd/Enums.h>
 #include <cphd/Types.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -43,7 +44,7 @@ namespace cphd
  *
  * \return Randomly generated double
  */
-double getRandom();
+SIX_CPHD_API double getRandom();
 
 /*
  *  \func getRandomVector3
@@ -51,7 +52,7 @@ double getRandom();
  *
  *  \return Return vector3D object
  */
-Vector3 getRandomVector3();
+SIX_CPHD_API Vector3 getRandomVector3();
 
 /*
  *  \func setPVPXML
@@ -62,7 +63,7 @@ Vector3 getRandomVector3();
  *  \params[out] pvp A Pvp object for which values will be set
  *
  */
-void setPVPXML(Pvp& pvp);
+SIX_CPHD_API void setPVPXML(Pvp& pvp);
 
 /*
  *  \func setVectorParameters
@@ -77,7 +78,7 @@ void setPVPXML(Pvp& pvp);
  *   will be returned with data filled in for specific vector
  *
  */
-void setVectorParameters(size_t channel,
+SIX_CPHD_API void setVectorParameters(size_t channel,
                           size_t vector,
                           PVPBlock& pvpBlock);
 
@@ -88,7 +89,7 @@ void setVectorParameters(size_t channel,
  *  \param[out] Filled metadata object
  *
  */
-void setUpMetadata(Metadata& metadata);
+SIX_CPHD_API void setUpMetadata(Metadata& metadata);
 
 /*
  *  \func setUpData

--- a/six/modules/c++/cphd/include/cphd/Types.h
+++ b/six/modules/c++/cphd/include/cphd/Types.h
@@ -34,6 +34,8 @@
 #include <six/Utilities.h>
 #include <six/sicd/GeoData.h>
 
+#include "cphd/Exports.h"
+
 namespace cphd
 {
 // Use the same types that SIX uses
@@ -98,7 +100,7 @@ enum class Version
     v1_0_1, // {"1.0.1", xml::lite::Uri("http://api.nsgreg.nga.mil/schema/cphd/1.0.1")},
     v1_1_0, // {"1.1.0", xml::lite::Uri("http://api.nsgreg.nga.mil/schema/cphd/1.1.0")}
 };
-std::string to_string(Version); // "1.0.0", "1.0.1", "1.1.0"
+SIX_CPHD_API std::string to_string(Version); // "1.0.0", "1.0.1", "1.1.0"
 
 // Existing code handles this via XML validation, not C++.
 using ZeroToOne = double;

--- a/six/modules/c++/cphd/include/cphd/Utilities.h
+++ b/six/modules/c++/cphd/include/cphd/Utilities.h
@@ -20,6 +20,7 @@
  *
  */
 
+#pragma once
 #ifndef __CPHD_UTILITIES_H__
 #define __CPHD_UTILITIES_H__
 
@@ -30,6 +31,7 @@
 
 #include <cphd/Enums.h>
 #include <cphd/Types.h>
+#include <cphd/Exports.h>
 
 namespace cphd
 {
@@ -45,7 +47,7 @@ namespace cphd
  *
  *  \return Returns number of bytes: 2, 4 or 8. (0 if uninitialized)
  */
-size_t getNumBytesPerSample(const SignalArrayFormat& signalArrayFormat);
+SIX_CPHD_API size_t getNumBytesPerSample(const SignalArrayFormat& signalArrayFormat);
 
 /*
  *  \func validateFormat

--- a/six/modules/c++/cphd/include/cphd/Wideband.h
+++ b/six/modules/c++/cphd/include/cphd/Wideband.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __CPHD_WIDEBAND_H__
 #define __CPHD_WIDEBAND_H__
-#pragma once
 
 #include <complex>
 #include <string>
@@ -30,6 +30,7 @@
 #include <scene/sys_Conf.h>
 #include <cphd/MetadataBase.h>
 #include <cphd/Utilities.h>
+#include <cphd/Exports.h>
 
 #include <io/SeekableStreams.h>
 #include <mem/BufferView.h>
@@ -48,7 +49,7 @@ namespace cphd
  */
 //  It contains the cphd::Data structure (for channel and vector sizes).
 //  Provides methods read wideband data from CPHD file/stream
-struct Wideband final
+struct SIX_CPHD_API Wideband final
 {
     static const size_t ALL;
 

--- a/six/modules/c++/cphd/source/CPHDWriter.cpp
+++ b/six/modules/c++/cphd/source/CPHDWriter.cpp
@@ -32,6 +32,7 @@
 #include <cphd/FileHeader.h>
 #include <cphd/Utilities.h>
 #include <cphd/Wideband.h>
+#include <cphd/Exports.h>
 
 #undef min
 #undef max
@@ -382,19 +383,19 @@ void CPHDWriter::writeCPHDData(io::SeekableOutputStream& stream,
     writeCPHDData(*dataWriter, data, numElements, channel);
 }
 
-template void CPHDWriter::writeCPHDData(io::SeekableOutputStream&,
+template SIX_CPHD_API void CPHDWriter::writeCPHDData(io::SeekableOutputStream&,
     const sys::ubyte* data, // For compressed data
     size_t numElements, size_t channel);
-template void CPHDWriter::writeCPHDData(io::SeekableOutputStream&,
+template SIX_CPHD_API void CPHDWriter::writeCPHDData(io::SeekableOutputStream&,
     const std::byte* data,
     size_t numElements, size_t channel);
-template void CPHDWriter::writeCPHDData<cphd::zint8_t>(io::SeekableOutputStream&,
+template SIX_CPHD_API void CPHDWriter::writeCPHDData<cphd::zint8_t>(io::SeekableOutputStream&,
     const cphd::zint8_t* data,
     size_t numElements, size_t channel);
-template void CPHDWriter::writeCPHDData<cphd::zint16_t>(io::SeekableOutputStream&,
+template SIX_CPHD_API void CPHDWriter::writeCPHDData<cphd::zint16_t>(io::SeekableOutputStream&,
     const cphd::zint16_t* data,
     size_t numElements, size_t channel);
-template void CPHDWriter::writeCPHDData<cphd::zfloat>(io::SeekableOutputStream&,
+template SIX_CPHD_API void CPHDWriter::writeCPHDData<cphd::zfloat>(io::SeekableOutputStream&,
     const cphd::zfloat* data,
     size_t numElements, size_t channel);
 }

--- a/six/modules/c++/cphd/source/TestDataGenerator.cpp
+++ b/six/modules/c++/cphd/source/TestDataGenerator.cpp
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#include <cphd/TestDataGenerator.h>
 
 #include <iostream>
 #include <stdlib.h>

--- a/six/modules/c++/cphd03/cphd03.vcxproj
+++ b/six/modules/c++/cphd03/cphd03.vcxproj
@@ -19,12 +19,12 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -50,7 +50,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_CPHD03_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -79,7 +79,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_CPHD03_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -105,8 +105,17 @@
     <ProjectReference Include="..\..\..\..\externals\coda-oss\modules\c++\coda-oss.vcxproj">
       <Project>{9997e895-5161-4ddf-8f3f-099894cb2f21}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c++\nitf-c++.vcxproj">
+      <Project>{8f357a19-799e-4971-850e-3f28485c130b}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\cphd\cphd.vcxproj">
       <Project>{01be4480-9620-4ded-b34f-d2e3ab4b7c8b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\scene\scene.vcxproj">
+      <Project>{1cfcde59-6410-4037-95eb-b37d31e10820}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\six.sicd\six.sicd.vcxproj">
+      <Project>{34ac2314-fbd1-42ad-aaf4-0cebc6bf737e}</Project>
     </ProjectReference>
     <ProjectReference Include="..\six\six.vcxproj">
       <Project>{62aad4dd-35ba-41a0-8263-1f4dfd755689}</Project>
@@ -120,6 +129,7 @@
     <ClInclude Include="include\cphd03\CPHDWriter.h" />
     <ClInclude Include="include\cphd03\CPHDXMLControl.h" />
     <ClInclude Include="include\cphd03\Data.h" />
+    <ClInclude Include="include\cphd03\Exports.h" />
     <ClInclude Include="include\cphd03\FileHeader.h" />
     <ClInclude Include="include\cphd03\Global.h" />
     <ClInclude Include="include\cphd03\Metadata.h" />

--- a/six/modules/c++/cphd03/cphd03.vcxproj.filters
+++ b/six/modules/c++/cphd03/cphd03.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClInclude Include="include\cphd03\VectorParameters.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\cphd03\Exports.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/six/modules/c++/cphd03/include/cphd03/Antenna.h
+++ b/six/modules/c++/cphd03/include/cphd03/Antenna.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD03_ANTENNA_H__
 #define __CPHD03_ANTENNA_H__
 
@@ -27,6 +27,8 @@
 #include <vector>
 
 #include <six/sicd/Antenna.h>
+
+#include "cphd03/Exports.h"
 
 namespace cphd03
 {
@@ -80,7 +82,7 @@ typedef six::sicd::AntennaParameters AntennaParameters;
  *  and the receieve (Rcv) antenna.  A single set of prarameters may
  *  be provided for a combined two-way pattern (as appropriate)
  */
- struct Antenna
+ struct SIX_CPHD03_API Antenna final
 {
     //!  Constructor
     Antenna();

--- a/six/modules/c++/cphd03/include/cphd03/CPHDReader.h
+++ b/six/modules/c++/cphd03/include/cphd03/CPHDReader.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD03_CPHD03_READER_H__
 #define __CPHD03_CPHD03_READER_H__
 
@@ -30,11 +30,12 @@
 #include <cphd03/Metadata.h>
 #include <cphd03/FileHeader.h>
 #include <cphd03/VBM.h>
+#include <cphd03/Exports.h>
 #include <cphd/Wideband.h>
 
 namespace cphd03
 {
-class CPHDReader
+class SIX_CPHD03_API CPHDReader
 {
 public:
     //!  Constructor

--- a/six/modules/c++/cphd03/include/cphd03/CPHDWriter.h
+++ b/six/modules/c++/cphd03/include/cphd03/CPHDWriter.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD03_CPHD03_WRITER_H__
 #define __CPHD03_CPHD03_WRITER_H__
 
@@ -33,6 +33,7 @@
 #include <types/RowCol.h>
 #include <cphd03/Metadata.h>
 #include <cphd03/VBM.h>
+#include <cphd03/Exports.h>
 #include <cphd/CPHDWriter.h>
 
 namespace cphd03
@@ -42,7 +43,7 @@ namespace cphd03
  *  \brief Used to write a CPHD file. You must be able to provide the
  *         appropriate metadata and vector based metadata.
  */
-struct CPHDWriter final
+struct SIX_CPHD03_API CPHDWriter final
 {
     /*
      *  \func Constructor

--- a/six/modules/c++/cphd03/include/cphd03/Channel.h
+++ b/six/modules/c++/cphd03/include/cphd03/Channel.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD03_CHANNEL_H__
 #define __CPHD03_CHANNEL_H__
 
@@ -27,9 +27,11 @@
 #include <vector>
 #include <stddef.h>
 
+#include "cphd03/Exports.h"
+
 namespace cphd03
 {
-struct ChannelParameters
+struct SIX_CPHD03_API ChannelParameters
 {
     ChannelParameters();
 
@@ -68,7 +70,7 @@ struct ChannelParameters
 
 std::ostream& operator<< (std::ostream& os, const ChannelParameters& d);
 
-struct Channel
+struct SIX_CPHD03_API Channel
 {
     Channel()
     {

--- a/six/modules/c++/cphd03/include/cphd03/Data.h
+++ b/six/modules/c++/cphd03/include/cphd03/Data.h
@@ -20,7 +20,7 @@
  *
  */
 
-
+#pragma once
 #ifndef __CPHD03_DATA_H__
 #define __CPHD03_DATA_H__
 
@@ -31,9 +31,11 @@
 #include <cphd/Data.h>
 #include <cphd/Enums.h>
 
+#include "cphd03/Exports.h"
+
 namespace cphd03
 {
-struct ArraySize
+struct SIX_CPHD03_API ArraySize
 {
     ArraySize(size_t v = 0, size_t s = 0);
 

--- a/six/modules/c++/cphd03/include/cphd03/Exports.h
+++ b/six/modules/c++/cphd03/include/cphd03/Exports.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "config/compiler_extensions.h"
+
+// Need to specify how this code will be consumed, either SIX_CPHD03_LIB_ (static library)
+// or SIX_CPHD03_DLL_ (aka "shared" library).  For DLLs, it needs to be set for BOTH
+// "exporting" (building this code) and "importing" (consuming).
+//
+// Use Windows naming conventions (DLL, LIB) because this really only matters for _MSC_VER, see below.
+#if !defined(SIX_CPHD03_LIB_) && !defined(SIX_CPHD03_DLL_)
+    #if CODA_OSS_LIBRARY_SHARED
+        #if CODA_OSS_LIBRARY_STATIC
+            #error "CODA_OSS_LIBRARY_SHARED already #define'd'"
+        #endif
+        #define SIX_CPHD03_DLL_ 1  // Symbols must be exported and imported (see below).
+    #else
+        // CODA_OSS_LIBRARY_STATIC doesn't have to be defined
+        #define SIX_CPHD03_LIB_ 1  // Static library, all symbols visible.
+    #endif
+#endif
+#if !defined(SIX_CPHD03_LIB_) && !defined(SIX_CPHD03_DLL_)
+    #error "One of SIX_CPHD03_LIB_ pr SIX_CPHD03_DLL_ must be #define'd'"
+#endif
+#if defined(SIX_CPHD03_LIB_) && defined(SIX_CPHD03_DLL_)
+    #error "Both SIX_CPHD03_LIB_ and SIX_CPHD03_DLL_ are #define'd'"
+#endif
+#if defined(SIX_CPHD03_EXPORTS) && defined(SIX_CPHD03_LIB_)
+    #error "Can't export from a LIB'"
+#endif
+
+// The following ifdef block is the standard way of creating macros which make exporting
+// from a DLL simpler. All files within this DLL are compiled with the SIX_CPHD03_EXPORTS
+// symbol defined on the command line. This symbol should not be defined on any project
+// that uses this DLL. This way any other project whose source files include this file see
+// SIX_CPHD03_API functions as being imported from a DLL, whereas this DLL sees symbols
+// defined with this macro as being exported.
+// https://www.gnu.org/software/gnulib/manual/html_node/Exported-Symbols-of-Shared-Libraries.html
+#ifdef SIX_CPHD03_EXPORTS
+    #define SIX_CPHD03_API CODA_OSS_library_export
+#else
+    // Either building a static library (no SIX_CPHD03_EXPORTS) or
+    // importing (not building) a shared library.
+
+    // We need to know whether we're consuming (importing) a DLL or static LIB
+    // The default is a static LIB as that's what existing code/builds expect.
+    #ifdef SIX_CPHD03_DLL_
+        // Actually, it seems that the linker is able to figure this out from the .LIB, so 
+        // there doesn't seem to be a need for __declspec(dllimport).  Clients don't
+        // need to #define SIX_CPHD03_DLL_ ... ?  Well, almost ... it looks
+        // like __declspec(dllimport) is needed to get virtual "inline"s (e.g., 
+        // destructors) correct.
+        #define SIX_CPHD03_API CODA_OSS_library_import
+    #else
+        #define SIX_CPHD03_API /* "importing" a static LIB */
+    #endif
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4251) // '...' : class '...' needs to have dll-interface to be used by clients of struct '...'
+#endif

--- a/six/modules/c++/cphd03/include/cphd03/FileHeader.h
+++ b/six/modules/c++/cphd03/include/cphd03/FileHeader.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __CPHD03_FILE_HEADER_H__
 #define __CPHD03_FILE_HEADER_H__
 
@@ -30,9 +30,11 @@
 #include <io/SeekableStreams.h>
 #include <cphd/BaseFileHeader.h>
 
+#include "cphd03/Exports.h"
+
 namespace cphd03
 {
-class FileHeader : public cphd::BaseFileHeader
+class SIX_CPHD03_API FileHeader : public cphd::BaseFileHeader
 {
 public:
     static const char DEFAULT_VERSION[];

--- a/six/modules/c++/cphd03/include/cphd03/Global.h
+++ b/six/modules/c++/cphd03/include/cphd03/Global.h
@@ -20,7 +20,7 @@
  *
  */
 
-
+#pragma once
 #ifndef __CPHD03_GLOBAL_H__
 #define __CPHD03_GLOBAL_H__
 
@@ -31,10 +31,12 @@
 #include <cphd/Enums.h>
 #include <cphd/Types.h>
 
+#include "cphd03/Exports.h"
+
 namespace cphd03
 {
 // Optional segment DwellTime
-struct DwellTimeParameters
+struct SIX_CPHD03_API DwellTimeParameters
 {
     DwellTimeParameters();
 
@@ -57,7 +59,7 @@ std::ostream& operator<< (std::ostream& os, const DwellTimeParameters& d);
 
 typedef six::sicd::AreaDirectionParameters AreaDirectionParameters;
 
-struct AreaPlane
+struct SIX_CPHD03_API AreaPlane
 {
     AreaPlane();
 
@@ -76,7 +78,7 @@ struct AreaPlane
 
 std::ostream& operator<< (std::ostream& os, const AreaPlane& d);
 
-struct ImageArea
+struct SIX_CPHD03_API ImageArea
 {
     ImageArea();
 
@@ -93,7 +95,7 @@ struct ImageArea
 
 std::ostream& operator<< (std::ostream& os, const ImageArea& d);
 
-struct Global
+struct SIX_CPHD03_API Global final
 {
     Global();
 

--- a/six/modules/c++/cphd03/include/cphd03/Metadata.h
+++ b/six/modules/c++/cphd03/include/cphd03/Metadata.h
@@ -20,7 +20,7 @@
  *
  */
 
-
+#pragma once
 #ifndef __CPHD03_METADATA_H__
 #define __CPHD03_METADATA_H__
 
@@ -34,6 +34,7 @@
 #include <cphd03/SRP.h>
 #include <cphd03/Antenna.h>
 #include <cphd03/VectorParameters.h>
+#include <cphd03/Exports.h>
 
 namespace cphd03
 {
@@ -50,7 +51,7 @@ namespace cphd03
  *
  *
  */
-struct Metadata : cphd::MetadataBase
+struct SIX_CPHD03_API Metadata : cphd::MetadataBase
 {
     Metadata() = default;
 
@@ -107,7 +108,7 @@ struct Metadata : cphd::MetadataBase
     }
 };
 
-std::ostream& operator<< (std::ostream& os, const Metadata& d);
+SIX_CPHD03_API std::ostream& operator<< (std::ostream& os, const Metadata& d);
 }
 
 #endif

--- a/six/modules/c++/cphd03/include/cphd03/SRP.h
+++ b/six/modules/c++/cphd03/include/cphd03/SRP.h
@@ -20,19 +20,20 @@
  *
  */
 
-
+#pragma once
 #ifndef __CPHD03_SRP_H__
 #define __CPHD03_SRP_H__
 
 #include <iostream>
 #include <cphd/Types.h>
 #include <cphd03/Utilities.h>
+#include <cphd03/Exports.h>
 #include <six/Init.h>
 
 
 namespace cphd03
 {
-struct SRP
+struct SIX_CPHD03_API SRP final
 {
     SRP();
 

--- a/six/modules/c++/cphd03/include/cphd03/VBM.h
+++ b/six/modules/c++/cphd03/include/cphd03/VBM.h
@@ -31,6 +31,7 @@
 #include <cphd/Types.h>
 #include <cphd03/Data.h>
 #include <cphd03/VectorParameters.h>
+#include <cphd03/Exports.h>
 
 namespace cphd03
 {
@@ -42,7 +43,7 @@ namespace cphd03
 //  the cphd03::VectorParameters info (for the map of available VBM entries)
 //  and the VBP data itself
 
-struct VBM
+struct SIX_CPHD03_API VBM final
 {
     /*
      *  \func Constructor
@@ -327,7 +328,7 @@ private:
     // Then one VectorBasedParameter per vector.
     std::vector<std::vector<VectorBasedParameters> > mData;
 
-    friend std::ostream& operator<< (std::ostream& os, const VBM& d);
+    SIX_CPHD03_API friend std::ostream& operator<< (std::ostream& os, const VBM& d);
 };
 }
 

--- a/six/modules/c++/cphd03/include/cphd03/VectorParameters.h
+++ b/six/modules/c++/cphd03/include/cphd03/VectorParameters.h
@@ -20,7 +20,7 @@
  *
  */
 
-
+#pragma once
 #ifndef __CPHD03_VECTOR_PARAMETERS_H__
 #define __CPHD03_VECTOR_PARAMETERS_H__
 
@@ -30,9 +30,11 @@
 #include <mem/ScopedCopyablePtr.h>
 #include <six/Init.h>
 
+#include "cphd03/Exports.h"
+
 namespace cphd03
 {
-struct FxParameters
+struct SIX_CPHD03_API FxParameters
 {
     FxParameters();
 
@@ -57,7 +59,7 @@ struct FxParameters
 
 std::ostream& operator<< (std::ostream& os, const FxParameters& d);
 
-struct TOAParameters
+struct SIX_CPHD03_API TOAParameters
 {
     TOAParameters();
 
@@ -78,7 +80,7 @@ struct TOAParameters
 
 std::ostream& operator<< (std::ostream& os, const TOAParameters& d);
 
-struct VectorParameters
+struct SIX_CPHD03_API VectorParameters final
 {
     VectorParameters();
 
@@ -126,7 +128,7 @@ struct VectorParameters
     mem::ScopedCopyablePtr<TOAParameters> toaParameters;
 };
 
-std::ostream& operator<< (std::ostream& os, const VectorParameters& d);
+SIX_CPHD03_API std::ostream& operator<< (std::ostream& os, const VectorParameters& d);
 }
 
 #endif

--- a/six/modules/c++/cphd03/source/CPHDWriter.cpp
+++ b/six/modules/c++/cphd03/source/CPHDWriter.cpp
@@ -30,6 +30,7 @@
 #include <cphd03/CPHDXMLControl.h>
 #include <cphd03/Utilities.h>
 #include <cphd03/FileHeader.h>
+#include <cphd03/Exports.h>
 #include <cphd/ByteSwap.h>
 
 namespace cphd03
@@ -218,17 +219,17 @@ void CPHDWriter::writeCPHDData(const T* data,
     writeCPHDDataImpl(reinterpret_cast<const std::byte*>(data), numElements);
 }
 
-template
+template SIX_CPHD03_API
 void CPHDWriter::writeCPHDData<cphd::zint8_t >(
         const cphd::zint8_t* data,
         size_t numElements);
 
-template
+template SIX_CPHD03_API
 void CPHDWriter::writeCPHDData<cphd::zint16_t >(
         const cphd::zint16_t* data,
         size_t numElements);
 
-template
+template SIX_CPHD03_API
 void CPHDWriter::writeCPHDData<cphd::zfloat >(
         const cphd::zfloat* data,
         size_t numElements);

--- a/six/modules/c++/samples/crop_sicd.cpp
+++ b/six/modules/c++/samples/crop_sicd.cpp
@@ -155,7 +155,7 @@ int main(int argc, char** argv)
         }
 
         // Crop it
-        six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
         if (options->hasValue("ecef"))
         {

--- a/six/modules/c++/samples/crop_sidd.cpp
+++ b/six/modules/c++/samples/crop_sidd.cpp
@@ -70,7 +70,7 @@ int main(int argc, char** argv)
         getSchemaPaths(*options, "--schema", "schema", schemaPaths);
 
         // Crop it
-        six::XMLControlFactory::getInstance().addCreator<six::sidd::DerivedXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sidd::DerivedXMLControl>();
 
 
         six::sidd::cropSIDD(inPathname,

--- a/six/modules/c++/samples/test_create_sicd.cpp
+++ b/six/modules/c++/samples/test_create_sicd.cpp
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
         //        XMLControlRegistry xmlRegistry;
         //        xmlRegistry.addCreator<six::sicd::ComplexXMLControl>();
 
-        six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
         // Open a file with inputName
         io::FileInputStream inputFile(inputName);

--- a/six/modules/c++/samples/test_create_sicd_from_mem.cpp
+++ b/six/modules/c++/samples/test_create_sicd_from_mem.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
         std::unique_ptr<logging::Logger> logger(
                 logging::setupLogger(fs::path(argv[0]).filename().string()));
 
-        six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
         std::vector<six::zfloat > image(dims.row * dims.col);
 

--- a/six/modules/c++/samples/test_create_sidd.cpp
+++ b/six/modules/c++/samples/test_create_sidd.cpp
@@ -209,11 +209,8 @@ int main(int argc, char** argv)
 
     try
     {
-        six::XMLControlFactory::getInstance().
-            addCreator<six::sicd::ComplexXMLControl>();
-
-        six::XMLControlFactory::getInstance().
-            addCreator<six::sidd::DerivedXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sidd::DerivedXMLControl>();
 
         // Get a Complex Data structure from an XML file
         six::Options options;
@@ -225,7 +222,7 @@ int main(int argc, char** argv)
 
         std::unique_ptr<logging::Logger> log (new logging::NullLogger());
         six::Data* complexData =
-            six::XMLControlFactory::getInstance().newXMLControl(
+            six::getXMLControlFactory().newXMLControl(
                 six::DataType::COMPLEX,
                 log.get())->fromXML(parser.getDocument(),
                                     std::vector<std::string>());

--- a/six/modules/c++/samples/test_create_sidd_from_mem.cpp
+++ b/six/modules/c++/samples/test_create_sidd_from_mem.cpp
@@ -2525,9 +2525,8 @@ int main(int argc, char** argv)
         const bool smallImage = options->get<bool>("smallImage");
         const std::string strVersion = options->get<std::string>("version");
 
-        six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
-
-        six::XMLControlFactory::getInstance().addCreator<six::sidd::DerivedXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sidd::DerivedXMLControl>();
 
         // Output file name
         std::string outputName(options->get<std::string>("output"));
@@ -2572,7 +2571,7 @@ int main(int argc, char** argv)
             //------------------------------------------------------
             std::unique_ptr<logging::Logger> log(new logging::NullLogger());
             sicdData.reset(reinterpret_cast<six::sicd::ComplexData*>(
-                    six::XMLControlFactory::getInstance()
+                    six::getXMLControlFactory()
                             .newXMLControl(six::DataType::COMPLEX, log.get())
                             ->fromXML(parser.getDocument(),
                                       std::vector<std::string>())));

--- a/six/modules/c++/samples/test_parse_xml.cpp
+++ b/six/modules/c++/samples/test_parse_xml.cpp
@@ -67,9 +67,8 @@ void preview(const fs::path& outputFile)
  */
 void registerHandlers()
 {
-
-    six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
-    six::XMLControlFactory::getInstance().addCreator<six::sidd::DerivedXMLControl>();
+    six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
+    six::getXMLControlFactory().addCreator<six::sidd::DerivedXMLControl>();
 }
 /*
  * Dump all files out to the local directory
@@ -157,8 +156,7 @@ void run(const fs::path& inputFile_, std::string dataType)
                                                 : six::DataType::DERIVED;
 
         logging::NullLogger log;
-        six::XMLControl *control =
-                six::XMLControlFactory::getInstance().newXMLControl(dt, &log);
+        six::XMLControl *control = six::getXMLControlFactory().newXMLControl(dt, &log);
 
         six::Data *data = control->fromXML(treeBuilder.getDocument(),
                                            std::vector<std::string>());

--- a/six/modules/c++/samples/update_sicd_version.cpp
+++ b/six/modules/c++/samples/update_sicd_version.cpp
@@ -41,7 +41,7 @@ void writeSicd(std::unique_ptr<six::Data>&& complexData,
                const std::vector<std::string>& schemaPaths_,
                const std::string& pathname)
 {
-    six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+    six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
     mem::SharedPtr<six::Container> container(new six::Container(
         six::DataType::COMPLEX));

--- a/six/modules/c++/samples/update_sidd_version.cpp
+++ b/six/modules/c++/samples/update_sidd_version.cpp
@@ -125,7 +125,7 @@ int main(int argc, char** argv)
             schemaPaths.push_back(options->get<std::string>("schema"));
         }
 
-        six::XMLControlFactory::getInstance().addCreator<six::sidd::DerivedXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sidd::DerivedXMLControl>();
 
         std::unique_ptr<six::sidd::DerivedData> derivedData;
         std::vector<std::byte> widebandData;

--- a/six/modules/c++/scene/include/scene/AdjustableParams.h
+++ b/six/modules/c++/scene/include/scene/AdjustableParams.h
@@ -19,17 +19,19 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_ADJUSTABLE_PARAMS_H__
 #define __SCENE_ADJUSTABLE_PARAMS_H__
 
 #include <string>
 
 #include <scene/Types.h>
+#include <scene/Exports.h>
 
 namespace scene
 {
 // These should be in RIC_ECF
-struct AdjustableParams
+struct SIX_SCENE_API AdjustableParams
 {
     enum ParamsEnum
     {

--- a/six/modules/c++/scene/include/scene/CoordinateTransform.h
+++ b/six/modules/c++/scene/include/scene/CoordinateTransform.h
@@ -19,19 +19,21 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_COORDINATE_TRANSFORM_H__
 #define __SCENE_COORDINATE_TRANSFORM_H__
 
-#include <std/memory>
+#include <memory>
 
 #include "scene/Types.h"
 #include "scene/EllipsoidModel.h"
+#include "scene/Exports.h"
 
 
 namespace scene
 {
 
-struct CoordinateTransform
+struct SIX_SCENE_API CoordinateTransform
 {
     /**
      * Default constructor initializes the CoordinateTransform object with

--- a/six/modules/c++/scene/include/scene/ECEFToLLATransform.h
+++ b/six/modules/c++/scene/include/scene/ECEFToLLATransform.h
@@ -19,15 +19,17 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_ECEF_TO_LLA_TRANSFORM_H__
 #define __SCENE_ECEF_TO_LLA_TRANSFORM_H__
 
 #include "scene/CoordinateTransform.h"
+#include "scene/Exports.h"
 
 namespace scene
 {
 
-struct ECEFToLLATransform : public CoordinateTransform
+struct SIX_SCENE_API ECEFToLLATransform : public CoordinateTransform
 {
     /**
      * This constructor just calls the base class constructor

--- a/six/modules/c++/scene/include/scene/EllipsoidModel.h
+++ b/six/modules/c++/scene/include/scene/EllipsoidModel.h
@@ -19,17 +19,19 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_ELLIPSOID_MODEL_H__
 #define __SCENE_ELLIPSOID_MODEL_H__
 
 #include <std/optional>
 
 #include "scene/Types.h"
+#include "scene/Exports.h"
 
 namespace scene
 {
 
-struct EllipsoidModel
+struct SIX_SCENE_API EllipsoidModel
 {
     EllipsoidModel() = default;
 
@@ -150,7 +152,7 @@ protected:
     double polarRadius = 0.0;
 };
 
-class WGS84EllipsoidModel : public EllipsoidModel
+class SIX_SCENE_API WGS84EllipsoidModel : public EllipsoidModel
 {
 public:
     static const double EQUATORIAL_RADIUS_METERS;

--- a/six/modules/c++/scene/include/scene/Errors.h
+++ b/six/modules/c++/scene/include/scene/Errors.h
@@ -19,16 +19,18 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_ERRORS_H__
 #define __SCENE_ERRORS_H__
 
 #include <scene/sys_Conf.h>
 #include <math/linear/MatrixMxN.h>
 #include <scene/FrameType.h>
+#include <scene/Exports.h>
 
 namespace scene
 {
-struct Errors
+struct SIX_SCENE_API Errors
 {
     Errors() = default;
 

--- a/six/modules/c++/scene/include/scene/Exports.h
+++ b/six/modules/c++/scene/include/scene/Exports.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "config/compiler_extensions.h"
+
+// Need to specify how this code will be consumed, either SIX_SCENE_LIB_ (static library)
+// or SIX_SCENE_DLL_ (aka "shared" library).  For DLLs, it needs to be set for BOTH
+// "exporting" (building this code) and "importing" (consuming).
+//
+// Use Windows naming conventions (DLL, LIB) because this really only matters for _MSC_VER, see below.
+#if !defined(SIX_SCENE_LIB_) && !defined(SIX_SCENE_DLL_)
+    #if CODA_OSS_LIBRARY_SHARED
+        #if CODA_OSS_LIBRARY_STATIC
+            #error "CODA_OSS_LIBRARY_SHARED already #define'd'"
+        #endif
+        #define SIX_SCENE_DLL_ 1  // Symbols must be exported and imported (see below).
+    #else
+        // CODA_OSS_LIBRARY_STATIC doesn't have to be defined
+        #define SIX_SCENE_LIB_ 1  // Static library, all symbols visible.
+    #endif
+#endif
+#if !defined(SIX_SCENE_LIB_) && !defined(SIX_SCENE_DLL_)
+    #error "One of SIX_SCENE_LIB_ pr SIX_SCENE_DLL_ must be #define'd'"
+#endif
+#if defined(SIX_SCENE_LIB_) && defined(SIX_SCENE_DLL_)
+    #error "Both SIX_SCENE_LIB_ and SIX_SCENE_DLL_ are #define'd'"
+#endif
+#if defined(SIX_SCENE_EXPORTS) && defined(SIX_SCENE_LIB_)
+    #error "Can't export from a LIB'"
+#endif
+
+// The following ifdef block is the standard way of creating macros which make exporting
+// from a DLL simpler. All files within this DLL are compiled with the SIX_SCENE_EXPORTS
+// symbol defined on the command line. This symbol should not be defined on any project
+// that uses this DLL. This way any other project whose source files include this file see
+// SIX_SCENE_API functions as being imported from a DLL, whereas this DLL sees symbols
+// defined with this macro as being exported.
+// https://www.gnu.org/software/gnulib/manual/html_node/Exported-Symbols-of-Shared-Libraries.html
+#ifdef SIX_SCENE_EXPORTS
+    #define SIX_SCENE_API CODA_OSS_library_export
+#else
+    // Either building a static library (no SIX_SCENE_EXPORTS) or
+    // importing (not building) a shared library.
+
+    // We need to know whether we're consuming (importing) a DLL or static LIB
+    // The default is a static LIB as that's what existing code/builds expect.
+    #ifdef SIX_SCENE_DLL_
+        // Actually, it seems that the linker is able to figure this out from the .LIB, so 
+        // there doesn't seem to be a need for __declspec(dllimport).  Clients don't
+        // need to #define SIX_SCENE_DLL_ ... ?  Well, almost ... it looks
+        // like __declspec(dllimport) is needed to get virtual "inline"s (e.g., 
+        // destructors) correct.
+        #define SIX_SCENE_API CODA_OSS_library_import
+    #else
+        #define SIX_SCENE_API /* "importing" a static LIB */
+    #endif
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4251) // '...' : class '...' needs to have dll-interface to be used by clients of struct '...'
+#endif

--- a/six/modules/c++/scene/include/scene/FrameType.h
+++ b/six/modules/c++/scene/include/scene/FrameType.h
@@ -19,19 +19,21 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_FRAME_TYPE_H__
 #define __SCENE_FRAME_TYPE_H__
-#pragma once
 
 #include <string>
 #include <ostream>
+
+#include "scene/Exports.h"
 
 namespace scene
 {
 // NOTE: These enums and strings must exactly match what is in the SIX
 //       standard.  Since the scene module needs this concept as well though,
 //       it's present here.
-struct FrameType final
+struct SIX_SCENE_API FrameType final
 {
     //! The enumerations allowed
     enum FrameTypesEnum

--- a/six/modules/c++/scene/include/scene/GridECEFTransform.h
+++ b/six/modules/c++/scene/include/scene/GridECEFTransform.h
@@ -19,11 +19,13 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_GRID_ECEF_TRANSFORM_H__
 #define __SCENE_GRID_ECEF_TRANSFORM_H__
 
 #include <types/RowCol.h>
 #include <scene/Types.h>
+#include <scene/Exports.h>
 
 namespace scene
 {
@@ -32,7 +34,7 @@ namespace scene
  * \brief Used to convert from row/col pixel space to ECEF space and vice
  * versa
  */
-class GridECEFTransform
+class SIX_SCENE_API GridECEFTransform
 {
 public:
     virtual ~GridECEFTransform();
@@ -71,7 +73,7 @@ public:
  * \class PlanarGridECEFTransform
  * \brief Implementation for a planar gridded display (PGD)
  */
-class PlanarGridECEFTransform : public GridECEFTransform
+class SIX_SCENE_API PlanarGridECEFTransform : public GridECEFTransform
 {
 public:
     /*
@@ -118,7 +120,7 @@ private:
  * \class CylindricalGridECEFTransform
  * \brief Implementation for a cylindrical gridded display (CGD)
  */
-class CylindricalGridECEFTransform : public GridECEFTransform
+class SIX_SCENE_API CylindricalGridECEFTransform : public GridECEFTransform
 {
 public:
     CylindricalGridECEFTransform(const types::RowCol<double>& sampleSpacing,
@@ -149,7 +151,7 @@ private:
  * \class GeographicRowColECEFTransform
  * \brief Implementation for a geographic gridded display (GGD)
  */
-struct GeographicGridECEFTransform : public GridECEFTransform
+struct SIX_SCENE_API GeographicGridECEFTransform : public GridECEFTransform
 {
     GeographicGridECEFTransform(const types::RowCol<double>& sampleSpacing,
                                 const types::RowCol<double>& sceneCenter,

--- a/six/modules/c++/scene/include/scene/GridGeometry.h
+++ b/six/modules/c++/scene/include/scene/GridGeometry.h
@@ -19,17 +19,19 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_GRID_GEOMETRY_H__
 #define __SCENE_GRID_GEOMETRY_H__
 
 #include "scene/Types.h"
+#include "scene/Exports.h"
 
 #include <math/poly/OneD.h>
 #include <math/poly/TwoD.h>
 
 namespace scene
 {
-class GridGeometry
+class SIX_SCENE_API GridGeometry
 {
 public:
     enum { MAX_ITER = 50 };
@@ -53,7 +55,7 @@ public:
 };
 
 
-class PlanarGridGeometry : public GridGeometry
+class SIX_SCENE_API PlanarGridGeometry : public GridGeometry
 {
 public:
     PlanarGridGeometry(const Vector3& row,

--- a/six/modules/c++/scene/include/scene/LLAToECEFTransform.h
+++ b/six/modules/c++/scene/include/scene/LLAToECEFTransform.h
@@ -19,16 +19,19 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_LLA_TO_ECEF_TRANSFORM_H__
 #define __SCENE_LLA_TO_ECEF_TRANSFORM_H__
 
-#include "scene/CoordinateTransform.h"
 #include <sstream>
+
+#include "scene/CoordinateTransform.h"
+#include "scene/Exports.h"
 
 namespace scene
 {
 
-struct LLAToECEFTransform : public CoordinateTransform
+struct SIX_SCENE_API LLAToECEFTransform : public CoordinateTransform
 {
     /**
      * This constructor just calls the base class constructor

--- a/six/modules/c++/scene/include/scene/ProjectionModel.h
+++ b/six/modules/c++/scene/include/scene/ProjectionModel.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_PROJECTION_MODEL_H__
 #define __SCENE_PROJECTION_MODEL_H__
 
@@ -31,10 +32,11 @@
 #include <scene/GridECEFTransform.h>
 #include <scene/AdjustableParams.h>
 #include <scene/Errors.h>
+#include <scene/Exports.h>
 
 namespace scene
 {
-class ProjectionModel
+class SIX_SCENE_API ProjectionModel
 {
 public:
     enum { MAX_ITER = 50 };
@@ -368,7 +370,7 @@ protected:
     Errors mErrors;
 };
 
-class ProjectionModelWithImageVectors : public ProjectionModel
+class SIX_SCENE_API ProjectionModelWithImageVectors : public ProjectionModel
 {
 public:
     ProjectionModelWithImageVectors(
@@ -392,7 +394,7 @@ protected:
     Vector3 mImagePlaneColVector;
 };
 
-class RangeAzimProjectionModel : public ProjectionModelWithImageVectors
+class SIX_SCENE_API RangeAzimProjectionModel : public ProjectionModelWithImageVectors
 {
 public:
     RangeAzimProjectionModel(const math::poly::OneD<double>& polarAnglePoly,
@@ -420,7 +422,7 @@ private:
     math::poly::OneD<double> mKSFPolyPrime;
 };
 
-class RangeZeroProjectionModel : public ProjectionModelWithImageVectors
+class SIX_SCENE_API RangeZeroProjectionModel : public ProjectionModelWithImageVectors
 {
 public:
     RangeZeroProjectionModel(const math::poly::OneD<double>& timeCAPoly,
@@ -448,7 +450,7 @@ private:
     double mRangeCA;
 };
 
-class PlaneProjectionModel : public ProjectionModelWithImageVectors
+class SIX_SCENE_API PlaneProjectionModel : public ProjectionModelWithImageVectors
 {
 public:
     PlaneProjectionModel(const Vector3& slantPlaneNormal,
@@ -471,7 +473,7 @@ public:
 typedef PlaneProjectionModel XRGYCRProjectionModel;
 typedef PlaneProjectionModel XCTYATProjectionModel;
 
-class GeodeticProjectionModel : public ProjectionModel
+class SIX_SCENE_API GeodeticProjectionModel : public ProjectionModel
 {
 public:
     GeodeticProjectionModel(const Vector3& slantPlaneNormal,

--- a/six/modules/c++/scene/include/scene/ProjectionPolynomialFitter.h
+++ b/six/modules/c++/scene/include/scene/ProjectionPolynomialFitter.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_PROJECTION_POLYNOMIAL_FITTER_H__
 #define __SCENE_PROJECTION_POLYNOMIAL_FITTER_H__
 
@@ -26,6 +27,7 @@
 #include <scene/GridECEFTransform.h>
 #include <scene/ProjectionModel.h>
 #include <math/linear/Matrix2D.h>
+#include <scene/Exports.h>
 
 namespace scene
 {
@@ -35,7 +37,7 @@ namespace scene
  * sampling sceneToImage() across the output plane
  * versa
  */
-class ProjectionPolynomialFitter
+class SIX_SCENE_API ProjectionPolynomialFitter
 {
 public:
     static const size_t DEFAULTS_POINTS_1D;

--- a/six/modules/c++/scene/include/scene/SceneGeometry.h
+++ b/six/modules/c++/scene/include/scene/SceneGeometry.h
@@ -19,18 +19,20 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_SCENE_GEOMETRY_H__
 #define __SCENE_SCENE_GEOMETRY_H__
 
 #include <scene/sys_Conf.h>
 #include <mem/ScopedCopyablePtr.h>
 #include <scene/Types.h>
+#include <scene/Exports.h>
 #include <types/RgAz.h>
 #include <types/RowCol.h>
 
 namespace scene
 {
-class SceneGeometry
+class SIX_SCENE_API SceneGeometry
 {
 public:
     /*!

--- a/six/modules/c++/scene/include/scene/Types.h
+++ b/six/modules/c++/scene/include/scene/Types.h
@@ -35,6 +35,7 @@
 #include "math/linear/VectorN.h"
 
 #include "scene/sys_Conf.h"
+#include "scene/Exports.h"
 
 namespace scene
 {
@@ -69,7 +70,7 @@ namespace scene
         XYZ_X, XYZ_Y, XYZ_Z
     };
 
-    struct AngleMagnitude
+    struct SIX_SCENE_API AngleMagnitude
     {
         AngleMagnitude() = default;
         AngleMagnitude(double _angle, double _magnitude = 0) :
@@ -91,7 +92,7 @@ namespace scene
     };
 
     struct LatLonAlt;
-    struct LatLon
+    struct SIX_SCENE_API LatLon
     {
         LatLon() = default;
         LatLon(double scalar) :
@@ -189,7 +190,7 @@ namespace scene
         double mLon = 0.0;
     };
 
-    struct LatLonAlt : public LatLon
+    struct SIX_SCENE_API LatLonAlt : public LatLon
     {
         LatLonAlt() = default;
         LatLonAlt(double scalar) : LatLon(scalar), mAlt(scalar)

--- a/six/modules/c++/scene/include/scene/Utilities.h
+++ b/six/modules/c++/scene/include/scene/Utilities.h
@@ -19,16 +19,18 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SCENE_UTILITIES_H__
 #define __SCENE_UTILITIES_H__
 
 #include "scene/Types.h"
+#include "scene/Exports.h"
 
 namespace scene
 {
     struct GeographicGridECEFTransform;
 
-struct Utilities
+struct SIX_SCENE_API Utilities final
 {
     /*!
      *  Convert a lat/lon to ECEF. This method returns a

--- a/six/modules/c++/scene/scene.vcxproj
+++ b/six/modules/c++/scene/scene.vcxproj
@@ -19,12 +19,12 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v143</PlatformToolset>
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED;SIX_SCENE_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -81,7 +81,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED;SIX_SCENE_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -110,6 +110,7 @@
     <ClInclude Include="include\scene\ECEFToLLATransform.h" />
     <ClInclude Include="include\scene\EllipsoidModel.h" />
     <ClInclude Include="include\scene\Errors.h" />
+    <ClInclude Include="include\scene\Exports.h" />
     <ClInclude Include="include\scene\FrameType.h" />
     <ClInclude Include="include\scene\GridECEFTransform.h" />
     <ClInclude Include="include\scene\GridGeometry.h" />
@@ -143,6 +144,17 @@
     <ClCompile Include="source\SceneGeometry.cpp" />
     <ClCompile Include="source\Types.cpp" />
     <ClCompile Include="source\Utilities.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\externals\coda-oss\modules\c++\coda-oss.vcxproj">
+      <Project>{9997e895-5161-4ddf-8f3f-099894cb2f21}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c++\nitf-c++.vcxproj">
+      <Project>{8f357a19-799e-4971-850e-3f28485c130b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c\nitf-c.vcxproj">
+      <Project>{f06550ad-cfc7-40b8-8727-6c82c69a8982}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/six/modules/c++/scene/scene.vcxproj.filters
+++ b/six/modules/c++/scene/scene.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClInclude Include="include\scene\sys_Conf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\scene\Exports.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/six/modules/c++/six.convert/include/six/convert/Exports.h
+++ b/six/modules/c++/six.convert/include/six/convert/Exports.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "config/compiler_extensions.h"
+
+// Need to specify how this code will be consumed, either SIX_CONVERT_LIB_ (static library)
+// or SIX_CONVERT_DLL_ (aka "shared" library).  For DLLs, it needs to be set for BOTH
+// "exporting" (building this code) and "importing" (consuming).
+//
+// Use Windows naming conventions (DLL, LIB) because this really only matters for _MSC_VER, see below.
+#if !defined(SIX_CONVERT_LIB_) && !defined(SIX_CONVERT_DLL_)
+    #if CODA_OSS_LIBRARY_SHARED
+        #if CODA_OSS_LIBRARY_STATIC
+            #error "CODA_OSS_LIBRARY_SHARED already #define'd'"
+        #endif
+        #define SIX_CONVERT_DLL_ 1  // Symbols must be exported and imported (see below).
+    #else
+        // CODA_OSS_LIBRARY_STATIC doesn't have to be defined
+        #define SIX_CONVERT_LIB_ 1  // Static library, all symbols visible.
+    #endif
+#endif
+#if !defined(SIX_CONVERT_LIB_) && !defined(SIX_CONVERT_DLL_)
+    #error "One of SIX_CONVERT_LIB_ pr SIX_CONVERT_DLL_ must be #define'd'"
+#endif
+#if defined(SIX_CONVERT_LIB_) && defined(SIX_CONVERT_DLL_)
+    #error "Both SIX_CONVERT_LIB_ and SIX_CONVERT_DLL_ are #define'd'"
+#endif
+#if defined(SIX_CONVERT_EXPORTS) && defined(SIX_CONVERT_LIB_)
+    #error "Can't export from a LIB'"
+#endif
+
+// The following ifdef block is the standard way of creating macros which make exporting
+// from a DLL simpler. All files within this DLL are compiled with the SIX_CONVERT_EXPORTS
+// symbol defined on the command line. This symbol should not be defined on any project
+// that uses this DLL. This way any other project whose source files include this file see
+// SIX_CONVERT_API functions as being imported from a DLL, whereas this DLL sees symbols
+// defined with this macro as being exported.
+// https://www.gnu.org/software/gnulib/manual/html_node/Exported-Symbols-of-Shared-Libraries.html
+#ifdef SIX_CONVERT_EXPORTS
+    #define SIX_CONVERT_API CODA_OSS_library_export
+#else
+    // Either building a static library (no SIX_CONVERT_EXPORTS) or
+    // importing (not building) a shared library.
+
+    // We need to know whether we're consuming (importing) a DLL or static LIB
+    // The default is a static LIB as that's what existing code/builds expect.
+    #ifdef SIX_CONVERT_DLL_
+        // Actually, it seems that the linker is able to figure this out from the .LIB, so 
+        // there doesn't seem to be a need for __declspec(dllimport).  Clients don't
+        // need to #define SIX_CONVERT_DLL_ ... ?  Well, almost ... it looks
+        // like __declspec(dllimport) is needed to get virtual "inline"s (e.g., 
+        // destructors) correct.
+        #define SIX_CONVERT_API CODA_OSS_library_import
+    #else
+        #define SIX_CONVERT_API /* "importing" a static LIB */
+    #endif
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4251) // '...' : class '...' needs to have dll-interface to be used by clients of struct '...'
+#endif

--- a/six/modules/c++/six.convert/six.convert.vcxproj
+++ b/six/modules/c++/six.convert/six.convert.vcxproj
@@ -19,12 +19,12 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -50,7 +50,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; SIX_CONVERT_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -79,7 +79,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; SIX_CONVERT_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -107,6 +107,7 @@
     <ClInclude Include="include\six\convert\ConverterProvider.h" />
     <ClInclude Include="include\six\convert\ConverterProviderRegistry.h" />
     <ClInclude Include="include\six\convert\ConvertingReadControl.h" />
+    <ClInclude Include="include\six\convert\Exports.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
@@ -119,6 +120,9 @@
     <ClCompile Include="source\ConvertingReadControl.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\externals\coda-oss\modules\c++\coda-oss.vcxproj">
+      <Project>{9997e895-5161-4ddf-8f3f-099894cb2f21}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\externals\nitro\modules\c++\nitf-c++.vcxproj">
       <Project>{8f357a19-799e-4971-850e-3f28485c130b}</Project>
     </ProjectReference>

--- a/six/modules/c++/six.convert/six.convert.vcxproj.filters
+++ b/six/modules/c++/six.convert/six.convert.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="include\six\convert\ConvertingReadControl.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\six\convert\Exports.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/six/modules/c++/six.sicd/include/six/sicd/Antenna.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Antenna.h
@@ -33,6 +33,8 @@
 #include "six/Parameter.h"
 #include "six/XsElement.h"
 
+#include "six/sicd/Exports.h"
+
 #include <mem/ScopedCopyablePtr.h>
 
 namespace six
@@ -47,7 +49,7 @@ namespace sicd
  *  the DCXPoly is the EB sterring x-axis direction
  *  cosine (DCX) as a function of slow time
  */
-struct ElectricalBoresight final
+struct SIX_SICD_API ElectricalBoresight final
 {
     //! Constructor
     ElectricalBoresight();
@@ -75,7 +77,7 @@ struct ElectricalBoresight final
     six::XsElement_minOccurs0<bool> useEBPVP{ "UseEBPVP" };
 };
 
-std::ostream& operator<< (std::ostream& os, const ElectricalBoresight& d);
+SIX_SICD_API std::ostream& operator<< (std::ostream& os, const ElectricalBoresight& d);
 
 /*!
  *  \struct HalfPowerBeamwidths
@@ -86,7 +88,7 @@ std::ostream& operator<< (std::ostream& os, const ElectricalBoresight& d);
  *
  *  Removed in 1.0.0
  */
-struct HalfPowerBeamwidths
+struct SIX_SICD_API HalfPowerBeamwidths
 {
     //! Constructor
     HalfPowerBeamwidths();
@@ -119,7 +121,7 @@ std::ostream& operator<< (std::ostream& os, const HalfPowerBeamwidths& d);
  *  electronically steered arrays, the EB is steered to
  *  DCX = 0, DCY = 0.
  */
-struct GainAndPhasePolys final
+struct SIX_SICD_API GainAndPhasePolys final
 {
     //! No init right now, could do that and set const coef to zero
     GainAndPhasePolys();
@@ -148,14 +150,14 @@ struct GainAndPhasePolys final
     six::XsElement_minOccurs0<std::u8string> antGPId {"AntGPId"};  // new in CPHD 1.1.0
 };
 
-std::ostream& operator<< (std::ostream& os, const GainAndPhasePolys& d);
+SIX_SICD_API std::ostream& operator<< (std::ostream& os, const GainAndPhasePolys& d);
 
 /*!
  *  \struct AntennaParameters
  *  \brief SICD Tx/Rcv, etc Antenna parameter
  *
  */
-struct AntennaParameters
+struct SIX_SICD_API AntennaParameters
 {
 
     //!  Constructor
@@ -223,7 +225,7 @@ struct AntennaParameters
     BooleanType mainlobeFrequencyDilation;
 };
 
-std::ostream& operator<< (std::ostream& os, const AntennaParameters& d);
+SIX_SICD_API std::ostream& operator<< (std::ostream& os, const AntennaParameters& d);
 
 /*!
  *  \struct Antenna
@@ -237,7 +239,7 @@ std::ostream& operator<< (std::ostream& os, const AntennaParameters& d);
  *  and the receieve (Rcv) antenna.  A single set of prarameters may
  *  be provided for a combined two-way pattern (as appropriate)
  */
-struct Antenna
+struct SIX_SICD_API Antenna
 {
     //! Transmit parameters
     mem::ScopedCopyablePtr<AntennaParameters> tx;

--- a/six/modules/c++/six.sicd/include/six/sicd/AreaPlaneUtility.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/AreaPlaneUtility.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_SICD_AREA_PLANE_UTILITY_H__
 #define __SIX_SICD_AREA_PLANE_UTILITY_H__
 
@@ -27,6 +28,7 @@
 #include <six/Types.h>
 #include <six/sicd/ComplexData.h>
 #include <six/sicd/RadarCollection.h>
+#include <six/sicd/Exports.h>
 
 #include <types/RgAz.h>
 #include <types/RowCol.h>
@@ -40,7 +42,7 @@ namespace sicd
  * \brief Provides functions to populate
  * ComplexData->RadarCollection->Area->Plane if unset
  */
-class AreaPlaneUtility
+class SIX_SICD_API AreaPlaneUtility
 {
 public:
     /*!

--- a/six/modules/c++/six.sicd/include/six/sicd/ComplexData.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ComplexData.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_sicd_ComplexData_h_INCLUDED_
 #define SIX_sicd_ComplexData_h_INCLUDED_
-#pragma once
 
 #include <memory>
 #include <vector>
@@ -48,6 +48,7 @@
 #include "six/sicd/PFA.h"
 #include "six/sicd/RMA.h"
 #include "six/sicd/RgAzComp.h"
+#include "six/sicd/Exports.h"
 
 namespace six
 {
@@ -73,7 +74,7 @@ namespace sicd
  *
  *
  */
-struct ComplexData: public Data
+struct SIX_SICD_API ComplexData: public Data
 {
     //!  CollectionInfo block.  Contains the general collection information
     mem::ScopedCloneablePtr<CollectionInformation> collectionInformation;
@@ -397,7 +398,7 @@ private:
     std::string mVersion;
 };
 
-struct ComplexImageResult final
+struct SIX_SICD_API ComplexImageResult final
 {
     std::unique_ptr<ComplexData> pComplexData;
     std::vector<six::zfloat> widebandData;
@@ -407,7 +408,7 @@ struct ComplexImageResult final
     ComplexImageResult(ComplexImageResult&&) = default;
     ComplexImageResult& operator=(ComplexImageResult&&) = default;
 };
-struct ComplexImage final
+struct SIX_SICD_API ComplexImage final
 {
     const ComplexData& data;
     std::span<const six::zfloat> image;

--- a/six/modules/c++/six.sicd/include/six/sicd/ComplexXMLControl.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ComplexXMLControl.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_COMPLEX_XML_CONTROL_H__
 #define __SIX_COMPLEX_XML_CONTROL_H__
 
@@ -28,6 +29,7 @@
 #include <six/Enums.h>
 
 #include <six/sicd/ComplexXMLParser.h>
+#include <six/sicd/Exports.h>
 
 namespace six
 {
@@ -48,7 +50,7 @@ namespace sicd
  *  XMLControlFactory::newXMLControl() methods
  *  to create this object.
  */
-struct ComplexXMLControl : public XMLControl
+struct SIX_SICD_API ComplexXMLControl : public XMLControl
 {
     //!  Constructor
     ComplexXMLControl(logging::Logger* log = nullptr, bool ownLog = false);

--- a/six/modules/c++/six.sicd/include/six/sicd/CropUtils.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/CropUtils.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __SIX_SICD_CROP_UTILS_H__
 #define __SIX_SICD_CROP_UTILS_H__
 
@@ -29,6 +29,7 @@
 #include <scene/Types.h>
 #include <six/NITFReadControl.h>
 #include <six/sicd/ComplexData.h>
+#include <six/sicd/Exports.h>
 
 namespace six
 {
@@ -44,7 +45,7 @@ namespace sicd
  * \param aoiDims Size of AOI
  * \param outPathname Output cropped SICD pathname
  */
-void cropSICD(const std::string& inPathname,
+SIX_SICD_API void cropSICD(const std::string& inPathname,
               const std::vector<std::string>& schemaPaths,
               const types::RowCol<size_t>& aoiOffset,
               const types::RowCol<size_t>& aoiDims,
@@ -54,7 +55,7 @@ void cropSICD(const std::string& inPathname,
  * Same as above but allow an already-opened reader to be used.
  * NITFReadControl::load() must be called prior to calling this function.
  */
-void cropSICD(six::NITFReadControl& reader,
+SIX_SICD_API void cropSICD(six::NITFReadControl& reader,
               const std::vector<std::string>& schemaPaths,
               const types::RowCol<size_t>& aoiOffset,
               const types::RowCol<size_t>& aoiDims,
@@ -74,7 +75,7 @@ void cropSICD(six::NITFReadControl& reader,
  * be in-bounds (and the SICD metadata will reflect this).  If this is false,
  * an exception will be thrown.
  */
-void cropSICD(const std::string& inPathname,
+SIX_SICD_API void cropSICD(const std::string& inPathname,
               const std::vector<std::string>& schemaPaths,
               const std::vector<scene::Vector3>& corners,
               const std::string& outPathname,
@@ -84,7 +85,7 @@ void cropSICD(const std::string& inPathname,
  * Same as above but allow an already-opened reader to be used.
  * NITFReadControl::load() must be called prior to calling this function.
  */
-void cropSICD(six::NITFReadControl& reader,
+SIX_SICD_API void cropSICD(six::NITFReadControl& reader,
               const std::vector<std::string>& schemaPaths,
               const std::vector<scene::Vector3>& corners,
               const std::string& outPathname,
@@ -100,7 +101,7 @@ void cropSICD(six::NITFReadControl& reader,
  * rectangular in the slant plane, an AOI will be exscribed from these
  * \param outPathname Output cropped SICD pathname
  */
-void cropSICD(const std::string& inPathname,
+SIX_SICD_API void cropSICD(const std::string& inPathname,
               const std::vector<std::string>& schemaPaths,
               const std::vector<scene::LatLonAlt>& corners,
               const std::string& outPathname,
@@ -110,7 +111,7 @@ void cropSICD(const std::string& inPathname,
  * Same as above but allow an already-opened reader to be used.
  * NITFReadControl::load() must be called prior to calling this function.
  */
-void cropSICD(six::NITFReadControl& reader,
+SIX_SICD_API void cropSICD(six::NITFReadControl& reader,
               const std::vector<std::string>& schemaPaths,
               const std::vector<scene::LatLonAlt>& corners,
               const std::string& outPathname,
@@ -126,7 +127,7 @@ void cropSICD(six::NITFReadControl& reader,
  * \returns A cloned complex data object where the 
  * meta data has been updated to reflect the cropped aoi.
  */
-std::unique_ptr<six::sicd::ComplexData>
+SIX_SICD_API std::unique_ptr<six::sicd::ComplexData>
 cropMetaData(const six::sicd::ComplexData& complexData,
              const types::RowCol<size_t>& aoiOffset,
              const types::RowCol<size_t>& aoiDims);

--- a/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/DataParser.h
@@ -35,12 +35,13 @@
 #include "six/Utilities.h"
 #include "six/XMLControlFactory.h"
 #include "six/sicd/ComplexData.h"
+#include "six/sicd/Exports.h"
 
 namespace six
 {
 namespace sicd
 {
-class DataParser final
+class SIX_SICD_API DataParser final
 {
     six::DataParser mDataParser;
 

--- a/six/modules/c++/six.sicd/include/six/sicd/Exports.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Exports.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "config/compiler_extensions.h"
+
+// Need to specify how this code will be consumed, either SIX_SICD_LIB_ (static library)
+// or SIX_SICD_DLL_ (aka "shared" library).  For DLLs, it needs to be set for BOTH
+// "exporting" (building this code) and "importing" (consuming).
+//
+// Use Windows naming conventions (DLL, LIB) because this really only matters for _MSC_VER, see below.
+#if !defined(SIX_SICD_LIB_) && !defined(SIX_SICD_DLL_)
+    #if CODA_OSS_LIBRARY_SHARED
+        #if CODA_OSS_LIBRARY_STATIC
+            #error "CODA_OSS_LIBRARY_SHARED already #define'd'"
+        #endif
+        #define SIX_SICD_DLL_ 1  // Symbols must be exported and imported (see below).
+    #else
+        // CODA_OSS_LIBRARY_STATIC doesn't have to be defined
+        #define SIX_SICD_LIB_ 1  // Static library, all symbols visible.
+    #endif
+#endif
+#if !defined(SIX_SICD_LIB_) && !defined(SIX_SICD_DLL_)
+    #error "One of SIX_SICD_LIB_ pr SIX_SICD_DLL_ must be #define'd'"
+#endif
+#if defined(SIX_SICD_LIB_) && defined(SIX_SICD_DLL_)
+    #error "Both SIX_SICD_LIB_ and SIX_SICD_DLL_ are #define'd'"
+#endif
+#if defined(SIX_SICD_EXPORTS) && defined(SIX_SICD_LIB_)
+    #error "Can't export from a LIB'"
+#endif
+
+// The following ifdef block is the standard way of creating macros which make exporting
+// from a DLL simpler. All files within this DLL are compiled with the SIX_SICD_EXPORTS
+// symbol defined on the command line. This symbol should not be defined on any project
+// that uses this DLL. This way any other project whose source files include this file see
+// SIX_SICD_API functions as being imported from a DLL, whereas this DLL sees symbols
+// defined with this macro as being exported.
+// https://www.gnu.org/software/gnulib/manual/html_node/Exported-Symbols-of-Shared-Libraries.html
+#ifdef SIX_SICD_EXPORTS
+    #define SIX_SICD_API CODA_OSS_library_export
+#else
+    // Either building a static library (no SIX_SICD_EXPORTS) or
+    // importing (not building) a shared library.
+
+    // We need to know whether we're consuming (importing) a DLL or static LIB
+    // The default is a static LIB as that's what existing code/builds expect.
+    #ifdef SIX_SICD_DLL_
+        // Actually, it seems that the linker is able to figure this out from the .LIB, so 
+        // there doesn't seem to be a need for __declspec(dllimport).  Clients don't
+        // need to #define SIX_SICD_DLL_ ... ?  Well, almost ... it looks
+        // like __declspec(dllimport) is needed to get virtual "inline"s (e.g., 
+        // destructors) correct.
+        #define SIX_SICD_API CODA_OSS_library_import
+    #else
+        #define SIX_SICD_API /* "importing" a static LIB */
+    #endif
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4251) // '...' : class '...' needs to have dll-interface to be used by clients of struct '...'
+#endif

--- a/six/modules/c++/six.sicd/include/six/sicd/GeoData.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/GeoData.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_GEO_DATA_H__
 #define __SIX_GEO_DATA_H__
 
@@ -28,6 +29,8 @@
 #include "six/GeoInfo.h"
 #include "scene/ProjectionModel.h"
 #include <logging/Logger.h>
+
+#include "six/sicd/Exports.h"
 
 namespace six
 {
@@ -43,7 +46,7 @@ struct ImageData;
  *
  *  Compiler-generated copy constructor and assignment operator are sufficient
  */
-class GeoData : public GeoDataBase
+class SIX_SICD_API GeoData : public GeoDataBase
 {
 public:
 

--- a/six/modules/c++/six.sicd/include/six/sicd/Grid.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Grid.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_six_sicd_Grid_h_INCLUDED_
 #define SIX_six_sicd_Grid_h_INCLUDED_
-#pragma once
 
 #include <logging/Logger.h>
 #include <mem/ScopedCopyablePtr.h>
@@ -36,6 +36,7 @@
 #include "six/sicd/ImageData.h"
 #include "six/sicd/RadarCollection.h"
 #include "six/sicd/RMA.h"
+#include "six/sicd/Exports.h"
 
 namespace six
 {
@@ -45,7 +46,7 @@ struct PFA;
 struct RgAzComp;
 struct SCPCOA;
 
-struct WeightType
+struct SIX_SICD_API WeightType
 {
     WeightType();
 
@@ -80,7 +81,7 @@ struct WeightType
  *  Parameters describing increasing row or column
  *  direction image coords
  */
-struct DirectionParameters
+struct SIX_SICD_API DirectionParameters
 {
     DirectionParameters();
     DirectionParameters* clone() const;
@@ -183,7 +184,7 @@ private:
  *  The block of parameters that describes the image sample grid
  *
  */
-struct Grid
+struct SIX_SICD_API Grid
 {
 
     //! TODO what to do with plane

--- a/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/ImageData.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_IMAGE_DATA_H__
 #define __SIX_IMAGE_DATA_H__
 
@@ -37,6 +38,8 @@
 #include "six/Init.h"
 #include "six/Parameter.h"
 
+#include "six/sicd/Exports.h"
+
 namespace six
 {
 namespace sicd
@@ -48,7 +51,7 @@ class GeoData;
  *
  *  This block describes image pixel data
  */
-struct ImageData
+struct SIX_SICD_API ImageData
 {
     //!  Everything is undefined at this time
     ImageData() = default;
@@ -109,6 +112,9 @@ struct ImageData
      */
     static const six::Amp8iPhs8iLookup_t& getLookup(const six::AmplitudeTable* pAmplitudeTable);
 };
+
+SIX_SICD_API const details::ComplexToAMP8IPHS8I& make_ComplexToAMP8IPHS8I(const six::AmplitudeTable*);
+SIX_SICD_API AMP8I_PHS8I_t nearest_neighbor(const details::ComplexToAMP8IPHS8I&, const six::zfloat& v);
 
 }
 }

--- a/six/modules/c++/six.sicd/include/six/sicd/NITFReadComplexXMLControl.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/NITFReadComplexXMLControl.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_sicd_NITFReadComplexXMLControl_h_INCLUDED_
 #define SIX_sicd_NITFReadComplexXMLControl_h_INCLUDED_
-#pragma once
 
 #include <vector>
 #include <std/filesystem>
@@ -36,12 +36,13 @@
 #include "six/Region.h"
 #include "six/sicd/ComplexData.h"
 #include "six/sicd/SICDMesh.h"
+#include "six/sicd/Exports.h"
 
 namespace six
 {
 	namespace sicd
 	{
-		class NITFReadComplexXMLControl final
+		class SIX_SICD_API NITFReadComplexXMLControl final
 		{
 			six::XMLControlRegistry xmlRegistry;
 			six::NITFReadControl reader;

--- a/six/modules/c++/six.sicd/include/six/sicd/PFA.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/PFA.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_PFA_H__
 #define __SIX_PFA_H__
 
@@ -29,6 +30,7 @@
 #include "six/sicd/GeoData.h"
 #include "six/sicd/Position.h"
 #include "six/sicd/SCPCOA.h"
+#include "six/sicd/Exports.h"
 
 namespace six
 {
@@ -42,7 +44,7 @@ struct Grid;
  *  Parameters to describe image domain slow time
  *  deskew processing.  Name changed for API consistency
  */
-struct SlowTimeDeskew
+struct SIX_SICD_API SlowTimeDeskew
 {
     //!  Constructor
     SlowTimeDeskew();
@@ -77,7 +79,7 @@ struct SlowTimeDeskew
  *  \note This is currently limited to a one item choice in SICD,
  *  which would make it hard to do anything else
  */
-struct PFA
+struct SIX_SICD_API PFA
 {
     //!  Constructor, nothing defined
     PFA();

--- a/six/modules/c++/six.sicd/include/six/sicd/Position.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Position.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_POSITION_H__
 #define __SIX_POSITION_H__
 
@@ -27,6 +28,8 @@
 #include "six/Types.h"
 #include "six/Init.h"
 #include "six/Parameter.h"
+
+#include "six/sicd/Exports.h"
 
 namespace six
 {
@@ -41,7 +44,7 @@ struct SCPCOA;
  *  Receive aperture phase center (APC).  The size of the vector
  *  of the vector the number of receive APC polys
  */
-struct RcvAPC
+struct SIX_SICD_API RcvAPC
 {
     //!  Constructor
     RcvAPC()
@@ -69,7 +72,7 @@ struct RcvAPC
  *  This block describes the platform and ground reference
  *  positions vs. time.
  */
-struct Position
+struct SIX_SICD_API Position
 {
     /*!
      *  Aperture reference point as a function of time in ECEF meters

--- a/six/modules/c++/six.sicd/include/six/sicd/RMA.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/RMA.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_RMA_H__
 #define __SIX_RMA_H__
 
@@ -31,6 +32,7 @@
 #include "six/sicd/GeoData.h"
 #include "six/sicd/Position.h"
 #include "six/sicd/SCPCOA.h"
+#include "six/sicd/Exports.h"
 
 namespace six
 {
@@ -42,7 +44,7 @@ namespace sicd
  *  \brief   Parameters for Range Migration with Along Track phase
  *           stabilization.
  */
-struct RMAT
+struct SIX_SICD_API RMAT
 {
     //!  Constructor
     RMAT();
@@ -109,7 +111,7 @@ private:
  *  Note: this is a repeat of parameters in RMAT but
  *        we recreate them to avoid confusion
  */
-struct RMCR
+struct SIX_SICD_API RMCR
 {
     //!  Constructor
     RMCR();
@@ -154,7 +156,7 @@ private:
  *  \struct  INCA
  *  \brief   Parameters for Imaging Near Closest Approach.
  */
-struct INCA
+struct SIX_SICD_API INCA
 {
     //!  Constructor
     INCA();
@@ -214,7 +216,7 @@ private:
  *  \brief   Range Migration Algorithm (RMA) parameters, included when
  *           the image is formed with RMA.
  */
-struct RMA
+struct SIX_SICD_API RMA
 {
     //! Constructor
     RMA();

--- a/six/modules/c++/six.sicd/include/six/sicd/RadarCollection.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/RadarCollection.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_RADAR_COLLECTION_H__
 #define __SIX_RADAR_COLLECTION_H__
 
@@ -30,6 +31,8 @@
 #include <mem/ScopedCloneablePtr.h>
 #include <logging/Logger.h>
 
+#include "six/sicd/Exports.h"
+
 namespace six
 {
 namespace sicd
@@ -40,7 +43,7 @@ namespace sicd
  *
  *  Represents a transmit sequence step
  */
-struct TxStep
+struct SIX_SICD_API TxStep
 {
     //!  Constructor
     TxStep();
@@ -77,7 +80,7 @@ struct TxStep
  *  indexed starting at 1 by the index, but this is stored in a vector
  *  and starts at zero as a result.  The serializer hides this.
  */
-struct WaveformParameters
+struct SIX_SICD_API WaveformParameters
 {
     //!  Constructor
     WaveformParameters();
@@ -140,7 +143,7 @@ private:
  *
  *  Parameters for a data channel.
  */
-struct ChannelParameters
+struct SIX_SICD_API ChannelParameters
 {
     //!  Constructor
     ChannelParameters();
@@ -183,7 +186,7 @@ struct ChannelParameters
  *  associated with a SICD.  It includes  the unit vector, the sample
  *  spacing, and the first element
  */
-struct AreaDirectionParameters
+struct SIX_SICD_API AreaDirectionParameters
 {
     //!  Constructor
     AreaDirectionParameters();
@@ -224,7 +227,7 @@ struct AreaDirectionParameters
     }
 };
 
-std::ostream& operator<< (std::ostream& os, const AreaDirectionParameters& d);
+SIX_SICD_API std::ostream& operator<< (std::ostream& os, const AreaDirectionParameters& d);
 
 /*!
  *  \struct Segment
@@ -239,7 +242,7 @@ std::ostream& operator<< (std::ostream& os, const AreaDirectionParameters& d);
  *
  *  Contains also the start line/sample and end/line sample for each segment
  */
-struct Segment
+struct SIX_SICD_API Segment
 {
     //!  Construct
     Segment();
@@ -328,7 +331,7 @@ struct Segment
  *  This object contains parameters describing a rectangular
  *  area in a geo-referenced display plane
  */
-struct AreaPlane
+struct SIX_SICD_API AreaPlane
 {
     /*!
      *  Constructor
@@ -420,7 +423,7 @@ struct AreaPlane
  *
  *  (Optional) Parameters describing the image area covered by the collection.
  */
-struct Area
+struct SIX_SICD_API Area
 {
 
     /*!
@@ -466,7 +469,7 @@ struct Area
  *  populated by the application developer.
  *
  */
-struct RadarCollection
+struct SIX_SICD_API RadarCollection
 {
 
     /*!

--- a/six/modules/c++/six.sicd/include/six/sicd/RgAzComp.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/RgAzComp.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_RG_AZ_COMP_H__
 #define __SIX_RG_AZ_COMP_H__
 
@@ -28,6 +29,7 @@
 #include "six/sicd/GeoData.h"
 #include "six/sicd/SCPCOA.h"
 #include "six/sicd/Timeline.h"
+#include "six/sicd/Exports.h"
 
 namespace six
 {
@@ -40,7 +42,7 @@ struct Timeline;
  *  \brief   Parameters included for a Range, Doppler image.
  *           Required parameters for ImageFormAlgo = RGAZCOMP.
  */
-struct RgAzComp
+struct SIX_SICD_API RgAzComp
 {
     //! Constructor
     RgAzComp() :

--- a/six/modules/c++/six.sicd/include/six/sicd/SCPCOA.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SCPCOA.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_SCPCOA_H__
 #define __SIX_SCPCOA_H__
 
@@ -27,6 +28,8 @@
 #include "six/Types.h"
 #include "six/Parameter.h"
 #include "scene/SceneGeometry.h"
+
+#include "six/sicd/Exports.h"
 
 namespace six
 {
@@ -41,7 +44,7 @@ struct Position;
  *
  *  Required parameters describing the COA for the scene center point
  */
-struct SCPCOA
+struct SIX_SICD_API SCPCOA
 {
 
     /*!

--- a/six/modules/c++/six.sicd/include/six/sicd/SICDVersionUpdater.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/SICDVersionUpdater.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_SICD_VERSION_UPDATER_H__
 #define __SIX_SICD_VERSION_UPDATER_H__
 
@@ -26,6 +27,7 @@
 #include <logging/Logger.h>
 #include <six/VersionUpdater.h>
 #include <six/sicd/ComplexData.h>
+#include <six/sicd/Exports.h>
 
 namespace six
 {
@@ -39,7 +41,7 @@ namespace sicd
  * updates. Some inserted fields will be valid XML but
  * mathematically garbage.
  */
-class SICDVersionUpdater : public VersionUpdater
+class SIX_SICD_API SICDVersionUpdater : public VersionUpdater
 {
 public:
     /*!

--- a/six/modules/c++/six.sicd/include/six/sicd/Timeline.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Timeline.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_TIMELINE_H__
 #define __SIX_TIMELINE_H__
 
@@ -26,6 +27,7 @@
 #include "six/Types.h"
 #include "six/Init.h"
 #include "six/Parameter.h"
+#include "six/sicd/Exports.h"
 
 namespace six
 {
@@ -38,7 +40,7 @@ namespace sicd
  *  Identifies a set of IPP parameters.  Minimum of 1 set of
  *  parameters are required for IPP
  */
-struct TimelineSet
+struct SIX_SICD_API TimelineSet
 {
     //!  Constructor
     TimelineSet();
@@ -75,7 +77,7 @@ struct TimelineSet
  *  Describes the interpulse period (IPP) parameters.  This section
  *  of SICD is optional, and contains one or more Sets (TimelineSet)
  */
-struct InterPulsePeriod
+struct SIX_SICD_API InterPulsePeriod
 {
     /*!
      *  Constructor.
@@ -109,7 +111,7 @@ struct InterPulsePeriod
  *  optional.
  *
  */
-struct Timeline
+struct SIX_SICD_API Timeline
 {
     //! Constructor
     Timeline();

--- a/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
+++ b/six/modules/c++/six.sicd/include/six/sicd/Utilities.h
@@ -37,12 +37,13 @@
 #include <six/sicd/SICDMesh.h>
 #include <six/NITFReadControl.h>
 #include <six/sicd/AreaPlaneUtility.h>
+#include <six/sicd/Exports.h>
 
 namespace six
 {
 namespace sicd
 {
-struct Utilities final
+struct SIX_SICD_API Utilities final
 {
     /*!
      * Build SceneGeometry from ComplexData members
@@ -646,7 +647,7 @@ struct Utilities final
 
 
 // c.f. six_sicd.i
-extern std::vector<std::byte> readFromNITF(const std::filesystem::path& pathname, const std::vector<std::filesystem::path>*,
+SIX_SICD_API std::vector<std::byte> readFromNITF(const std::filesystem::path& pathname, const std::vector<std::filesystem::path>*,
     std::unique_ptr<ComplexData>& pComplexData); 
 inline std::vector<std::byte> readFromNITF(const std::filesystem::path& pathname, const std::vector<std::filesystem::path>& schemaPaths,
     std::unique_ptr<ComplexData>& pComplexData)
@@ -659,15 +660,15 @@ inline std::vector<std::byte> readFromNITF(const std::filesystem::path& pathname
 }
 
 // c.f. six_sicd.i
-extern void writeAsNITF(const std::filesystem::path&, const std::vector<std::string>& schemaPaths, const ComplexData&, std::span<const six::zfloat> image);
-extern void writeAsNITF(const std::filesystem::path&, const std::vector<std::filesystem::path>& schemaPaths, const ComplexData&, std::span<const six::zfloat> image);
-extern void writeAsNITF(const std::filesystem::path&, const std::vector<std::filesystem::path>& schemaPaths, const ComplexImage&);
+SIX_SICD_API void writeAsNITF(const std::filesystem::path&, const std::vector<std::string>& schemaPaths, const ComplexData&, std::span<const six::zfloat> image);
+SIX_SICD_API void writeAsNITF(const std::filesystem::path&, const std::vector<std::filesystem::path>& schemaPaths, const ComplexData&, std::span<const six::zfloat> image);
+SIX_SICD_API void writeAsNITF(const std::filesystem::path&, const std::vector<std::filesystem::path>& schemaPaths, const ComplexImage&);
 
 
 namespace testing
 {
-    extern std::vector<six::zfloat> make_complex_image(const types::RowCol<size_t>&);
-    extern std::vector<std::byte> toBytes(const ComplexImageResult&);
+    SIX_SICD_API std::vector<six::zfloat> make_complex_image(const types::RowCol<size_t>&);
+    SIX_SICD_API std::vector<std::byte> toBytes(const ComplexImageResult&);
 }
 
 }

--- a/six/modules/c++/six.sicd/six.sicd.vcxproj
+++ b/six/modules/c++/six.sicd/six.sicd.vcxproj
@@ -19,12 +19,12 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_SICD_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -80,7 +80,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_SICD_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -120,6 +120,7 @@
     <ClInclude Include="include\six\sicd\ComplexXMLParser10x.h" />
     <ClInclude Include="include\six\sicd\CropUtils.h" />
     <ClInclude Include="include\six\sicd\DataParser.h" />
+    <ClInclude Include="include\six\sicd\Exports.h" />
     <ClInclude Include="include\six\sicd\Functor.h" />
     <ClInclude Include="include\six\sicd\GeoData.h" />
     <ClInclude Include="include\six\sicd\GeoLocator.h" />
@@ -184,6 +185,23 @@
     <ClCompile Include="source\SlantPlanePixelTransformer.cpp" />
     <ClCompile Include="source\Timeline.cpp" />
     <ClCompile Include="source\Utilities.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\externals\coda-oss\modules\c++\coda-oss.vcxproj">
+      <Project>{9997e895-5161-4ddf-8f3f-099894cb2f21}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c++\nitf-c++.vcxproj">
+      <Project>{8f357a19-799e-4971-850e-3f28485c130b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c\nitf-c.vcxproj">
+      <Project>{f06550ad-cfc7-40b8-8727-6c82c69a8982}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\scene\scene.vcxproj">
+      <Project>{1cfcde59-6410-4037-95eb-b37d31e10820}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\six\six.vcxproj">
+      <Project>{62aad4dd-35ba-41a0-8263-1f4dfd755689}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/six/modules/c++/six.sicd/six.sicd.vcxproj.filters
+++ b/six/modules/c++/six.sicd/six.sicd.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClInclude Include="include\six\sicd\DataParser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\six\sicd\Exports.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/six/modules/c++/six.sicd/source/ComplexToAMP8IPHS8I.cpp
+++ b/six/modules/c++/six.sicd/source/ComplexToAMP8IPHS8I.cpp
@@ -176,7 +176,7 @@ static inline uint8_t nearest(const std::vector<float>& magnitudes, float value)
     return gsl::narrow<uint8_t>(distance);
 }
 
-six::AMP8I_PHS8I_t six::sicd::details::ComplexToAMP8IPHS8I::nearest_neighbor(const six::zfloat &v) const
+six::AMP8I_PHS8I_t six::sicd::details::ComplexToAMP8IPHS8I::nearest_neighbor_(const six::zfloat &v) const
 {
     six::AMP8I_PHS8I_t retval;
     retval.phase = getPhase(v);
@@ -190,6 +190,10 @@ six::AMP8I_PHS8I_t six::sicd::details::ComplexToAMP8IPHS8I::nearest_neighbor(con
     //assert(std::abs(projection - std::abs(v)) < 1e-5); // TODO ???
     retval.amplitude = nearest(magnitudes, projection);
     return retval;
+}
+six::AMP8I_PHS8I_t six::sicd::nearest_neighbor(const details::ComplexToAMP8IPHS8I& i, const six::zfloat& v)
+{
+    return i.nearest_neighbor_(v);
 }
 
  // Yes, this is duplicated code :-(  1) hopefully it will go away someday "soon,"
@@ -237,10 +241,10 @@ std::vector<six::AMP8I_PHS8I_t> six::sicd::details::ComplexToAMP8IPHS8I::nearest
     std::span<const zfloat> inputs, const six::AmplitudeTable* pAmplitudeTable)
 {
     // make a structure to quickly find the nearest neighbor
-    const auto& converter = make(pAmplitudeTable);
+    const auto& converter = make_(pAmplitudeTable);
     const auto nearest_neighbor = [&converter](const auto& v)
     {
-        return converter.nearest_neighbor(v);
+        return converter.nearest_neighbor_(v);
     };
 
     std::vector<six::AMP8I_PHS8I_t> retval(inputs.size());
@@ -248,7 +252,7 @@ std::vector<six::AMP8I_PHS8I_t> six::sicd::details::ComplexToAMP8IPHS8I::nearest
     return retval;
 }
 
-const six::sicd::details::ComplexToAMP8IPHS8I& six::sicd::details::ComplexToAMP8IPHS8I::make(const six::AmplitudeTable* pAmplitudeTable)
+const six::sicd::details::ComplexToAMP8IPHS8I& six::sicd::details::ComplexToAMP8IPHS8I::make_(const six::AmplitudeTable* pAmplitudeTable)
 {
     if (pAmplitudeTable == nullptr)
     {
@@ -270,4 +274,8 @@ const six::sicd::details::ComplexToAMP8IPHS8I& six::sicd::details::ComplexToAMP8
         pAmplitudeTable->cacheFromComplex_(std::move(pTree));
         return *(pAmplitudeTable->getFromComplex());
     }
+}
+const six::sicd::details::ComplexToAMP8IPHS8I& six::sicd::make_ComplexToAMP8IPHS8I(const six::AmplitudeTable* pAmplitudeTable)
+{
+    return six::sicd::details::ComplexToAMP8IPHS8I::make_(pAmplitudeTable);
 }

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -59,6 +59,7 @@
 #include <six/sicd/ImageData.h>
 #include <six/sicd/NITFReadComplexXMLControl.h>
 #include <six/sicd/DataParser.h>
+#include <six/sicd/Exports.h>
 
 namespace fs = std::filesystem;
 
@@ -842,7 +843,7 @@ void Utilities::getWidebandData(const std::string& sicdPathname,
     getWidebandData(sicdPathname, schemaPaths, complexData, offset, extent, buffer);
 }
 
-template<>
+template<> SIX_SICD_API
 void Utilities::getRawData(NITFReadControl& reader,
     const ComplexData& complexData,
     const types::RowCol<size_t>& offset,
@@ -858,7 +859,7 @@ void Utilities::getRawData(NITFReadControl& reader,
     getWidebandData(reader, complexData, offset, extent, buffer);
 }
 
-template<>
+template<> SIX_SICD_API
 void Utilities::getRawData(NITFReadControl& reader,
     const ComplexData& complexData,
     const types::RowCol<size_t>& offset,
@@ -884,7 +885,7 @@ void Utilities::getRawData(NITFReadControl& reader,
         });
 }
 
-template<>
+template<> SIX_SICD_API
 void Utilities::getRawData(NITFReadControl& reader,
     const ComplexData& complexData,
     const types::RowCol<size_t>& offset,

--- a/six/modules/c++/six.sicd/source/Utilities.cpp
+++ b/six/modules/c++/six.sicd/source/Utilities.cpp
@@ -1634,7 +1634,7 @@ std::vector<std::byte> six::sicd::readFromNITF(const fs::path& pathname, const s
 
 static void writeAsNITF(const fs::path& pathname, const std::vector<std::string>& schemaPaths_, const six::sicd::ComplexData& data, const six::zfloat* image_)
 {
-    six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+    six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
     six::NITFWriteControl writer(data.unique_clone());
     writer.setLogger(logging::setupLogger("out"));

--- a/six/modules/c++/six.sicd/tests/test_add_additional_des.cpp
+++ b/six/modules/c++/six.sicd/tests/test_add_additional_des.cpp
@@ -253,7 +253,7 @@ int main(int argc, char** argv)
         validateArguments(argc, argv);
         const std::string xmlPathname(argv[1]);
 
-        six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
         bool allPassed = true;
         allPassed = addingNullSegmentWriterShouldThrow(xmlPathname) && allPassed;

--- a/six/modules/c++/six.sicd/tests/test_clone_container.cpp
+++ b/six/modules/c++/six.sicd/tests/test_clone_container.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
     try
     {
 
-        XMLControlFactory::getInstance(). addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
         NITFReadControl* reader = new NITFReadControl();
         reader->load(inputFile);
 

--- a/six/modules/c++/six.sicd/tests/test_read_sicd_with_extra_des.cpp
+++ b/six/modules/c++/six.sicd/tests/test_read_sicd_with_extra_des.cpp
@@ -175,7 +175,7 @@ int main(int argc, char** argv)
         validateArguments(argc, argv);
         const std::string xmlPathname(argv[1]);
 
-        six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
         std::unique_ptr<io::TempFile> nitf = createNITFFromXML(xmlPathname);
         six::NITFReadControl reader;

--- a/six/modules/c++/six.sicd/tests/test_sicd_schemata.cpp
+++ b/six/modules/c++/six.sicd/tests/test_sicd_schemata.cpp
@@ -2435,7 +2435,7 @@ bool cmpRoundTripXMLs(std::string xmlText, std::string xmlPath = "",
 
         // translate XML into Complex Data structure
         const std::unique_ptr<six::XMLControl> xmlControl(
-            six::XMLControlFactory::getInstance().newXMLControl(six::DataType::COMPLEX, log.get()));
+            six::getXMLControlFactory().newXMLControl(six::DataType::COMPLEX, log.get()));
         six::sicd::ComplexData* data = (
             six::sicd::ComplexData*)xmlControl->fromXML(doc, std::vector<std::string>());
 
@@ -2573,7 +2573,7 @@ int main(int argc, char** argv)
         params.push_back(options->get<std::string> ("xmlPath"));
         params.push_back(options->get<std::string> ("verbose"));
 
-        six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
         // Validate that the resultant XML data from SICD Complex Data
         //   matches before and after round-trip for each format and algorithm

--- a/six/modules/c++/six.sicd/tests/test_streaming_write.cpp
+++ b/six/modules/c++/six.sicd/tests/test_streaming_write.cpp
@@ -500,7 +500,7 @@ int main(int /*argc*/, char** /*argv*/)
         const std::vector<std::string> schemaPaths;
 
         // create an XML registry
-        six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
         // Run tests with no funky segmentation
         bool success = true;

--- a/six/modules/c++/six.sicd/unittests/test_AMP8I_PHS8I.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_AMP8I_PHS8I.cpp
@@ -468,7 +468,7 @@ static void read_nitf(const std::string& testName,
 static void buffer_list_save(const std::filesystem::path& outputName, const std::vector<six::zfloat>& image,
     std::unique_ptr<six::sicd::ComplexData>&& pComplexData)
 {
-    six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+    six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
     six::NITFWriteControl writer(std::unique_ptr<six::Data>(std::move(pComplexData)));
 
     static const std::vector<std::string> schemaPaths;

--- a/six/modules/c++/six.sicd/unittests/test_AMP8I_PHS8I.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_AMP8I_PHS8I.cpp
@@ -642,7 +642,7 @@ static void do_test_ComplexToAMP8IPHS8I_(const std::string& testName,
     const six::zfloat& input_dbl, const std::vector<Pairs>& candidates)
 {
     // Calculate the nearest neighbor quickly.
-    const auto test_integral = item.nearest_neighbor(input_dbl);
+    const auto test_integral = six::sicd::nearest_neighbor(item, input_dbl);
 
     // Calculate the nearest neighbor via exhaustive calculation.
     double min_distance = std::abs(candidates[0].floating - input_dbl);
@@ -696,7 +696,7 @@ TEST_CASE(test_ComplexToAMP8IPHS8I)
     {
         amplitudeTable.index(i) = static_cast<double>(i) + 10.0;
     }    
-    const auto& item = six::sicd::details::ComplexToAMP8IPHS8I::make(&amplitudeTable);
+    const auto& item = six::sicd::make_ComplexToAMP8IPHS8I(&amplitudeTable);
 
     // Generate the full 256x256 matrix of possible AMP8I_PHS8I values.
     std::vector<Pairs> candidates;
@@ -713,7 +713,7 @@ TEST_CASE(test_ComplexToAMP8IPHS8I)
     // These are simple cases that don't necessarily exercise the nearest neighbor property.
     for(auto& i : candidates) {
         auto truth = i.integral;
-        auto test = item.nearest_neighbor(six::zfloat(i.floating.real(), i.floating.imag()));
+        auto test = six::sicd::nearest_neighbor(item, six::zfloat(i.floating.real(), i.floating.imag()));
         TEST_ASSERT_EQ(truth.amplitude, test.amplitude);
         TEST_ASSERT_EQ(truth.phase, test.phase);
     }
@@ -723,7 +723,7 @@ TEST_CASE(test_ComplexToAMP8IPHS8I)
     six::zfloat problem {
         1.0f, -1e-4f
     };
-    TEST_ASSERT_EQ(item.nearest_neighbor(problem).phase, 0);
+    TEST_ASSERT_EQ(six::sicd::nearest_neighbor(item, problem).phase, 0);
 
     // Verify the nearest neighbor property via random search through the possible space.
     // For each sampled point we check that we found the true nearest neighbor.

--- a/six/modules/c++/six.sicd/unittests/test_valid_six.cpp
+++ b/six/modules/c++/six.sicd/unittests/test_valid_six.cpp
@@ -376,7 +376,7 @@ static void read_nitf(const std::string& testName,
 static void buffer_list_save(const std::filesystem::path& outputName, const std::vector<six::zfloat>& image,
     std::unique_ptr<six::sicd::ComplexData>&& pComplexData)
 {
-    six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+    six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
     six::NITFWriteControl writer(std::unique_ptr<six::Data>(std::move(pComplexData)));
 
     static const std::vector<std::string> schemaPaths;

--- a/six/modules/c++/six.sidd/include/six/sidd/DerivedData.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/DerivedData.h
@@ -41,6 +41,7 @@
 #include <six/sidd/Compression.h>
 #include <six/sidd/DigitalElevationData.h>
 #include <six/sidd/Annotations.h>
+#include <six/sidd/Exports.h>
 
 namespace six
 {
@@ -57,7 +58,7 @@ namespace sidd300
     };
     std::string to_string(ISMVersion); // "v201609" or "v13"
 
-    ISMVersion get(ISMVersion defaultIfNotSet); // overloaded on ISMVersion
+    SIX_SIDD_API ISMVersion get(ISMVersion defaultIfNotSet); // overloaded on ISMVersion
     std::optional<ISMVersion> set(ISMVersion); // returns previous value, if any
     std::optional<ISMVersion> getISMVersion();
     std::optional<ISMVersion> clearISMVersion(); // returns previous value, if any
@@ -88,7 +89,7 @@ Version normalizeVersion(const std::string&);
  *  Contains the structs that are the model for SIDD products
  *
  */
-struct DerivedData : public Data
+struct SIX_SIDD_API DerivedData : public Data
 {
     /*!
      *  Information related to processor, classification,

--- a/six/modules/c++/six.sidd/include/six/sidd/DerivedDataBuilder.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/DerivedDataBuilder.h
@@ -19,11 +19,12 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __SIX_DERIVED_DATA_BUILDER_H__
 #define __SIX_DERIVED_DATA_BUILDER_H__
 
 #include "six/sidd/DerivedData.h"
+#include "six/sidd/Exports.h"
 
 namespace six
 {
@@ -40,7 +41,7 @@ namespace sidd
  *  DerivedData object as a prototype.
  *
  */
-class DerivedDataBuilder
+class SIX_SIDD_API DerivedDataBuilder
 {
 public:
     //!  Construct. Creates and owns a new DerivedData object

--- a/six/modules/c++/six.sidd/include/six/sidd/DerivedXMLControl.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/DerivedXMLControl.h
@@ -31,6 +31,7 @@
 
 #include <six/sidd/DerivedData.h>
 #include <six/sidd/DerivedXMLParser.h>
+#include <six/sidd/Exports.h>
 
 namespace six
 {
@@ -45,7 +46,7 @@ namespace sidd
  *  if necessary.  A best practice is to use the six::toXMLCharArray
  *  and six::toXMLString functions to turn Data* objects into XML
  */
-struct DerivedXMLControl : public XMLControl
+struct SIX_SIDD_API DerivedXMLControl : public XMLControl
 {
     DerivedXMLControl(logging::Logger* log = nullptr, bool ownLog = false);
     DerivedXMLControl(std::unique_ptr<logging::Logger>&&);

--- a/six/modules/c++/six.sidd/include/six/sidd/DownstreamReprocessing.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/DownstreamReprocessing.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_DOWNSTREAM_REPROCESSING_H__
 #define __SIX_DOWNSTREAM_REPROCESSING_H__
 
@@ -26,6 +27,8 @@
 #include "six/Types.h"
 #include "six/Init.h"
 #include "six/ParameterCollection.h"
+
+#include "six/sidd/Exports.h"
 
 namespace six
 {
@@ -37,7 +40,7 @@ namespace sidd
  *
  *  Contains information related to downstream chipping of the product.
  */
-struct GeometricChip
+struct SIX_SIDD_API GeometricChip
 {
     //!  Size of the chipped product in pixels
     RowColInt chipSize;

--- a/six/modules/c++/six.sidd/include/six/sidd/ExploitationFeatures.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/ExploitationFeatures.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_EXPLOITATION_FEATURES_H__
 #define __SIX_EXPLOITATION_FEATURES_H__
 
@@ -27,6 +28,8 @@
 #include <six/Types.h>
 #include <six/Init.h>
 #include <six/ParameterCollection.h>
+
+#include "six/sidd/Exports.h"
 
 /*!
  *  This file deals with the SIDD data structures for ExploitationFeatures
@@ -363,7 +366,7 @@ struct ProcTxRcvPolarization
  *  Metadata about the product, including the resolution and angle
  *  to north
  */
-struct Product
+struct SIX_SIDD_API Product
 {
     //!  Constructor, everything is undefined
     Product();

--- a/six/modules/c++/six.sidd/include/six/sidd/Exports.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/Exports.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "config/compiler_extensions.h"
+
+// Need to specify how this code will be consumed, either SIX_SIDD_LIB_ (static library)
+// or SIX_SIDD_DLL_ (aka "shared" library).  For DLLs, it needs to be set for BOTH
+// "exporting" (building this code) and "importing" (consuming).
+//
+// Use Windows naming conventions (DLL, LIB) because this really only matters for _MSC_VER, see below.
+#if !defined(SIX_SIDD_LIB_) && !defined(SIX_SIDD_DLL_)
+    #if CODA_OSS_LIBRARY_SHARED
+        #if CODA_OSS_LIBRARY_STATIC
+            #error "CODA_OSS_LIBRARY_SHARED already #define'd'"
+        #endif
+        #define SIX_SIDD_DLL_ 1  // Symbols must be exported and imported (see below).
+    #else
+        // CODA_OSS_LIBRARY_STATIC doesn't have to be defined
+        #define SIX_SIDD_LIB_ 1  // Static library, all symbols visible.
+    #endif
+#endif
+#if !defined(SIX_SIDD_LIB_) && !defined(SIX_SIDD_DLL_)
+    #error "One of SIX_SIDD_LIB_ pr SIX_SIDD_DLL_ must be #define'd'"
+#endif
+#if defined(SIX_SIDD_LIB_) && defined(SIX_SIDD_DLL_)
+    #error "Both SIX_SIDD_LIB_ and SIX_SIDD_DLL_ are #define'd'"
+#endif
+#if defined(SIX_SIDD_EXPORTS) && defined(SIX_SIDD_LIB_)
+    #error "Can't export from a LIB'"
+#endif
+
+// The following ifdef block is the standard way of creating macros which make exporting
+// from a DLL simpler. All files within this DLL are compiled with the SIX_SIDD_EXPORTS
+// symbol defined on the command line. This symbol should not be defined on any project
+// that uses this DLL. This way any other project whose source files include this file see
+// SIX_SIDD_API functions as being imported from a DLL, whereas this DLL sees symbols
+// defined with this macro as being exported.
+// https://www.gnu.org/software/gnulib/manual/html_node/Exported-Symbols-of-Shared-Libraries.html
+#ifdef SIX_SIDD_EXPORTS
+    #define SIX_SIDD_API CODA_OSS_library_export
+#else
+    // Either building a static library (no SIX_SIDD_EXPORTS) or
+    // importing (not building) a shared library.
+
+    // We need to know whether we're consuming (importing) a DLL or static LIB
+    // The default is a static LIB as that's what existing code/builds expect.
+    #ifdef SIX_SIDD_DLL_
+        // Actually, it seems that the linker is able to figure this out from the .LIB, so 
+        // there doesn't seem to be a need for __declspec(dllimport).  Clients don't
+        // need to #define SIX_SIDD_DLL_ ... ?  Well, almost ... it looks
+        // like __declspec(dllimport) is needed to get virtual "inline"s (e.g., 
+        // destructors) correct.
+        #define SIX_SIDD_API CODA_OSS_library_import
+    #else
+        #define SIX_SIDD_API /* "importing" a static LIB */
+    #endif
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4251) // '...' : class '...' needs to have dll-interface to be used by clients of struct '...'
+#endif

--- a/six/modules/c++/six.sidd/include/six/sidd/GeographicAndTarget.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/GeographicAndTarget.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_GEOGRAPHIC_AND_TARGET_H__
 #define __SIX_GEOGRAPHIC_AND_TARGET_H__
 
@@ -30,6 +31,8 @@
 #include <six/ParameterCollection.h>
 #include <six/GeoInfo.h>
 
+#include "six/sidd/Exports.h"
+
 namespace six
 {
 namespace sidd
@@ -40,7 +43,7 @@ namespace sidd
  *
  *  Provides target specific geographic information.
  */
-struct TargetInformation
+struct SIX_SIDD_API TargetInformation
 {
     //! SIDD Identifier set (min occurs one, max unbounded)
     ParameterCollection identifiers;
@@ -76,7 +79,7 @@ struct TargetInformation
  *  The GeographicInformation object gives specifics about the geo-region
  *
  */
-struct GeographicInformation
+struct SIX_SIDD_API GeographicInformation
 {
     //!  SIDD CountryCode Country code (1+)
     std::vector<std::string> countryCodes;
@@ -112,7 +115,7 @@ struct GeographicInformation
  *  This object contains the information associated with some geographic
  *  coverage
  */
-class GeographicCoverage
+class SIX_SIDD_API GeographicCoverage
 {
 public:
     //!  Constructor requires a RegionType to properly initialize
@@ -154,7 +157,7 @@ public:
  *  Note: Only used by SIDD 1.0
  *
  */
-class GeographicAndTarget
+class SIX_SIDD_API GeographicAndTarget
 {
 public:
     // This section is used for SIDD 1.0

--- a/six/modules/c++/six.sidd/include/six/sidd/SFA.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/SFA.h
@@ -19,6 +19,7 @@
 * see <http://www.gnu.org/licenses/>.
 *
 */
+#pragma once
 #ifndef __SIX_SIDD_SFA_H__
 #define __SIX_SIDD_SFA_H__
 
@@ -26,12 +27,14 @@
 
 #include <import/six.h>
 
+#include "six/sidd/Exports.h"
+
 namespace six
 {
 namespace sidd
 {
 
-struct SFATyped
+struct SIX_SIDD_API SFATyped
 {
 public:
     virtual ~SFATyped()
@@ -64,7 +67,7 @@ inline bool operator!=(const SFATyped& lhs, const SFATyped& rhs)
 }
 
 //! Abstract type
-struct SFAGeometry : public SFATyped
+struct SIX_SIDD_API SFAGeometry : public SFATyped
 {
     virtual SFAGeometry* clone() const = 0;
 
@@ -75,7 +78,7 @@ protected:
     }
 };
 
-struct SFAPoint : public SFAGeometry
+struct SIX_SIDD_API SFAPoint : public SFAGeometry
 {
     double x, y, z, m;
 
@@ -137,7 +140,7 @@ private:
 };
 
 //! Abstract type
-struct SFACurve : public SFAGeometry
+struct SIX_SIDD_API SFACurve : public SFAGeometry
 {
 protected:
     SFACurve(const std::string& typeName) :
@@ -146,7 +149,7 @@ protected:
     }
 };
 
-struct SFALineString : public SFACurve
+struct SIX_SIDD_API SFALineString : public SFACurve
 {
 public:
     SFALineString() :
@@ -180,7 +183,7 @@ private:
     }
 };
 
-struct SFALine : public SFALineString
+struct SIX_SIDD_API SFALine : public SFALineString
 {
 public:
     SFALine() :
@@ -214,7 +217,7 @@ private:
     }
 };
 
-struct SFALinearRing : public SFALineString
+struct SIX_SIDD_API SFALinearRing : public SFALineString
 {
 public:
     SFALinearRing() :
@@ -249,7 +252,7 @@ private:
 };
 
 //! Abstract type
-struct SFASurface : public SFAGeometry
+struct SIX_SIDD_API SFASurface : public SFAGeometry
 {
 protected:
     SFASurface(const std::string& typeName) :
@@ -258,7 +261,7 @@ protected:
     }
 };
 
-struct SFAPolygon : public SFASurface
+struct SIX_SIDD_API SFAPolygon : public SFASurface
 {
 public:
     SFAPolygon() :
@@ -290,7 +293,7 @@ private:
     }
 };
 
-struct SFATriangle : public SFAPolygon
+struct SIX_SIDD_API SFATriangle : public SFAPolygon
 {
 public:
     SFATriangle() :
@@ -326,7 +329,7 @@ private:
     }
 };
 
-struct SFAPolyhedralSurface : public SFASurface
+struct SIX_SIDD_API SFAPolyhedralSurface : public SFASurface
 {
 public:
     SFAPolyhedralSurface() :
@@ -364,7 +367,7 @@ private:
 
 // note that we are deriving Surface rather than PolyhedralSurface
 // this is to avoid the patches name clash
-struct SFATriangulatedIrregularNetwork : public SFASurface
+struct SIX_SIDD_API SFATriangulatedIrregularNetwork : public SFASurface
 {
 public:
     SFATriangulatedIrregularNetwork() :
@@ -401,7 +404,7 @@ private:
 };
 
 //! Abstract type
-struct SFAGeometryCollection : public SFAGeometry
+struct SIX_SIDD_API SFAGeometryCollection : public SFAGeometry
 {
 protected:
     SFAGeometryCollection(const std::string& typeName) :
@@ -410,7 +413,7 @@ protected:
     }
 };
 
-struct SFAMultiPoint : public SFAGeometryCollection
+struct SIX_SIDD_API SFAMultiPoint : public SFAGeometryCollection
 {
 public:
     SFAMultiPoint() :
@@ -445,7 +448,7 @@ private:
 };
 
 //! Abstract type
-struct SFAMultiCurve : public SFAGeometryCollection
+struct SIX_SIDD_API SFAMultiCurve : public SFAGeometryCollection
 {
 protected:
     SFAMultiCurve(const std::string& typeName) :
@@ -454,7 +457,7 @@ protected:
     }
 };
 
-struct SFAMultiLineString : public SFAMultiCurve
+struct SIX_SIDD_API SFAMultiLineString : public SFAMultiCurve
 {
 public:
     SFAMultiLineString() :
@@ -492,7 +495,7 @@ private:
 };
 
 //! Abstract type
-struct SFAMultiSurface : public SFAGeometryCollection
+struct SIX_SIDD_API SFAMultiSurface : public SFAGeometryCollection
 {
 protected:
     SFAMultiSurface(const std::string& typeName) :
@@ -501,7 +504,7 @@ protected:
     }
 };
 
-struct SFAMultiPolygon : public SFAMultiSurface
+struct SIX_SIDD_API SFAMultiPolygon : public SFAMultiSurface
 {
 public:
     SFAMultiPolygon() :
@@ -538,7 +541,7 @@ private:
 };
 
 //! Abstract type
-struct SFACoordinateSystem : public SFATyped
+struct SIX_SIDD_API SFACoordinateSystem : public SFATyped
 {
 public:
     virtual SFACoordinateSystem* clone() const = 0;
@@ -550,7 +553,7 @@ protected:
     }
 };
 
-struct SFAPrimeMeridian final
+struct SIX_SIDD_API SFAPrimeMeridian final
 {
     std::string name;
     double longitude = 0.0;
@@ -565,7 +568,7 @@ struct SFAPrimeMeridian final
     }
 };
 
-struct SFASpheroid final
+struct SIX_SIDD_API SFASpheroid final
 {
     std::string name;
     double semiMajorAxis = 0.0;
@@ -583,7 +586,7 @@ struct SFASpheroid final
     }
 };
 
-struct SFAParameter final
+struct SIX_SIDD_API SFAParameter final
 {
     std::string name;
     double value = 0.0;
@@ -599,7 +602,7 @@ struct SFAParameter final
     }
 };
 
-struct SFAProjection final
+struct SIX_SIDD_API SFAProjection final
 {
     std::string name;
 
@@ -614,7 +617,7 @@ struct SFAProjection final
     }
 };
 
-struct SFADatum final
+struct SIX_SIDD_API SFADatum final
 {
     SFASpheroid spheroid;
 
@@ -629,7 +632,7 @@ struct SFADatum final
     }
 };
 
-struct SFAGeocentricCoordinateSystem : public SFACoordinateSystem
+struct SIX_SIDD_API SFAGeocentricCoordinateSystem : public SFACoordinateSystem
 {
     std::string csName;
     SFADatum datum;
@@ -669,7 +672,7 @@ private:
     }
 };
 
-struct SFAGeographicCoordinateSystem : public SFACoordinateSystem
+struct SIX_SIDD_API SFAGeographicCoordinateSystem : public SFACoordinateSystem
 {
     std::string csName;
     SFADatum datum;
@@ -712,7 +715,7 @@ private:
     }
 };
 
-struct SFAProjectedCoordinateSystem : public SFACoordinateSystem
+struct SIX_SIDD_API SFAProjectedCoordinateSystem : public SFACoordinateSystem
 {
     std::string csName;
     mem::ScopedCopyablePtr<SFAGeographicCoordinateSystem> geographicCoordinateSystem;
@@ -750,7 +753,7 @@ private:
     }
 };
 
-struct SFAReferenceSystem
+struct SIX_SIDD_API SFAReferenceSystem
 {
     mem::ScopedCloneablePtr<SFACoordinateSystem> coordinateSystem;
     std::vector<std::string> axisNames;

--- a/six/modules/c++/six.sidd/include/six/sidd/SIDDByteProvider.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/SIDDByteProvider.h
@@ -19,12 +19,13 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __SIX_SIDD_SIDD_BYTE_PROVIDER_H__
 #define __SIX_SIDD_SIDD_BYTE_PROVIDER_H__
 
 #include <six/ByteProvider.h>
 #include <six/sidd/DerivedData.h>
+#include <six/sidd/Exports.h>
 
 namespace six
 {
@@ -46,7 +47,7 @@ namespace sidd
  * copies.  A single logical SIDD image which spans multiple NITF image segments
  * is supported; unrelated SIDD images in one NITF are not yet supported.
  */
-class SIDDByteProvider : public six::ByteProvider
+class SIX_SIDD_API SIDDByteProvider final : public six::ByteProvider
 {
 public:
     /*!

--- a/six/modules/c++/six.sidd/include/six/sidd/Utilities.h
+++ b/six/modules/c++/six.sidd/include/six/sidd/Utilities.h
@@ -33,12 +33,13 @@
 #include <six/Utilities.h>
 #include <six/sidd/DerivedData.h>
 #include <six/sidd/DerivedXMLControl.h>
+#include <six/sidd/Exports.h>
 
 namespace six
 {
 namespace sidd
 {
-class Utilities
+class SIX_SIDD_API Utilities
 {
 public:
     // TODO: This is only needed because getSceneGeometry() isn't implemented

--- a/six/modules/c++/six.sidd/six.sidd.vcxproj
+++ b/six/modules/c++/six.sidd/six.sidd.vcxproj
@@ -19,12 +19,12 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_SIDD_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -80,7 +80,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_SIDD_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -122,6 +122,7 @@
     <ClInclude Include="include\six\sidd\DownstreamReprocessing.h" />
     <ClInclude Include="include\six\sidd\Enums.h" />
     <ClInclude Include="include\six\sidd\ExploitationFeatures.h" />
+    <ClInclude Include="include\six\sidd\Exports.h" />
     <ClInclude Include="include\six\sidd\Filter.h" />
     <ClInclude Include="include\six\sidd\GeographicAndTarget.h" />
     <ClInclude Include="include\six\sidd\GeoTIFFReadControl.h" />
@@ -177,6 +178,23 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </Xsd>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\externals\coda-oss\modules\c++\coda-oss.vcxproj">
+      <Project>{9997e895-5161-4ddf-8f3f-099894cb2f21}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c++\nitf-c++.vcxproj">
+      <Project>{8f357a19-799e-4971-850e-3f28485c130b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c\nitf-c.vcxproj">
+      <Project>{f06550ad-cfc7-40b8-8727-6c82c69a8982}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\scene\scene.vcxproj">
+      <Project>{1cfcde59-6410-4037-95eb-b37d31e10820}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\six\six.vcxproj">
+      <Project>{62aad4dd-35ba-41a0-8263-1f4dfd755689}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/six/modules/c++/six.sidd/six.sidd.vcxproj.filters
+++ b/six/modules/c++/six.sidd/six.sidd.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClInclude Include="include\six\sidd\DataParser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\six\sidd\Exports.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/six/modules/c++/six.sidd/tests/test_byte_swap.cpp
+++ b/six/modules/c++/six.sidd/tests/test_byte_swap.cpp
@@ -174,7 +174,7 @@ int main(int /*argc*/, char** /*argv*/)
 {
     try
     {
-        six::XMLControlFactory::getInstance().addCreator<six::sidd::DerivedXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sidd::DerivedXMLControl>();
 
         bool success = run(false, false) && run(true, false) &&
             run(false, true) && run(true, true);

--- a/six/modules/c++/six.sidd/tests/test_check_blocking.cpp
+++ b/six/modules/c++/six.sidd/tests/test_check_blocking.cpp
@@ -212,7 +212,7 @@ int main(int argc, char** argv)
 
         const std::string siddPathname(options->get<std::string>("sidd"));
 
-        six::XMLControlFactory::getInstance().addCreator<six::sidd::DerivedXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sidd::DerivedXMLControl>();
 
         std::unique_ptr<six::Data> sidd = read(siddPathname);
 

--- a/six/modules/c++/six.sidd/tests/test_geotiff.cpp
+++ b/six/modules/c++/six.sidd/tests/test_geotiff.cpp
@@ -139,7 +139,7 @@ int main(int /*argc*/, char** /*argv*/)
 {
     try
     {
-        six::XMLControlFactory::getInstance().addCreator<six::sidd::DerivedXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sidd::DerivedXMLControl>();
 
         if (run())
         {

--- a/six/modules/c++/six.sidd/tests/test_sidd_blocking.cpp
+++ b/six/modules/c++/six.sidd/tests/test_sidd_blocking.cpp
@@ -184,7 +184,7 @@ int main(int argc, char** argv)
     }
     try
     {
-        six::XMLControlFactory::getInstance().addCreator<six::sidd::DerivedXMLControl>();
+        six::getXMLControlFactory().addCreator<six::sidd::DerivedXMLControl>();
 
         const std::string installPathname(argv[1]);
         TempFileWithExtension multiImageSidd(".nitf");

--- a/six/modules/c++/six.sidd/unittests/test_valid_sixsidd.cpp
+++ b/six/modules/c++/six.sidd/unittests/test_valid_sixsidd.cpp
@@ -128,7 +128,7 @@ TEST_CASE(test_read_sidd200_no_LUT)
 {
     static const auto pathname = get_sample_nitf_path("2023-07-26-11-37-27_UMBRA-04_SIDD.nitf");
 
-    six::XMLControlRegistry& xml_registry = six::XMLControlFactory::getInstance();
+    six::XMLControlRegistry& xml_registry = six::getXMLControlFactory();
     xml_registry.addCreator(six::DataType::DERIVED,
         new six::XMLControlCreatorT<six::sidd::DerivedXMLControl>());
 

--- a/six/modules/c++/six/include/six/AmplitudeTable.h
+++ b/six/modules/c++/six/include/six/AmplitudeTable.h
@@ -38,6 +38,7 @@
 #include <scene/sys_Conf.h>
 
 #include "six/Complex.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -50,7 +51,7 @@ namespace six
  *  (e.g., 2 for short) depending on the type that is being housed
  *
  */
-struct LUT
+struct SIX_SIX_API LUT
 {
     std::vector<unsigned char> table;
     size_t numEntries = 0;
@@ -164,7 +165,7 @@ using phase_values_t = std::array<six::zfloat, UINT8_MAX + 1>;
 using Amp8iPhs8iLookup_t = std::array<phase_values_t, UINT8_MAX + 1>;
 
 // More descriptive than std::pair<uint8_t, uint8_t>
-struct AMP8I_PHS8I_t final
+struct SIX_SIX_API AMP8I_PHS8I_t final
 {
     uint8_t amplitude;
     uint8_t phase;
@@ -189,7 +190,7 @@ class ComplexToAMP8IPHS8I final
     explicit ComplexToAMP8IPHS8I(const six::AmplitudeTable* pAmplitudeTable = nullptr);
 
 public:
-    static const ComplexToAMP8IPHS8I& make(const six::AmplitudeTable* pAmplitudeTable); // AmplitudeTable* = NULL is cached
+    static const ComplexToAMP8IPHS8I& make_(const six::AmplitudeTable* pAmplitudeTable); // AmplitudeTable* = NULL is cached
 
     ~ComplexToAMP8IPHS8I() = default;
     ComplexToAMP8IPHS8I(const ComplexToAMP8IPHS8I&) = delete;
@@ -202,7 +203,7 @@ public:
      * @param v complex value to query with
      * @return nearest amplitude and phase value
      */
-    AMP8I_PHS8I_t nearest_neighbor(const six::zfloat& v) const;
+    AMP8I_PHS8I_t nearest_neighbor_(const six::zfloat& v) const;
     static std::vector<AMP8I_PHS8I_t> nearest_neighbors(std::span<const six::zfloat> inputs,  const six::AmplitudeTable*);
 
 private:
@@ -222,7 +223,7 @@ private:
 }
 }
 
-struct AmplitudeTable final : public LUT
+struct SIX_SIX_API AmplitudeTable final : public LUT
 {
     //!  Constructor.  Creates a 256-entry table
     AmplitudeTable(size_t elementSize) noexcept(false) :

--- a/six/modules/c++/six/include/six/ByteProvider.h
+++ b/six/modules/c++/six/include/six/ByteProvider.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __SIX_BYTE_PROVIDER_H__
 #define __SIX_BYTE_PROVIDER_H__
 
@@ -33,6 +33,7 @@
 #include <six/NITFHeaderCreator.h>
 #include <six/NITFSegmentInfo.h>
 #include <six/XMLControlFactory.h>
+#include <six/Exports.h>
 
 namespace six
 {
@@ -51,7 +52,7 @@ namespace six
  * rather than one contiguous block of memory in order to minimize the number of
  * copies.
  */
-class ByteProvider : public nitf::ByteProvider
+class SIX_SIX_API ByteProvider : public nitf::ByteProvider
 {
 public:
     /*!

--- a/six/modules/c++/six/include/six/Classification.h
+++ b/six/modules/c++/six/include/six/Classification.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_CLASSIFICATION_H__
 #define __SIX_CLASSIFICATION_H__
 
@@ -26,6 +27,7 @@
 #include "logging/Logger.h"
 #include "nitf/FileSecurity.h"
 #include "six/Options.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -46,7 +48,7 @@ namespace six
  *  directly.  The free parameters are applied last, by the file format
  *  container.  Currently only NITF free parameters are supported.
  */
-struct Classification
+struct SIX_SIX_API Classification
 {
     virtual ~Classification() = default;
 

--- a/six/modules/c++/six/include/six/CollectionInformation.h
+++ b/six/modules/c++/six/include/six/CollectionInformation.h
@@ -126,7 +126,7 @@ struct SIX_SIX_API CollectionInformation
     virtual void setClassificationLevel(const std::u8string& classification);
 
     //! Ostream operators for six::CollectionInformation type (utility only).
-    friend std::ostream& operator<<(std::ostream& os, const six::CollectionInformation& c);
+    SIX_SIX_API friend std::ostream& operator<<(std::ostream& os, const six::CollectionInformation& c);
 
   bool operator==(const CollectionInformation& rhs) const; // needs to be member-function for SWIG
   bool operator!=(const CollectionInformation& rhs) const  // needs to be member-function for SWIG

--- a/six/modules/c++/six/include/six/CollectionInformation.h
+++ b/six/modules/c++/six/include/six/CollectionInformation.h
@@ -32,6 +32,7 @@
 #include "six/Init.h"
 #include "six/Parameter.h"
 #include "six/ParameterCollection.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -44,7 +45,7 @@ namespace six
  *  the collection.  There is nothing wrong with the SICD name, but
  *  for API consistency, naming is lengthened.
  */
-struct CollectionInformation
+struct SIX_SIX_API CollectionInformation
 {
 
     /*!

--- a/six/modules/c++/six/include/six/CompressedByteProvider.h
+++ b/six/modules/c++/six/include/six/CompressedByteProvider.h
@@ -19,7 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __SIX_COMPRESSED_BYTE_PROVIDER_H__
 #define __SIX_COMPRESSED_BYTE_PROVIDER_H__
 
@@ -31,6 +31,7 @@
 #include <six/NITFWriteControl.h>
 #include <six/NITFSegmentInfo.h>
 #include <six/XMLControlFactory.h>
+#include <six/Exports.h>
 
 namespace six
 {
@@ -50,7 +51,7 @@ namespace six
  * rather than one contiguous block of memory in order to minimize the number of
  * copies.
  */
-class CompressedByteProvider : public nitf::CompressedByteProvider
+class SIX_SIX_API CompressedByteProvider : public nitf::CompressedByteProvider
 {
 protected:
     /*!

--- a/six/modules/c++/six/include/six/Container.h
+++ b/six/modules/c++/six/include/six/Container.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_CONTAINER_H__
 #define __SIX_CONTAINER_H__
 
@@ -30,6 +31,7 @@
 #include <mem/ScopedCloneablePtr.h>
 #include <six/Legend.h>
 #include <six/Data.h>
+#include <six/Exports.h>
 
 namespace six
 {
@@ -47,7 +49,7 @@ namespace six
  *  Compiler-generated copy constructor and assignment operator are
  *  sufficient.
  */
-class Container
+class SIX_SIX_API Container
 {
 public:
     /*!

--- a/six/modules/c++/six/include/six/Data.h
+++ b/six/modules/c++/six/include/six/Data.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_DATA_H__
 #define __SIX_DATA_H__
 
@@ -32,6 +33,7 @@
 #include "six/Types.h"
 #include "six/Classification.h"
 #include "six/Utilities.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -48,7 +50,7 @@ namespace six
  *  currently NITF, GeoTIFF (SIDD only).
  *
  */
-struct Data
+struct SIX_SIX_API Data
 {
     Data() = default;
 

--- a/six/modules/c++/six/include/six/Enum.h
+++ b/six/modules/c++/six/include/six/Enum.h
@@ -20,9 +20,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_six_Enum_h_INCLUDED_
 #define SIX_six_Enum_h_INCLUDED_
-#pragma once
 
 #include <string>
 #include <map>

--- a/six/modules/c++/six/include/six/ErrorStatistics.h
+++ b/six/modules/c++/six/include/six/ErrorStatistics.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_six_ErrorStatistics_h_INCLUDED_
 #define SIX_six_ErrorStatistics_h_INCLUDED_
-#pragma once
 
 #include <assert.h>
 
@@ -34,6 +34,7 @@
 #include "six/Parameter.h"
 #include "six/ParameterCollection.h"
 #include "six/XsElement.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -45,7 +46,7 @@ namespace six
  *  Correlation coefficient parameters.  This object is shared
  *  between SICD and SIDD
  */
-struct CorrCoefs
+struct SIX_SIX_API CorrCoefs
 {
     CorrCoefs() = default;
 
@@ -82,7 +83,7 @@ struct CorrCoefs
  *  Position and velocity error statistics for the
  *  radar platform.  Name is altered to match API conventions
  */
-struct PosVelError
+struct SIX_SIX_API PosVelError
 {
     //!  CorrCoefs are nullptr, since optional
     PosVelError() = default;
@@ -118,7 +119,7 @@ struct PosVelError
  *
  *  Radar sensor error statistics.
  */
-struct RadarSensor
+struct SIX_SIX_API RadarSensor
 {
     /*!
      *  Range bias error standard deviation. 
@@ -164,7 +165,7 @@ struct RadarSensor
  *
  *  Contains troposphere delay error statistics
  */
-struct TropoError
+struct SIX_SIX_API TropoError
 {
     /*!
      *  (Optional) Troposphere two-way delay error for normal
@@ -206,7 +207,7 @@ struct TropoError
  *
  *  Contains Ionosphere delay error statistics
  */
-struct IonoError
+struct SIX_SIX_API IonoError
 {
     /*!
      *  (Optional) Ionosphere two-way delay error for normal
@@ -255,7 +256,7 @@ struct IonoError
  *
  *  Contains Unmodeled error statistics 
  */
-struct Unmodeled final
+struct SIX_SIX_API Unmodeled final
 {
     XsElement<double> Xrow{ "Xrow" };
     XsElement<double> Ycol{ "Ycol" };
@@ -309,7 +310,7 @@ inline bool operator!=(const Unmodeled& lhs, const Unmodeled& rhs)
  *  (Optional) Error statistics by components.  All children are
  *  optional and thus, not initialized by the constructor
  */
-struct Components
+struct SIX_SIX_API Components
 {
     Components() = default;
 
@@ -347,7 +348,7 @@ struct Components
  *  RG_AZ.
  *
  */
-struct CompositeSCP
+struct SIX_SIX_API CompositeSCP
 {
     //!  Types
     enum SCPType
@@ -392,7 +393,7 @@ struct CompositeSCP
  *  Parameters needed for computing error statistics.
  *
  */
-struct ErrorStatistics
+struct SIX_SIX_API ErrorStatistics
 {
     /*!
      *  (Optional) Composite error statistics estimated at the scene

--- a/six/modules/c++/six/include/six/Exports.h
+++ b/six/modules/c++/six/include/six/Exports.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "config/compiler_extensions.h"
+
+// Need to specify how this code will be consumed, either SIX_SIX_LIB_ (static library)
+// or SIX_SIX_DLL_ (aka "shared" library).  For DLLs, it needs to be set for BOTH
+// "exporting" (building this code) and "importing" (consuming).
+//
+// Use Windows naming conventions (DLL, LIB) because this really only matters for _MSC_VER, see below.
+#if !defined(SIX_SIX_LIB_) && !defined(SIX_SIX_DLL_)
+    #if CODA_OSS_LIBRARY_SHARED
+        #if CODA_OSS_LIBRARY_STATIC
+            #error "CODA_OSS_LIBRARY_SHARED already #define'd'"
+        #endif
+        #define SIX_SIX_DLL_ 1  // Symbols must be exported and imported (see below).
+    #else
+        // CODA_OSS_LIBRARY_STATIC doesn't have to be defined
+        #define SIX_SIX_LIB_ 1  // Static library, all symbols visible.
+    #endif
+#endif
+#if !defined(SIX_SIX_LIB_) && !defined(SIX_SIX_DLL_)
+    #error "One of SIX_SIX_LIB_ pr SIX_SIX_DLL_ must be #define'd'"
+#endif
+#if defined(SIX_SIX_LIB_) && defined(SIX_SIX_DLL_)
+    #error "Both SIX_SIX_LIB_ and SIX_SIX_DLL_ are #define'd'"
+#endif
+#if defined(SIX_SIX_EXPORTS) && defined(SIX_SIX_LIB_)
+    #error "Can't export from a LIB'"
+#endif
+
+// The following ifdef block is the standard way of creating macros which make exporting
+// from a DLL simpler. All files within this DLL are compiled with the SIX_SIX_EXPORTS
+// symbol defined on the command line. This symbol should not be defined on any project
+// that uses this DLL. This way any other project whose source files include this file see
+// SIX_SIX_API functions as being imported from a DLL, whereas this DLL sees symbols
+// defined with this macro as being exported.
+// https://www.gnu.org/software/gnulib/manual/html_node/Exported-Symbols-of-Shared-Libraries.html
+#ifdef SIX_SIX_EXPORTS
+    #define SIX_SIX_API CODA_OSS_library_export
+#else
+    // Either building a static library (no SIX_SIX_EXPORTS) or
+    // importing (not building) a shared library.
+
+    // We need to know whether we're consuming (importing) a DLL or static LIB
+    // The default is a static LIB as that's what existing code/builds expect.
+    #ifdef SIX_SIX_DLL_
+        // Actually, it seems that the linker is able to figure this out from the .LIB, so 
+        // there doesn't seem to be a need for __declspec(dllimport).  Clients don't
+        // need to #define SIX_SIX_DLL_ ... ?  Well, almost ... it looks
+        // like __declspec(dllimport) is needed to get virtual "inline"s (e.g., 
+        // destructors) correct.
+        #define SIX_SIX_API CODA_OSS_library_import
+    #else
+        #define SIX_SIX_API /* "importing" a static LIB */
+    #endif
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable: 4251) // '...' : class '...' needs to have dll-interface to be used by clients of struct '...'
+#endif

--- a/six/modules/c++/six/include/six/GeoDataBase.h
+++ b/six/modules/c++/six/include/six/GeoDataBase.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_GEO_DATA_BASE_H__
 #define __SIX_GEO_DATA_BASE_H__
 
@@ -27,6 +28,7 @@
 #include "six/GeoInfo.h"
 #include "six/Parameter.h"
 #include "six/ParameterCollection.h"
+#include "six/Exports.h"
 #include "scene/ProjectionModel.h"
 #include <mem/ScopedCloneablePtr.h>
 #include <logging/Logger.h>
@@ -42,7 +44,7 @@ namespace six
  *
  *  Compiler-generated copy constructor and assignment operator are sufficient
  */
-struct GeoDataBase
+struct SIX_SIX_API GeoDataBase
 {
     GeoDataBase() = default;
 

--- a/six/modules/c++/six/include/six/GeoInfo.h
+++ b/six/modules/c++/six/include/six/GeoInfo.h
@@ -81,7 +81,7 @@ struct SIX_SIX_API GeoInfo
 };
 
 //! Ostream operator
-std::ostream& operator<< (std::ostream& os, const GeoInfo& g);
+SIX_SIX_API std::ostream& operator<< (std::ostream& os, const GeoInfo& g);
 }
 
 #endif

--- a/six/modules/c++/six/include/six/GeoInfo.h
+++ b/six/modules/c++/six/include/six/GeoInfo.h
@@ -20,6 +20,7 @@
  *
  */
 
+#pragma once
 #ifndef __SIX_GEO_INFO_H__
 #define __SIX_GEO_INFO_H__
 
@@ -28,6 +29,7 @@
 
 #include <six/Types.h>
 #include <six/ParameterCollection.h>
+#include <six/Exports.h>
 #include <mem/ScopedCopyablePtr.h>
 
 namespace six
@@ -41,7 +43,7 @@ namespace six
  *
  *  Compiler-generated copy constructor and assignment operator are sufficient
  */
-struct GeoInfo
+struct SIX_SIX_API GeoInfo
 {
     GeoInfo() = default;
 

--- a/six/modules/c++/six/include/six/Init.h
+++ b/six/modules/c++/six/include/six/Init.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_six_Init_h_INCLUDED_
 #define SIX_six_Init_h_INCLUDED_
-#pragma once
 
 #include <assert.h>
 
@@ -34,6 +34,7 @@
 #include <types/RgAz.h>
 #include <import/except.h>
 #include <except/Exception.h>
+#include <six/Exports.h>
 
 namespace six
 {
@@ -49,7 +50,7 @@ DECLARE_EXCEPTION(UninitializedValue);
  *  Sometimes, the init value is the same as the default constructor
  *  (e.g., std::string), in which case this doesn't need to be used
  */
-struct Init
+struct SIX_SIX_API Init final
 {
     template<typename T> static bool isUndefined(T value)
     {
@@ -72,61 +73,65 @@ struct Init
 // This is intentionally undefined in order to generate a linker error
 template<> bool Init::undefined<bool>();
 
-template<> std::string Init::undefined<std::string>();
-template<> float Init::undefined<float>();
-template<> double Init::undefined<double>();
-template<> types::RgAz<double> Init::undefined<types::RgAz<double> >();
-template<> RowColInt Init::undefined<RowColInt>();
-template<> RowColDouble Init::undefined<RowColDouble>();
-template<> DecorrType Init::undefined<DecorrType>();
-template<> AngleMagnitude Init::undefined<AngleMagnitude>();
-template<> DateTime Init::undefined<DateTime>();
-template<> Vector3 Init::undefined<Vector3>();
-template<> LatLon Init::undefined<LatLon>();
-template<> LatLonAlt Init::undefined<LatLonAlt>();
-template<> ReferencePoint Init::undefined<ReferencePoint>();
-template<> Poly1D Init::undefined<Poly1D>();
-template<> Poly2D Init::undefined<Poly2D>();
-template<> PolyXYZ Init::undefined<PolyXYZ>();
-template<> Parameter Init::undefined<Parameter>();
+#define SIX_Init_undefined_(T) template<> SIX_SIX_API T Init::undefined<T>()
+
+SIX_Init_undefined_(std::string);
+SIX_Init_undefined_(float);
+SIX_Init_undefined_(double);
+SIX_Init_undefined_(types::RgAz<double>);
+SIX_Init_undefined_(RowColInt);
+SIX_Init_undefined_(RowColDouble);
+SIX_Init_undefined_(DecorrType);
+SIX_Init_undefined_(AngleMagnitude);
+SIX_Init_undefined_(DateTime);
+SIX_Init_undefined_(Vector3);
+SIX_Init_undefined_(LatLon);
+SIX_Init_undefined_(LatLonAlt);
+SIX_Init_undefined_(ReferencePoint);
+SIX_Init_undefined_(Poly1D);
+SIX_Init_undefined_(Poly2D);
+SIX_Init_undefined_(PolyXYZ);
+SIX_Init_undefined_(Parameter);
 
 // enums
-template<> AppliedType Init::undefined<AppliedType>();
-template<> AutofocusType Init::undefined<AutofocusType>();
-template<> BooleanType Init::undefined<BooleanType>();
-template<> ByteSwapping Init::undefined<ByteSwapping>();
-template<> CollectType Init::undefined<CollectType>();
-template<> ComplexImageGridType Init::undefined<ComplexImageGridType>();
-template<> ComplexImagePlaneType Init::undefined<ComplexImagePlaneType>();
-template<> LatLonCorners Init::undefined<LatLonCorners>();
-template<> LatLonAltCorners Init::undefined<LatLonAltCorners>();
-template<> DataType Init::undefined<DataType>();
-template<> DecimationMethod Init::undefined<DecimationMethod>();
-template<> DemodType Init::undefined<DemodType>();
-template<> DisplayType Init::undefined<DisplayType>();
-template<> DualPolarizationType Init::undefined<DualPolarizationType>();
-template<> EarthModelType Init::undefined<EarthModelType>();
-template<> FFTSign Init::undefined<FFTSign>();
-template<> FrameType Init::undefined<FrameType>();
-template<> ImageBeamCompensationType Init::undefined<ImageBeamCompensationType>();
-template<> ImageFormationType Init::undefined<ImageFormationType>();
-template<> MagnificationMethod Init::undefined<MagnificationMethod>();
-template<> OrientationType Init::undefined<OrientationType>();
-template<> PixelType Init::undefined<PixelType>();
-template<> PolarizationSequenceType Init::undefined<PolarizationSequenceType>();
-template<> PolarizationType Init::undefined<PolarizationType>();
-template<> ProjectionType Init::undefined<ProjectionType>();
-template<> RMAlgoType Init::undefined<RMAlgoType>();
-template<> RadarModeType Init::undefined<RadarModeType>();
-template<> RegionType Init::undefined<RegionType>();
-template<> RowColEnum Init::undefined<RowColEnum>();
-template<> SCPType Init::undefined<SCPType>();
-template<> SideOfTrackType Init::undefined<SideOfTrackType>();
-template<> SlowTimeBeamCompensationType Init::undefined<SlowTimeBeamCompensationType>();
-template<> XYZEnum Init::undefined<XYZEnum>();
+SIX_Init_undefined_(AppliedType);
+SIX_Init_undefined_(AutofocusType);
+SIX_Init_undefined_(BooleanType);
+SIX_Init_undefined_(ByteSwapping);
+SIX_Init_undefined_(CollectType);
+SIX_Init_undefined_(ComplexImageGridType);
+SIX_Init_undefined_(ComplexImagePlaneType);
+SIX_Init_undefined_(LatLonCorners);
+SIX_Init_undefined_(LatLonAltCorners);
+SIX_Init_undefined_(DataType);
+SIX_Init_undefined_(DecimationMethod);
+SIX_Init_undefined_(DemodType);
+SIX_Init_undefined_(DisplayType);
+SIX_Init_undefined_(DualPolarizationType);
+SIX_Init_undefined_(EarthModelType);
+SIX_Init_undefined_(FFTSign);
+SIX_Init_undefined_(FrameType);
+SIX_Init_undefined_(ImageBeamCompensationType);
+SIX_Init_undefined_(ImageFormationType);
+SIX_Init_undefined_(MagnificationMethod);
+SIX_Init_undefined_(OrientationType);
+SIX_Init_undefined_(PixelType);
+SIX_Init_undefined_(PolarizationSequenceType);
+SIX_Init_undefined_(PolarizationType);
+SIX_Init_undefined_(ProjectionType);
+SIX_Init_undefined_(RMAlgoType);
+SIX_Init_undefined_(RadarModeType);
+SIX_Init_undefined_(RegionType);
+SIX_Init_undefined_(RowColEnum);
+SIX_Init_undefined_(SCPType);
+SIX_Init_undefined_(SideOfTrackType);
+SIX_Init_undefined_(SlowTimeBeamCompensationType);
+SIX_Init_undefined_(XYZEnum);
 
-template<> bool Init::isUndefined<float>(float);
-template<> bool Init::isUndefined<double>(double);
+#undef SIX_Init_undefined_
+
+template<> SIX_SIX_API bool Init::isUndefined<float>(float);
+template<> SIX_SIX_API bool Init::isUndefined<double>(double);
 
 // These allow switching between `double` and `std::optional<double>` w/o changing a lot of other code.
 template<typename T>

--- a/six/modules/c++/six/include/six/Logger.h
+++ b/six/modules/c++/six/include/six/Logger.h
@@ -20,19 +20,21 @@
  *
  */
 
+#pragma once
 #ifndef SIX_six_Logger_h_INCLUDED_
 #define SIX_six_Logger_h_INCLUDED_
-#pragma once
 
 #include <memory>
 #include <new> // std::nothrow_t
 
 #include <import/logging.h>
 
+#include "six/Exports.h"
+
 namespace six
 {
 	// Encapsulate common (and legacy) logging code
-	class Logger final
+	class SIX_SIX_API Logger final
 	{
 		logging::Logger* pLog_ = nullptr;
 		bool ownLog_ = false;

--- a/six/modules/c++/six/include/six/MatchInformation.h
+++ b/six/modules/c++/six/include/six/MatchInformation.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_MATCH_INFORMATION_H__
 #define __SIX_MATCH_INFORMATION_H__
 
@@ -26,6 +27,7 @@
 #include <six/Init.h>
 #include <six/Parameter.h>
 #include <six/ParameterCollection.h>
+#include <six/Exports.h>
 
 namespace six
 {
@@ -39,7 +41,7 @@ namespace six
  *      - coreName
  *      - parameters
  */
-struct MatchCollect
+struct SIX_SIX_API MatchCollect
 {
     //! Constructor
     MatchCollect();
@@ -75,7 +77,7 @@ struct MatchCollect
  *  collection.  Match types are text strings describing the
  *  collection (e.g., COHERENT, STEREO)
  */
-struct MatchType
+struct SIX_SIX_API MatchType
 {
     //! Constructor
     MatchType();
@@ -119,7 +121,7 @@ struct MatchType
  *  or related to this collection.  This parameter block is optional
  *  in the SICD and SIDD specs.
  */
-struct MatchInformation
+struct SIX_SIX_API MatchInformation
 {
 public:
     //!  Constructor.  Creates a single default-constructed collection.

--- a/six/modules/c++/six/include/six/MatchInformation.h
+++ b/six/modules/c++/six/include/six/MatchInformation.h
@@ -148,7 +148,7 @@ public:
     /*
      *  Ostream operators for six::MatchInformation type
      */
-    friend std::ostream& operator<< (std::ostream& os, const MatchInformation& m);
+    SIX_SIX_API friend std::ostream& operator<< (std::ostream& os, const MatchInformation& m);
 };
 }
 

--- a/six/modules/c++/six/include/six/NITFHeaderCreator.h
+++ b/six/modules/c++/six/include/six/NITFHeaderCreator.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_NITF_HEADER_CREATOR_H__
 #define __SIX_NITF_HEADER_CREATOR_H__
 
@@ -31,6 +32,7 @@
 #include "six/NITFImageInfo.h"
 #include "six/Adapters.h"
 #include "six/Logger.h"
+#include "six/Exports.h"
 #include <import/logging.h>
 
 namespace six
@@ -43,7 +45,7 @@ namespace six
  *  This class helps in populating NITF header fields
  *  prior to writing.
  */
-struct NITFHeaderCreator
+struct SIX_SIX_API NITFHeaderCreator
 {
     //! Constructor. Must call initialize to use.
     NITFHeaderCreator(FILE* log = stderr);

--- a/six/modules/c++/six/include/six/NITFHeaderCreator.h
+++ b/six/modules/c++/six/include/six/NITFHeaderCreator.h
@@ -207,7 +207,7 @@ struct SIX_SIX_API NITFHeaderCreator
         mXMLRegistry = xmlRegistry;
         if (!mXMLRegistry)
         {
-            mXMLRegistry = &XMLControlFactory::getInstance();
+            mXMLRegistry = &getXMLControlFactory();
         }
     }
 

--- a/six/modules/c++/six/include/six/NITFImageInfo.h
+++ b/six/modules/c++/six/include/six/NITFImageInfo.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_NITF_IMAGE_INFO_H__
 #define __SIX_NITF_IMAGE_INFO_H__
-#pragma once
 
 #include <string>
 
@@ -31,6 +31,7 @@
 #include <six/Data.h>
 #include <six/Utilities.h>
 #include <six/NITFSegmentInfo.h>
+#include <six/Exports.h>
 #include <nitf/ImageSegmentComputer.h>
 
 namespace six
@@ -48,7 +49,7 @@ namespace six
  *
  *
  */
-class NITFImageInfo
+class SIX_SIX_API NITFImageInfo
 {
 public:
     /*!

--- a/six/modules/c++/six/include/six/NITFReadControl.h
+++ b/six/modules/c++/six/include/six/NITFReadControl.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_NITF_READ_CONTROL_H__
 #define __SIX_NITF_READ_CONTROL_H__
-#pragma once
 
 #include <map>
 #include <memory>
@@ -31,6 +31,7 @@
 #include "six/ReadControl.h"
 #include "six/ReadControlFactory.h"
 #include "six/Adapters.h"
+#include "six/Exports.h"
 #include <io/SeekableStreams.h>
 #include <import/nitf.hpp>
 #include <nitf/IOStreamReader.hpp>
@@ -52,7 +53,7 @@ namespace six
  *  This class is not copyable.
  *
  */
-struct NITFReadControl : public ReadControl
+struct SIX_SIX_API NITFReadControl : public ReadControl
 {
     //!  Constructor
     NITFReadControl(FILE* log);

--- a/six/modules/c++/six/include/six/NITFSegmentInfo.h
+++ b/six/modules/c++/six/include/six/NITFSegmentInfo.h
@@ -19,12 +19,14 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_NITF_SEGMENT_INFO_H__
 #define __SIX_NITF_SEGMENT_INFO_H__
 
 #include <algorithm>
 
 #include <six/Types.h>
+#include <six/Exports.h>
 
 namespace six
 {
@@ -34,7 +36,7 @@ namespace six
  *
  *  This class contains the per-segment information for an image.
  */
-struct NITFSegmentInfo
+struct SIX_SIX_API NITFSegmentInfo
 {
     //! First row in the image segment in real space
     size_t firstRow = 0;

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_six_NITFWriteControl_h_INCLUDED_
 #define SIX_six_NITFWriteControl_h_INCLUDED_
-#pragma once
 
 #include <stdint.h>
 
@@ -42,6 +42,7 @@
 #include "six/NITFImageInfo.h"
 #include "six/Adapters.h"
 #include "six/NITFHeaderCreator.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -56,7 +57,7 @@ namespace six
  *  we take advantage of the WriteHandler API and bypass the normal
  *  blocker.
  */
-class NITFWriteControl : public WriteControl
+class SIX_SIX_API NITFWriteControl : public WriteControl
 {
     void addLegend(const Legend&, int imageNumber);
 

--- a/six/modules/c++/six/include/six/NITFWriteControl.h
+++ b/six/modules/c++/six/include/six/NITFWriteControl.h
@@ -561,7 +561,7 @@ private:
 };
 
 // Help out the compiler with overloads, and keep the class smaller.
-extern void save(NITFWriteControl&, const six::zfloat*, const std::string&, const std::vector<std::string>&);
+SIX_SIX_API void save(NITFWriteControl&, const six::zfloat*, const std::string&, const std::vector<std::string>&);
 
 template<typename T>
 inline void save(NITFWriteControl& writeControl, 

--- a/six/modules/c++/six/include/six/Options.h
+++ b/six/modules/c++/six/include/six/Options.h
@@ -19,12 +19,15 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_OPTIONS_H__
 #define __SIX_OPTIONS_H__
 
+#include <map>
+
 #include "six/Types.h"
 #include "six/Parameter.h"
-#include <map>
+#include "six/Exports.h"
 
 namespace six
 {
@@ -41,7 +44,7 @@ namespace six
  *  from a string type into the native one.
  *
  */
-class Options
+class SIX_SIX_API Options
 {
 public:
     typedef std::map<std::string, Parameter> ParameterMap;

--- a/six/modules/c++/six/include/six/Parameter.h
+++ b/six/modules/c++/six/include/six/Parameter.h
@@ -28,6 +28,7 @@
 #include <import/str.h>
 
 #include "six/Types.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -40,7 +41,7 @@ namespace six
  *  and get parameters directly from native types without string
  *  conversion.
  */
-struct Parameter final
+struct SIX_SIX_API Parameter final
 {
     Parameter() = default;
     ~Parameter() = default;

--- a/six/modules/c++/six/include/six/ParameterCollection.h
+++ b/six/modules/c++/six/include/six/ParameterCollection.h
@@ -19,13 +19,14 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 #ifndef __SIX_PARAMETER_COLLECTION_H__
 #define __SIX_PARAMETER_COLLECTION_H__
 
 #include <string>
 #include <vector>
 #include "six/Parameter.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -38,7 +39,7 @@ namespace six
  * This class keeps track of a set of parameters.
  *
  */
-class ParameterCollection
+class SIX_SIX_API ParameterCollection
 {
 public:
 

--- a/six/modules/c++/six/include/six/Radiometric.h
+++ b/six/modules/c++/six/include/six/Radiometric.h
@@ -19,12 +19,14 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_RADIOMETRIC_H__
 #define __SIX_RADIOMETRIC_H__
 
 #include "six/Types.h"
 #include "six/Init.h"
 #include "six/Parameter.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -35,7 +37,7 @@ namespace six
  *
  *  Field and subfields added in 1.0.0
  */
-struct NoiseLevel
+struct SIX_SIX_API NoiseLevel
 {
     NoiseLevel();
 
@@ -79,7 +81,7 @@ struct NoiseLevel
  *  undefined, in which case they will not be written out.
  *
  */
-struct Radiometric
+struct SIX_SIX_API Radiometric
 {
 public:
 

--- a/six/modules/c++/six/include/six/ReadControl.h
+++ b/six/modules/c++/six/include/six/ReadControl.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_READ_CONTROL_H__
 #define __SIX_READ_CONTROL_H__
 
@@ -32,6 +33,7 @@
 #include "six/Options.h"
 #include "six/XMLControlFactory.h"
 #include "six/Logger.h"
+#include "six/Exports.h"
 #include <mem/ScopedArray.h>
 #include <import/logging.h>
 
@@ -55,7 +57,7 @@ namespace six
  *  to know that the NITF is split due to technical complications.
  *
  */
-struct ReadControl
+struct SIX_SIX_API ReadControl
 {
     //!  Constructor.  Null-set the current container reference
     ReadControl() noexcept(false) : mLogger(mLog, mOwnLog, nullptr)

--- a/six/modules/c++/six/include/six/ReadControl.h
+++ b/six/modules/c++/six/include/six/ReadControl.h
@@ -210,7 +210,7 @@ struct SIX_SIX_API ReadControl
     {
         mXMLRegistry = xmlRegistry;
         if (!mXMLRegistry)
-            mXMLRegistry = &XMLControlFactory::getInstance();
+            mXMLRegistry = &getXMLControlFactory();
     }
     void setXMLControlRegistry(const XMLControlRegistry& xmlRegistry)
     {

--- a/six/modules/c++/six/include/six/SICommonXMLParser.h
+++ b/six/modules/c++/six/include/six/SICommonXMLParser.h
@@ -20,9 +20,9 @@
  *
  */
 
+#pragma once
 #ifndef SIX_six_SICommonXMLParser_h_INCLUDED_
 #define SIX_six_SICommonXMLParser_h_INCLUDED_
-#pragma once
 
 #include <six/CollectionInformation.h>
 #include <six/MatchInformation.h>
@@ -33,10 +33,11 @@
 #include <six/Radiometric.h>
 #include <six/GeoInfo.h>
 #include <six/MatchInformation.h>
+#include <six/Exports.h>
 
 namespace six
 {
-struct SICommonXMLParser : public XMLParser
+struct SIX_SIX_API SICommonXMLParser : public XMLParser
 {
     SICommonXMLParser(const std::string& defaultURI, bool addClassAttributes, const std::string& siCommonURI,
         logging::Logger* log = nullptr, bool ownLog = false);

--- a/six/modules/c++/six/include/six/SICommonXMLParser01x.h
+++ b/six/modules/c++/six/include/six/SICommonXMLParser01x.h
@@ -20,15 +20,17 @@
  *
  */
 
+#pragma once
 #ifndef __SIX_SI_COMPLEX_COMMON_XML_PARSER_01X_H__
 #define __SIX_SI_COMPLEX_COMMON_XML_PARSER_01X_H__
 
 #include <six/SICommonXMLParser.h>
+#include <six/Exports.h>
 
 namespace six
 {
 
-class SICommonXMLParser01x : public SICommonXMLParser
+class SIX_SIX_API SICommonXMLParser01x : public SICommonXMLParser
 {
 public:
     SICommonXMLParser01x(const std::string& defaultURI,

--- a/six/modules/c++/six/include/six/SICommonXMLParser10x.h
+++ b/six/modules/c++/six/include/six/SICommonXMLParser10x.h
@@ -20,16 +20,17 @@
  *
  */
 
+#pragma once
 #ifndef SIX_six_SICommonXMLParser10x_h_INCLUDED_
 #define SIX_six_SICommonXMLParser10x_h_INCLUDED_
-#pragma once
 
 #include <six/SICommonXMLParser.h>
+#include <six/Exports.h>
 
 namespace six
 {
 
-struct SICommonXMLParser10x : public SICommonXMLParser
+struct SIX_SIX_API SICommonXMLParser10x : public SICommonXMLParser
 {
     SICommonXMLParser10x(const std::string& defaultURI, bool addClassAttributes, const std::string& siCommonURI,
         logging::Logger* log = nullptr, bool ownLog = false);

--- a/six/modules/c++/six/include/six/Types.h
+++ b/six/modules/c++/six/include/six/Types.h
@@ -408,7 +408,7 @@ enum ImageMode
  *
  * \return Whether this corresponds to frame or scan mode
  */
-ImageMode getImageMode(RadarModeType radarMode);
+SIX_SIX_API ImageMode getImageMode(RadarModeType radarMode);
 
 /*!
  *  \class MissingRequiredException

--- a/six/modules/c++/six/include/six/Types.h
+++ b/six/modules/c++/six/include/six/Types.h
@@ -48,6 +48,7 @@
 #include "six/Enums.h"
 #include "six/Complex.h"
 #include "six/AmplitudeTable.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -103,7 +104,7 @@ typedef scene::FrameType FrameType;
  *
  *  Just a simple pair for error stats
  */
-struct DecorrType
+struct SIX_SIX_API DecorrType
 {
     DecorrType() = default;
         DecorrType(double ccz, double dr = 0.0) :
@@ -143,7 +144,7 @@ typedef types::RowCol<LatLon> RowColLatLon;
  *
  *  Static class to provide constant enums.
  */
-struct Constants
+struct SIX_SIX_API Constants final
 {
     //!  This is the upper bound of a NITF segment
     static const uint64_t IS_SIZE_MAX; // = 9999999998LL;
@@ -229,7 +230,7 @@ struct Constants
  *  and row-column position for a point.
  *
  */
-struct ReferencePoint final
+struct SIX_SIX_API ReferencePoint final
 {
     //!  ECEF location of point
     Vector3 ecef;
@@ -275,7 +276,7 @@ struct ReferencePoint final
  *  The SCP in ECEF (ecf, to match SICD convention) and LLH (or LatLonAlt
  *  as we refer to it).
  */
-struct SCP
+struct SIX_SIX_API SCP
 {
     SCP();
 

--- a/six/modules/c++/six/include/six/Types.h
+++ b/six/modules/c++/six/include/six/Types.h
@@ -55,7 +55,7 @@ namespace six
 static const char SCHEMA_PATH[] = "SIX_SCHEMA_PATH";
 // Gets the value of SIX_SCHEMA_PATH, or the compiled default if not set.
 // If the resulting path doesn't exist, an exception is thrown.
-extern std::string getSchemaPath(std::vector<std::string>&, bool tryToExpandIfNotFound = false);
+SIX_SIX_API std::string getSchemaPath(std::vector<std::string>&, bool tryToExpandIfNotFound = false);
 
 /*!
  * \class DESValidationException

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -373,15 +373,15 @@ public:
 
 namespace testing
 {
-    std::filesystem::path findRootDir(const std::filesystem::path& dir);
-    std::filesystem::path buildRootDir(const std::filesystem::path& argv0);
+    SIX_SIX_API std::filesystem::path findRootDir(const std::filesystem::path& dir);
+    SIX_SIX_API std::filesystem::path buildRootDir(const std::filesystem::path& argv0);
 
-    std::filesystem::path getNitfPath(const  std::filesystem::path& filename);
-    std::filesystem::path getNitroPath(const  std::filesystem::path& filename);
+    SIX_SIX_API std::filesystem::path getNitfPath(const  std::filesystem::path& filename);
+    SIX_SIX_API std::filesystem::path getNitroPath(const  std::filesystem::path& filename);
 
-    std::vector<std::filesystem::path> getSchemaPaths();
-    std::filesystem::path getModuleFile(const std::filesystem::path& modulePath, const  std::filesystem::path& filename);
-    std::filesystem::path getSampleXmlPath(const std::filesystem::path& module /*"six.sicd"*/, const  std::filesystem::path& filename);
+    SIX_SIX_API std::vector<std::filesystem::path> getSchemaPaths();
+    SIX_SIX_API std::filesystem::path getModuleFile(const std::filesystem::path& modulePath, const  std::filesystem::path& filename);
+    SIX_SIX_API std::filesystem::path getSampleXmlPath(const std::filesystem::path& module /*"six.sicd"*/, const  std::filesystem::path& filename);
 }
 
 }

--- a/six/modules/c++/six/include/six/Utilities.h
+++ b/six/modules/c++/six/include/six/Utilities.h
@@ -44,6 +44,7 @@
 #include "scene/SceneGeometry.h"
 #include "six/ErrorStatistics.h"
 #include "six/Init.h"
+#include "six/Exports.h"
 #include <scene/Utilities.h>
 
 
@@ -92,90 +93,60 @@ template<typename T> T toType(const std::string& s)
     return str::toType<T>(s);
 }
 
-template<> std::string toString(const float& value);
-template<> std::string toString(const double& value);
-template<> std::string toString(const six::Vector3 & v);
-template<> std::string toString(const six::PolyXYZ & p);
-template<> six::EarthModelType
-        toType<six::EarthModelType>(const std::string& s);
-template<> six::MagnificationMethod
-        toType<six::MagnificationMethod>(const std::string& s);
-template<> std::string toString(const six::MagnificationMethod& value);
-template<> six::MagnificationMethod
-        toType<six::MagnificationMethod>(const std::string& s);
-template<> six::DecimationMethod
-        toType<six::DecimationMethod>(const std::string& s);
-template<> std::string toString(const six::DecimationMethod& value);
+#define SIX_toString_(T) template<> SIX_SIX_API std::string toString(const T&)
 
-template<> six::PixelType toType<six::PixelType>(const std::string& s);
-template<> std::string toString(const six::PixelType& value);
+SIX_toString_(float);
+SIX_toString_(double);
+SIX_toString_(six::Vector3);
+SIX_toString_(six::PolyXYZ);
 
-template<> six::RadarModeType toType<six::RadarModeType>(const std::string& s);
-template<> std::string toString(const six::RadarModeType& value);
+#define SIX_toType_(T) template<> SIX_SIX_API T toType<T>(const std::string&)
+#define SIX_toString_toType_(T) SIX_toString_(T); SIX_toType_(T)
 
-template<> six::DateTime toType<six::DateTime>(const std::string& s);
-template<> std::string toString(const six::DateTime& value);
+SIX_toString_toType_(six::EarthModelType);
+SIX_toString_toType_(six::MagnificationMethod);
+SIX_toString_toType_(six::DecimationMethod);
 
-template<> std::string toString(const six::DataType& value);
-template<> std::string toString(const six::EarthModelType& value);
-template<> six::OrientationType
-        toType<six::OrientationType>(const std::string& s);
-template<> std::string toString(const six::OrientationType& value);
-template<> six::PolarizationSequenceType
-        toType<six::PolarizationSequenceType>(const std::string& s);
-template<> std::string toString(const six::PolarizationSequenceType& value);
-template<> six::PolarizationType
-        toType<six::PolarizationType>(const std::string& s);
-template<> std::string toString(const six::PolarizationType& value);
+SIX_toString_toType_(six::PixelType);
 
-template<> std::string toString(const six::DualPolarizationType& value);
-template<> six::DualPolarizationType
-        toType<six::DualPolarizationType>(const std::string& s);
-template<> six::DemodType toType<six::DemodType>(const std::string& s);
-template<> std::string toString(const six::DemodType& value);
+SIX_toString_toType_(six::RadarModeType);
 
-template<> std::string toString(const six::ImageFormationType& value);
-template<> six::ImageFormationType
-        toType<six::ImageFormationType>(const std::string& s);
-template<> std::string toString(const six::SlowTimeBeamCompensationType& value);
-template<> six::SlowTimeBeamCompensationType toType<
-        six::SlowTimeBeamCompensationType>(const std::string& s);
-template<> std::string toString(const six::ImageBeamCompensationType& value);
-template<> six::ImageBeamCompensationType
-toType<six::ImageBeamCompensationType>(const std::string& s);
-template<> std::string toString(const six::AutofocusType& value);
-template<> six::AutofocusType toType<six::AutofocusType>(const std::string& s);
-template<> std::string toString(const six::RMAlgoType& value);
-template<> six::RMAlgoType toType<six::RMAlgoType>(const std::string& s);
-template<> std::string toString(const six::SideOfTrackType& value);
+SIX_toString_toType_(six::DateTime);
 
-template<> six::BooleanType toType<six::BooleanType>(const std::string& s);
-template<> std::string toString(const six::BooleanType& value);
+SIX_toString_(six::DataType);
+SIX_toString_toType_(six::OrientationType);
+SIX_toString_toType_(six::PolarizationSequenceType);
+SIX_toString_toType_(six::PolarizationType);
 
-template<> six::SideOfTrackType
-        toType<six::SideOfTrackType>(const std::string& s);
+SIX_toString_toType_(six::DualPolarizationType);
+SIX_toString_toType_(six::DemodType);
 
-template<> six::ComplexImagePlaneType
-        toType<six::ComplexImagePlaneType>(const std::string& s);
-template<> std::string toString(const six::ComplexImagePlaneType& value);
+SIX_toString_toType_(six::ImageFormationType);
+SIX_toString_toType_(six::SlowTimeBeamCompensationType);
+SIX_toString_toType_(six::ImageBeamCompensationType);
+SIX_toString_toType_(six::AutofocusType);
+SIX_toString_toType_(six::RMAlgoType);
+SIX_toString_toType_(six::SideOfTrackType);
 
-template<> six::ComplexImageGridType
-        toType<six::ComplexImageGridType>(const std::string& s);
-template<> std::string toString(const six::ComplexImageGridType& value);
+SIX_toString_toType_(six::BooleanType);
 
-template<> six::FFTSign toType<six::FFTSign>(const std::string& s);
-template<> std::string toString(const six::FFTSign& value);
+SIX_toString_toType_(six::ComplexImagePlaneType);
 
-template<> six::AppliedType toType<six::AppliedType>(const std::string& s);
-template<> std::string toString(const six::AppliedType& value);
+SIX_toString_toType_(six::ComplexImageGridType);
 
-template<> six::CollectType toType<six::CollectType>(const std::string& s);
-template<> std::string toString(const six::CollectType& value);
+SIX_toString_toType_(six::FFTSign);
 
-template<> six::FrameType toType<six::FrameType>(const std::string& s);
-template<> std::string toString(const six::FrameType& value);
+SIX_toString_toType_(six::AppliedType);
 
-template<> std::string toString(const six::LatLonCorners& corners);
+SIX_toString_toType_(six::CollectType);
+
+SIX_toString_toType_(six::FrameType);
+
+SIX_toString_(six::LatLonCorners);
+
+#undef SIX_toString_
+#undef SIX_toType_
+#undef SIX_toString_toType_
 
 // Load the TRE plugins in the given directory
 // In most cases this is not needed as XML_DATA_CONTENT is linked statically
@@ -202,12 +173,12 @@ void loadXmlDataContentHandler(FILE* log);
  *
  * \return Data representation of 'xmlStream'
  */
-std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg, 
+SIX_SIX_API std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
                               ::io::InputStream& xmlStream, 
                               DataType dataType,
                               const std::vector<std::string>& schemaPaths,
                               logging::Logger& log);
-std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
+SIX_SIX_API std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
     ::io::InputStream& xmlStream, DataType dataType,
     const std::vector<std::filesystem::path>*, logging::Logger&);
 
@@ -222,11 +193,11 @@ std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
  *
  * \return Data representation of 'xmlStream'
  */
-std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
+SIX_SIX_API std::unique_ptr<Data> parseData(const XMLControlRegistry& xmlReg,
                               ::io::InputStream& xmlStream,
                               const std::vector<std::string>& schemaPaths,
                               logging::Logger& log);
-std::unique_ptr<Data> parseData(const XMLControlRegistry&, ::io::InputStream&,
+SIX_SIX_API std::unique_ptr<Data> parseData(const XMLControlRegistry&, ::io::InputStream&,
     const std::vector<std::filesystem::path>*, logging::Logger&);
 
 /*
@@ -241,7 +212,7 @@ std::unique_ptr<Data> parseData(const XMLControlRegistry&, ::io::InputStream&,
  *
  * \return Data representation of the contents of 'pathname'
  */
-std::unique_ptr<Data> parseDataFromFile(const XMLControlRegistry& xmlReg,
+SIX_SIX_API std::unique_ptr<Data> parseDataFromFile(const XMLControlRegistry& xmlReg,
     const std::string& pathname,
     DataType dataType,
     const std::vector<std::string>& schemaPaths,
@@ -258,7 +229,7 @@ std::unique_ptr<Data> parseDataFromFile(const XMLControlRegistry& xmlReg,
  *
  * \return Data representation of the contents of 'pathname'
  */
-std::unique_ptr<Data> parseDataFromFile(const XMLControlRegistry& xmlReg,
+SIX_SIX_API std::unique_ptr<Data> parseDataFromFile(const XMLControlRegistry& xmlReg,
     const std::string& pathname,
     const std::vector<std::string>& schemaPaths,
     logging::Logger& log);
@@ -306,7 +277,7 @@ std::unique_ptr<Data> parseDataFromString(const XMLControlRegistry& xmlReg,
     const std::vector<std::filesystem::path>* pSchemaPaths,
     logging::Logger* pLogger = nullptr);
 
-void getErrors(const ErrorStatistics* errorStats,
+SIX_SIX_API void getErrors(const ErrorStatistics* errorStats,
                const types::RgAz<double>& sampleSpacing,
                scene::Errors& errors);
 
@@ -319,7 +290,7 @@ void getErrors(const ErrorStatistics* errorStats,
  */
 std::string findSchemaPath(const std::string& progname);
 
-class DataParser final
+class SIX_SIX_API DataParser final
 {
     const std::vector<std::filesystem::path>* mpSchemaPaths = nullptr;
     logging::NullLogger mNullLogger;

--- a/six/modules/c++/six/include/six/VersionUpdater.h
+++ b/six/modules/c++/six/include/six/VersionUpdater.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_VERSION_UPDATER_H__
 #define __SIX_VERSION_UPDATER_H__
 
@@ -26,6 +27,7 @@
 #include <vector>
 #include <logging/Logger.h>
 #include <six/Data.h>
+#include <six/Exports.h>
 
 namespace six
 {
@@ -37,7 +39,7 @@ namespace six
  * updates. Some inserted fields will be valid XML but
  * mathematically garbage.
  */
-class VersionUpdater
+class SIX_SIX_API VersionUpdater
 {
 public:
     /*!

--- a/six/modules/c++/six/include/six/WriteControl.h
+++ b/six/modules/c++/six/include/six/WriteControl.h
@@ -273,7 +273,7 @@ protected:
     {
         mXMLRegistry = xmlRegistry;
         if (!mXMLRegistry)
-            mXMLRegistry = &XMLControlFactory::getInstance();
+            mXMLRegistry = &getXMLControlFactory();
     }
     std::shared_ptr<Container> mContainer;
     Options mOptions;

--- a/six/modules/c++/six/include/six/WriteControl.h
+++ b/six/modules/c++/six/include/six/WriteControl.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_six_WriteControl_h_INCLUDED_
 #define SIX_six_WriteControl_h_INCLUDED_
-#pragma once
 
 #include <memory>
 #include <std/span>
@@ -36,6 +36,7 @@
 #include "six/Options.h"
 #include "six/XMLControlFactory.h"
 #include "six/Logger.h"
+#include "six/Exports.h"
 #include <import/logging.h>
 
 namespace six
@@ -67,7 +68,7 @@ typedef std::vector<UByte*> NonConstBufferList;
  *  allows that data model to be transmitted to the container file format.
  *
  */
-struct WriteControl
+struct SIX_SIX_API WriteControl
 {
     //!  Global byte swap option.  Normally, you should leave this up to us
     static const char OPT_BYTE_SWAP[];

--- a/six/modules/c++/six/include/six/XMLControl.h
+++ b/six/modules/c++/six/include/six/XMLControl.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_XML_CONTROL_H__
 #define __SIX_XML_CONTROL_H__
 
@@ -33,6 +34,7 @@
 
 #include "six/Types.h"
 #include "six/Logger.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -60,7 +62,7 @@ namespace six
  *  They can also be used to interact with an XML model or a stub XML
  *  file as well.
  */
-class XMLControl
+class SIX_SIX_API XMLControl
 {
     public:
     //!  Constructor

--- a/six/modules/c++/six/include/six/XMLControlFactory.h
+++ b/six/modules/c++/six/include/six/XMLControlFactory.h
@@ -181,7 +181,7 @@ private:
  */
 std::u8string toXMLString(const Data* data,
                         const XMLControlRegistry *xmlRegistry = nullptr);
-std::string toXMLString_(const Data* data,
+SIX_SIX_API std::string toXMLString_(const Data* data,
     const XMLControlRegistry* xmlRegistry = nullptr);
 
 /*!

--- a/six/modules/c++/six/include/six/XMLControlFactory.h
+++ b/six/modules/c++/six/include/six/XMLControlFactory.h
@@ -188,14 +188,14 @@ SIX_SIX_API std::string toXMLString_(const Data* data,
  *  Additionally performs schema validation --
  *  This function must must receive a valid logger to print validation errors
  */
-std::u8string toValidXMLString(
+SIX_SIX_API std::u8string toValidXMLString(
         const Data* data,
         const std::vector<std::string>& schemaPaths,
         logging::Logger* log,
         const XMLControlRegistry *xmlRegistry = nullptr);
-std::u8string toValidXMLString(const Data&,
+SIX_SIX_API std::u8string toValidXMLString(const Data&,
     const std::vector<std::string>& schemaPaths, logging::Logger*, const XMLControlRegistry* xmlRegistry = nullptr);
-std::u8string toValidXMLString(const Data&,
+SIX_SIX_API std::u8string toValidXMLString(const Data&,
     const std::vector<std::filesystem::path>*, logging::Logger*, const XMLControlRegistry* xmlRegistry = nullptr);
 
 //!  Singleton declaration of our XMLControlRegistry

--- a/six/modules/c++/six/include/six/XMLControlFactory.h
+++ b/six/modules/c++/six/include/six/XMLControlFactory.h
@@ -19,6 +19,7 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef __SIX_XML_CONTROL_FACTORY_H__
 #define __SIX_XML_CONTROL_FACTORY_H__
 
@@ -34,6 +35,7 @@
 #include <scene/sys_Conf.h>
 
 #include "six/XMLControl.h"
+#include "six/Exports.h"
 
 namespace six
 {
@@ -91,7 +93,7 @@ template <typename T> struct XMLControlCreatorT : public XMLControlCreator
  *  identify which reader/writer to create, and one that uses a
  *  string (the same one that identifies the type in the container)
  */
-struct XMLControlRegistry
+struct SIX_SIX_API XMLControlRegistry
 {
     //!  Destructor
     virtual ~XMLControlRegistry();

--- a/six/modules/c++/six/include/six/XMLControlFactory.h
+++ b/six/modules/c++/six/include/six/XMLControlFactory.h
@@ -199,7 +199,7 @@ std::u8string toValidXMLString(const Data&,
     const std::vector<std::filesystem::path>*, logging::Logger*, const XMLControlRegistry* xmlRegistry = nullptr);
 
 //!  Singleton declaration of our XMLControlRegistry
-typedef mt::Singleton<XMLControlRegistry, true> XMLControlFactory;
+SIX_SIX_API XMLControlRegistry& getXMLControlFactory();
 
 }
 

--- a/six/modules/c++/six/include/six/XMLParser.h
+++ b/six/modules/c++/six/include/six/XMLParser.h
@@ -19,9 +19,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_six_XMLParser_h_INCLUDED_
 #define SIX_six_XMLParser_h_INCLUDED_
-#pragma once
 
 #include <assert.h>
 
@@ -38,10 +38,11 @@
 #include <xml/lite/Element.h>
 #include <six/XmlLite.h>
 #include <six/Logger.h>
+#include <six/Exports.h>
 
 namespace six
 {
-struct XMLParser
+struct SIX_SIX_API XMLParser
 {
     XMLParser(const std::string& defaultURI, bool addClassAttributes,
         logging::Logger* log = nullptr, bool ownLog = false);

--- a/six/modules/c++/six/include/six/XmlLite.h
+++ b/six/modules/c++/six/include/six/XmlLite.h
@@ -315,16 +315,16 @@ private:
     return createString_(name, p, parent);
   }
 
- xml::lite::Element& create(const XmlLite&, const XsElement<double>&, xml::lite::Element& parent);
- void getFirstAndOnly(const XmlLite&, const xml::lite::Element&, XsElement<double>&);
+    SIX_SIX_API xml::lite::Element& create(const XmlLite&, const XsElement<double>&, xml::lite::Element& parent);
+    SIX_SIX_API void getFirstAndOnly(const XmlLite&, const xml::lite::Element&, XsElement<double>&);
 
- xml::lite::Element* create(const XmlLite&, const XsElement_minOccurs0<bool>&, xml::lite::Element& parent);
- xml::lite::Element* create(const XmlLite&, const XsElement_minOccurs0<double>&, xml::lite::Element& parent);
- xml::lite::Element* create(const XmlLite&, const XsElement_minOccurs0<std::u8string>&, xml::lite::Element& parent);
+    SIX_SIX_API xml::lite::Element* create(const XmlLite&, const XsElement_minOccurs0<bool>&, xml::lite::Element& parent);
+    SIX_SIX_API xml::lite::Element* create(const XmlLite&, const XsElement_minOccurs0<double>&, xml::lite::Element& parent);
+    SIX_SIX_API xml::lite::Element* create(const XmlLite&, const XsElement_minOccurs0<std::u8string>&, xml::lite::Element& parent);
 
- bool parse(const XmlLite&, const xml::lite::Element&, XsElement_minOccurs0<bool>&);
- bool parse(const XmlLite&, const xml::lite::Element&, XsElement_minOccurs0<double>&);
- bool parse(const XmlLite&, const xml::lite::Element&, XsElement_minOccurs0<std::u8string>&);
+    SIX_SIX_API bool parse(const XmlLite&, const xml::lite::Element&, XsElement_minOccurs0<bool>&);
+    SIX_SIX_API bool parse(const XmlLite&, const xml::lite::Element&, XsElement_minOccurs0<double>&);
+    SIX_SIX_API bool parse(const XmlLite&, const xml::lite::Element&, XsElement_minOccurs0<std::u8string>&);
 
 }
 

--- a/six/modules/c++/six/include/six/XmlLite.h
+++ b/six/modules/c++/six/include/six/XmlLite.h
@@ -20,9 +20,9 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 #ifndef SIX_six_XmlLite_h_INCLUDED_
 #define SIX_six_XmlLite_h_INCLUDED_
-#pragma once
 
 #include <assert.h>
 
@@ -40,11 +40,12 @@
 #include <six/Utilities.h>
 #include <six/Logger.h>
 #include <six/XsElement.h>
+#include <six/Exports.h>
 
 namespace six
 {
 // A simple wrapper around xml::lite::MinidomParser
-struct MinidomParser final
+struct SIX_SIX_API MinidomParser final
 {
     MinidomParser();
     ~MinidomParser();
@@ -92,7 +93,7 @@ inline const xml::lite::Document& getDocument(const MinidomParser& xmlParser)
 }
 
 
-struct XmlLite final
+struct SIX_SIX_API XmlLite final
 {
     XmlLite(const xml::lite::Uri& defaultURI, bool addClassAttributes,
         logging::Logger* log = nullptr, bool ownLog = false);

--- a/six/modules/c++/six/six.vcxproj
+++ b/six/modules/c++/six/six.vcxproj
@@ -19,12 +19,12 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -51,7 +51,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_SIX_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -81,7 +81,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_LIB;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;SIX_DEFAULT_SCHEMA_PATH=R"($(SolutionDir)install-$(Configuration)-$(Platform).$(PlatformToolset)\conf\schema\six)";%(PreprocessorDefinitions);_SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING; CODA_OSS_LIBRARY_SHARED; SIX_SIX_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -117,6 +117,7 @@
     <ClInclude Include="include\six\Enum.h" />
     <ClInclude Include="include\six\Enums.h" />
     <ClInclude Include="include\six\ErrorStatistics.h" />
+    <ClInclude Include="include\six\Exports.h" />
     <ClInclude Include="include\six\GeoDataBase.h" />
     <ClInclude Include="include\six\GeoInfo.h" />
     <ClInclude Include="include\six\Init.h" />
@@ -194,6 +195,23 @@
     <ClCompile Include="source\XMLControlFactory.cpp" />
     <ClCompile Include="source\XmlLite.cpp" />
     <ClCompile Include="source\XMLParser.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\externals\coda-oss\modules\c++\coda-oss.vcxproj">
+      <Project>{9997e895-5161-4ddf-8f3f-099894cb2f21}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c++\nitf-c++.vcxproj">
+      <Project>{8f357a19-799e-4971-850e-3f28485c130b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c\nitf-c.vcxproj">
+      <Project>{f06550ad-cfc7-40b8-8727-6c82c69a8982}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\externals\nitro\modules\c\nitf\XML_DATA_CONTENT.vcxproj">
+      <Project>{78849481-d356-4cc7-b182-31c21f857ed1}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\scene\scene.vcxproj">
+      <Project>{1cfcde59-6410-4037-95eb-b37d31e10820}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/six/modules/c++/six/six.vcxproj.filters
+++ b/six/modules/c++/six/six.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClInclude Include="include\six\XsElement.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\six\Exports.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/six/modules/c++/six/source/Types.cpp
+++ b/six/modules/c++/six/source/Types.cpp
@@ -22,6 +22,7 @@
 #include "six/Types.h"
 
 #include "six/Init.h"
+#include "six/Exports.h"
 #include <nitf/ImageSegmentComputer.h>
 
 std::ostream& operator<<(std::ostream& os, const scene::LatLonAlt& latLonAlt)
@@ -80,7 +81,7 @@ ImageMode getImageMode(RadarModeType radarMode)
     }
 }
 
-template<>
+template<> SIX_SIX_API
 LatLonCorners::Corners() :
     upperLeft(Init::undefined<LatLon>()),
     upperRight(Init::undefined<LatLon>()),
@@ -89,7 +90,7 @@ LatLonCorners::Corners() :
 {
 }
 
-template<>
+template<> SIX_SIX_API
 LatLonAltCorners::Corners() :
     upperLeft(Init::undefined<LatLonAlt>()),
     upperRight(Init::undefined<LatLonAlt>()),

--- a/six/modules/c++/six/source/XMLControlFactory.cpp
+++ b/six/modules/c++/six/source/XMLControlFactory.cpp
@@ -92,7 +92,7 @@ std::u8string six_toValidXMLString(const Data& data,
 {
     if (!xmlRegistry)
     {
-        xmlRegistry = &XMLControlFactory::getInstance();
+        xmlRegistry = &getXMLControlFactory();
     }
 
     const std::unique_ptr<XMLControl>
@@ -126,4 +126,9 @@ std::u8string six::toValidXMLString(const Data& data,
     logging::Logger* log, const six::XMLControlRegistry* xmlRegistry)
 {
     return six_toValidXMLString(data, pSchemaPaths, log, xmlRegistry);
+}
+
+six::XMLControlRegistry& six::getXMLControlFactory()
+{
+    return mt::Singleton<XMLControlRegistry, true>::getInstance();
 }

--- a/six/modules/python/six.sicd/source/six_sicd.i
+++ b/six/modules/python/six.sicd/source/six_sicd.i
@@ -69,7 +69,7 @@ void writeNITF(const std::string& pathname, const std::vector<std::string>&
 {
     const std::complex<float>* image = reinterpret_cast<
             std::complex<float>* >(imageAdr);
-   six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+  six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
     mem::SharedPtr<six::Container> container(new six::Container(
             six::DataType::COMPLEX));
@@ -142,7 +142,7 @@ void cropSICDWrap(const std::string& inPathname,
               const std::string& outPathname)
 {
 
-    six::XMLControlFactory::getInstance().addCreator<six::sicd::ComplexXMLControl>();
+   six::getXMLControlFactory().addCreator<six::sicd::ComplexXMLControl>();
 
     cropSICD(inPathname, schemaPaths, aoiOffset,
 	         aoiDims, outPathname);


### PR DESCRIPTION
The various SIX components (e.g., **six.sicd**) are now build as DLLs in Visual Studio.