### PR TITLE
Fix elements passed in TX and Rcv PVP parsing

### DIFF
--- a/six/modules/c++/cphd/include/cphd/PVP.h
+++ b/six/modules/c++/cphd/include/cphd/PVP.h
@@ -629,18 +629,6 @@ struct SIX_CPHD_API Pvp final
      *   if format is invalid, or the receive antenna already has been set
      */
     void appendRcvAnt();
-    
-    /*
-     *  \func append
-     *
-     *  \brief Validate and append parameter to the next available block
-     *
-     *  \param[out] param The PVPType parameter that should be set
-     *
-     *  \throws except::Exception If param offset or size overlaps another parameter, or
-     *   if format is invalid
-     */
-    void append(six::XsElement_minOccurs0<TxAntenna>& ant);
 
     /*
      *  \func setParameter

--- a/six/modules/c++/cphd/include/cphd/PVP.h
+++ b/six/modules/c++/cphd/include/cphd/PVP.h
@@ -270,6 +270,20 @@ struct SIX_CPHD_API TxAntenna final
     {
         return !((*this) == other);
     }
+    
+    //! Given an offset, initialize all members respectively
+    void setOffset(const size_t offset)
+    {
+        txACX.value().param.setOffset(offset);      // 3 blocks
+        txACY.value().param.setOffset(offset + 3);  // 3 blocks
+        txEB.value().param.setOffset(offset + 6);  // 2 blocks
+    }
+    
+    //! Get the offset to the first member
+    const size_t getOffset() const
+    {
+        return txACX.value().param.getOffset();
+    }
 
     //! TxACX PVP Structure
     six::XsElement<PerVectorParameterXYZ> txACX{ "TxACX" };
@@ -307,7 +321,21 @@ struct SIX_CPHD_API RcvAntenna final
     {
         return !((*this) == other);
     }
-
+    
+    //! Given an offset, initialize all members respectively
+    void setOffset(const size_t offset)
+    {
+        rcvACX.value().param.setOffset(offset);      // 3 blocks
+        rcvACY.value().param.setOffset(offset + 3);  // 3 blocks
+        rcvEB.value().param.setOffset(offset + 6);  // 2 blocks
+    }
+    
+    //! Get the offset to the first member
+    const size_t getOffset() const
+    {
+        return rcvACX.value().param.getOffset();
+    }
+    
     //! RcvACX PVP Structure
     six::XsElement<PerVectorParameterXYZ> rcvACX{ "RcvACX" };
 
@@ -579,6 +607,38 @@ struct SIX_CPHD_API Pvp final
      *   if format is invalid
      */
     void append(PVPType& param);
+    
+    /*
+     *  \func append
+     *
+     *  \brief Add transmit antenna block to PVP data
+     *
+     *  \throws except::Exception If param offset or size overlaps another parameter, or
+     *   if format is invalid, or the transmit antenna already has been set
+     */
+    void appendTxAnt();
+    
+    /*
+     *  \func append
+     *
+     *  \brief Add receive antenna block to PVP data
+     *
+     *  \throws except::Exception If param offset or size overlaps another parameter, or
+     *   if format is invalid, or the receive antenna already has been set
+     */
+    void appendRcvAnt();
+    
+    /*
+     *  \func append
+     *
+     *  \brief Validate and append parameter to the next available block
+     *
+     *  \param[out] param The PVPType parameter that should be set
+     *
+     *  \throws except::Exception If param offset or size overlaps another parameter, or
+     *   if format is invalid
+     */
+    void append(six::XsElement_minOccurs0<TxAntenna>& ant);
 
     /*
      *  \func setParameter

--- a/six/modules/c++/cphd/include/cphd/PVP.h
+++ b/six/modules/c++/cphd/include/cphd/PVP.h
@@ -271,7 +271,7 @@ struct SIX_CPHD_API TxAntenna final
         return !((*this) == other);
     }
     
-    //! Given an offset, initialize all members respectively
+    //! Given an initial offset, setup each member relative to it
     void setOffset(const size_t offset)
     {
         txACX.value().param.setOffset(offset);      // 3 blocks
@@ -280,6 +280,7 @@ struct SIX_CPHD_API TxAntenna final
     }
     
     //! Get the offset to the first member
+    //! This assumes the fields are sequential, which isn't necessarily true 
     const size_t getOffset() const
     {
         return txACX.value().param.getOffset();
@@ -322,7 +323,7 @@ struct SIX_CPHD_API RcvAntenna final
         return !((*this) == other);
     }
     
-    //! Given an offset, initialize all members respectively
+    //! Given an initial offset, setup each member relative to it
     void setOffset(const size_t offset)
     {
         rcvACX.value().param.setOffset(offset);      // 3 blocks
@@ -331,6 +332,7 @@ struct SIX_CPHD_API RcvAntenna final
     }
     
     //! Get the offset to the first member
+    //! This assumes the fields are sequential, which isn't necessarily true 
     const size_t getOffset() const
     {
         return rcvACX.value().param.getOffset();
@@ -609,7 +611,7 @@ struct SIX_CPHD_API Pvp final
     void append(PVPType& param);
     
     /*
-     *  \func append
+     *  \func appendTxAnt
      *
      *  \brief Add transmit antenna block to PVP data
      *
@@ -619,7 +621,7 @@ struct SIX_CPHD_API Pvp final
     void appendTxAnt();
     
     /*
-     *  \func append
+     *  \func appendRcvAnt
      *
      *  \brief Add receive antenna block to PVP data
      *

--- a/six/modules/c++/cphd/include/cphd/PVPBlock.h
+++ b/six/modules/c++/cphd/include/cphd/PVPBlock.h
@@ -86,6 +86,39 @@ struct AddedPVP<std::string>
     }
 };
 
+struct PvpAntenna
+{
+    Vector3 acx;
+    Vector3 acy;
+    Vector2 eb;
+    
+    PvpAntenna(
+        Vector3 acx,
+        Vector3 acy,
+        Vector2 eb):
+        acx(acx),
+        acy(acy),
+        eb(eb){};
+    
+    bool operator==(const PvpAntenna& other) const 
+    {
+        return (acx == other.acx) &&
+               (acy == other.acy) &&
+               (eb == other.eb); 
+    };
+    
+    bool operator!=(const PvpAntenna& other) const 
+    {
+        return !(*this == other); 
+    };
+};
+inline std::ostream& operator<<(std::ostream& os, const PvpAntenna& v)
+{
+    os << v.acx << "\n";
+    os << v.acy << "\n";
+    os << v.eb << "\n";
+    return os;
+}
 /*!
  *  \struct PVPBlock
  *
@@ -184,6 +217,8 @@ struct SIX_CPHD_API PVPBlock
     double getTOAE2(size_t channel, size_t set) const;
     double getTdIonoSRP(size_t channel, size_t set) const;
     std::int64_t getSignal(size_t channel, size_t set) const;
+    PvpAntenna getTxAntenna(size_t channel, size_t set) const;
+    PvpAntenna getRcvAntenna(size_t channel, size_t set) const;
 
     template<typename T>
     T getAddedPVP(size_t channel, size_t set, const std::string& name) const
@@ -223,6 +258,8 @@ struct SIX_CPHD_API PVPBlock
     void setTOAE2(double value, size_t channel, size_t set);
     void setTdIonoSRP(double value, size_t channel, size_t set);
     void setSignal(std::int64_t value, size_t channel, size_t set);
+    void setTxAntenna(PvpAntenna value, size_t channel, size_t set);
+    void setRcvAntenna(PvpAntenna value, size_t channel, size_t set);
 
     template<typename T>
     void setAddedPVP(T value, size_t channel, size_t set, const std::string& name)
@@ -311,6 +348,14 @@ struct SIX_CPHD_API PVPBlock
     bool hasSignal() const
     {
         return mSignalEnabled;
+    }
+    bool hasTxAntenna() const
+    {
+        return mTxAntennaEnabled;
+    }
+    bool hasRcvAntenna() const
+    {
+        return mRcvAntennaEnabled;
     }
 
     /*
@@ -416,7 +461,8 @@ protected:
                     ampSF == other.ampSF && fxN1 == other.fxN1 &&
                     fxN2 == other.fxN2 && toaE1 == other.toaE1 &&
                     toaE2 == other.toaE2 && tdIonoSRP == other.tdIonoSRP &&
-                    signal == other.signal && addedPVP == other.addedPVP;
+                    signal == other.signal && addedPVP == other.addedPVP &&
+                    txAntenna == other.txAntenna && rcvAntenna == other.rcvAntenna;
         }
         bool operator!=(const PVPSet& other) const
         {
@@ -450,6 +496,8 @@ protected:
         mem::ScopedCopyablePtr<double> toaE2;
         mem::ScopedCopyablePtr<double> tdIonoSRP;
         mem::ScopedCopyablePtr<std::int64_t> signal;
+        mem::ScopedCopyablePtr<PvpAntenna> txAntenna;
+        mem::ScopedCopyablePtr<PvpAntenna> rcvAntenna;
 
         //! (Optional) Additional parameters
         std::unordered_map<std::string,six::Parameter> addedPVP;
@@ -474,6 +522,8 @@ private:
     bool mToaE2Enabled;
     bool mTDIonoSRPEnabled;
     bool mSignalEnabled;
+    bool mTxAntennaEnabled;
+    bool mRcvAntennaEnabled;
 
     //! Ostream operator
     SIX_CPHD_API friend std::ostream& operator<< (std::ostream& os, const PVPBlock& p);

--- a/six/modules/c++/cphd/include/cphd/PVPBlock.h
+++ b/six/modules/c++/cphd/include/cphd/PVPBlock.h
@@ -88,17 +88,24 @@ struct AddedPVP<std::string>
 
 struct PvpAntenna
 {
+    PvpAntenna() :
+        acx(Vector3()),
+        acy(Vector3()),
+        eb(Vector2()) {};
+    PvpAntenna(Vector3 acx, Vector3 acy, Vector2 eb):
+        acx(acx),
+        acy(acy),
+        eb(eb) {};
+    ~PvpAntenna() = default;
+    PvpAntenna(const PvpAntenna&) = default;
+    PvpAntenna& operator=(const PvpAntenna&) = default;
+    PvpAntenna(PvpAntenna&&) = default;
+    PvpAntenna& operator=(PvpAntenna&&) = default;
+    
     Vector3 acx;
     Vector3 acy;
     Vector2 eb;
     
-    PvpAntenna(
-        Vector3 acx,
-        Vector3 acy,
-        Vector2 eb):
-        acx(acx),
-        acy(acy),
-        eb(eb){};
     
     bool operator==(const PvpAntenna& other) const 
     {
@@ -119,6 +126,7 @@ inline std::ostream& operator<<(std::ostream& os, const PvpAntenna& v)
     os << v.eb << "\n";
     return os;
 }
+
 /*!
  *  \struct PVPBlock
  *

--- a/six/modules/c++/cphd/include/cphd/TestDataGenerator.h
+++ b/six/modules/c++/cphd/include/cphd/TestDataGenerator.h
@@ -47,6 +47,14 @@ namespace cphd
 SIX_CPHD_API double getRandom();
 
 /*
+ *  \func getRandomVector2
+ *  \brief generates vector2D type object with random values
+ *
+ *  \return Return vector2D object
+ */
+SIX_CPHD_API Vector2 getRandomVector2();
+
+/*
  *  \func getRandomVector3
  *  \brief generates vector3D type object with random values
  *

--- a/six/modules/c++/cphd/source/CPHDXMLParser.cpp
+++ b/six/modules/c++/cphd/source/CPHDXMLParser.cpp
@@ -1460,7 +1460,7 @@ void CPHDXMLParser::parse(const xml::lite::Element& parent, six::XsElement_minOc
 {
     if (const auto pXML = getOptional(parent, o.tag()))
     {
-        o = TxAntenna{};
+        o.value().emplace();
         parse(getFirstAndOnly(*pXML, "TxACX"), value(o).txACX);
         parse(getFirstAndOnly(*pXML, "TxACY"), value(o).txACY);
         parse(getFirstAndOnly(*pXML, "TxEB"), value(o).txEB);
@@ -1470,7 +1470,7 @@ void CPHDXMLParser::parse(const xml::lite::Element& parent, six::XsElement_minOc
 {
     if (const auto pXML = getOptional(parent, o.tag()))
     {
-        o = RcvAntenna{};
+        o.value().emplace();
         parse(getFirstAndOnly(*pXML, "RcvACX"), value(o).rcvACX);
         parse(getFirstAndOnly(*pXML, "RcvACY"), value(o).rcvACY);
         parse(getFirstAndOnly(*pXML, "RcvEB"), value(o).rcvEB);

--- a/six/modules/c++/cphd/source/CPHDXMLParser.cpp
+++ b/six/modules/c++/cphd/source/CPHDXMLParser.cpp
@@ -1096,7 +1096,6 @@ std::unique_ptr<Metadata> CPHDXMLParser::fromXML(const xml::lite::Document* doc)
 {
     const auto version = CPHDXMLControl::uriToVersion(xml::lite::Uri(getDefaultURI()));
     auto result = fromXML(*doc, version);
-    std::cerr<<result;
     return std::make_unique<Metadata>(std::move(result));
 }
 

--- a/six/modules/c++/cphd/source/CPHDXMLParser.cpp
+++ b/six/modules/c++/cphd/source/CPHDXMLParser.cpp
@@ -1096,6 +1096,7 @@ std::unique_ptr<Metadata> CPHDXMLParser::fromXML(const xml::lite::Document* doc)
 {
     const auto version = CPHDXMLControl::uriToVersion(xml::lite::Uri(getDefaultURI()));
     auto result = fromXML(*doc, version);
+    std::cerr<<result;
     return std::make_unique<Metadata>(std::move(result));
 }
 

--- a/six/modules/c++/cphd/source/CPHDXMLParser.cpp
+++ b/six/modules/c++/cphd/source/CPHDXMLParser.cpp
@@ -1461,9 +1461,9 @@ void CPHDXMLParser::parse(const xml::lite::Element& parent, six::XsElement_minOc
     if (const auto pXML = getOptional(parent, o.tag()))
     {
         o = TxAntenna{};
-        parse(*pXML, value(o).txACX);
-        parse(*pXML, value(o).txACY);
-        parse(*pXML, value(o).txEB);
+        parse(getFirstAndOnly(*pXML, "TxACX"), value(o).txACX);
+        parse(getFirstAndOnly(*pXML, "TxACY"), value(o).txACY);
+        parse(getFirstAndOnly(*pXML, "TxEB"), value(o).txEB);
     }
 }
 void CPHDXMLParser::parse(const xml::lite::Element& parent, six::XsElement_minOccurs0<RcvAntenna>& o) const
@@ -1471,9 +1471,9 @@ void CPHDXMLParser::parse(const xml::lite::Element& parent, six::XsElement_minOc
     if (const auto pXML = getOptional(parent, o.tag()))
     {
         o = RcvAntenna{};
-        parse(*pXML, value(o).rcvACX);
-        parse(*pXML, value(o).rcvACY);
-        parse(*pXML, value(o).rcvEB);
+        parse(getFirstAndOnly(*pXML, "RcvACX"), value(o).rcvACX);
+        parse(getFirstAndOnly(*pXML, "RcvACY"), value(o).rcvACY);
+        parse(getFirstAndOnly(*pXML, "RcvEB"), value(o).rcvEB);
     }
 }
 

--- a/six/modules/c++/cphd/source/PVP.cpp
+++ b/six/modules/c++/cphd/source/PVP.cpp
@@ -285,11 +285,11 @@ std::ostream& operator<< (std::ostream& os, const Pvp& p)
     }
     if (has_value(p.txAntenna))
     {
-        os << "  TxAntenna        : \n" << p.txAntenna << "\n";
+        os <<  p.txAntenna;
     }
     if (has_value(p.rcvAntenna))
     {
-        os << "  RcvAntenna        : \n" << p.rcvAntenna << "\n";
+        os <<  p.rcvAntenna;
     }
     for (auto it = p.addedPVP.begin(); it != p.addedPVP.end(); ++it)
     {

--- a/six/modules/c++/cphd/source/PVP.cpp
+++ b/six/modules/c++/cphd/source/PVP.cpp
@@ -112,6 +112,30 @@ void Pvp::append(PVPType& param)
     setOffset(currentOffset, param);
 }
 
+void Pvp::appendTxAnt()
+{
+    size_t currentOffset = mParamLocations.size();
+    if(has_value(txAntenna))
+    {
+        throw except::Exception(Ctxt("txAntenna already set"));
+    } 
+    validate(8, currentOffset);
+    txAntenna.value().emplace();
+    value(txAntenna).setOffset(currentOffset);
+}
+
+void Pvp::appendRcvAnt()
+{
+    size_t currentOffset = mParamLocations.size();
+    if(has_value(rcvAntenna))
+    {
+        throw except::Exception(Ctxt("rcvAntenna already set"));
+    } 
+    validate(8, currentOffset);
+    rcvAntenna.value().emplace();
+    value(rcvAntenna).setOffset(currentOffset);
+}
+
 // Assumes addedPVP is already correct size
 void Pvp::setCustomParameter(size_t size, size_t offset, const std::string& format, const std::string& name)
 {
@@ -174,6 +198,14 @@ size_t Pvp::getReqSetSize() const
     if(!six::Init::isUndefined<size_t>(signal.getOffset()))
     {
         res += signal.getSize();
+    }
+    if(has_value(txAntenna))
+    {
+        res += 8;
+    }
+    if(has_value(rcvAntenna))
+    {
+        res += 8;
     }
     for (auto it = addedPVP.begin(); it != addedPVP.end(); ++it)
     {

--- a/six/modules/c++/cphd/source/PVPBlock.cpp
+++ b/six/modules/c++/cphd/source/PVPBlock.cpp
@@ -83,16 +83,6 @@ inline void setData(const std::byte* data_,
     setData(&(data[1]), dest[1]);
     setData(&(data[2]), dest[2]);
 }
-inline void setData(const std::byte* data_,
-                    cphd::PvpAntenna& dest)
-{
-    const void* pData_ = data_;
-    auto data = static_cast<const double*>(pData_);
-    setData(&data[0], dest.acx);
-    setData(&data[3], dest.acy);
-    setData(&data[6], dest.eb);
-}
-
 
 // Get data from data struct and put into data block
 template <typename T> inline void getData(std::byte* dest,
@@ -130,16 +120,6 @@ inline void getData(std::byte* dest_,
     getData(&(dest[0]), value[0]);
     getData(&(dest[1]), value[1]);
     getData(&(dest[2]), value[2]);
-}
-inline void getData(std::byte* dest_,
-                    const cphd::PvpAntenna& value)
-{
-    void* pDest_ = dest_;
-    auto dest = static_cast<std::byte*>(pDest_);
-
-    getData(dest, &value.acx);
-    getData(dest + sizeof(cphd::Vector3), &value.acy);
-    getData(dest + sizeof(cphd::Vector3), &value.eb);
 }
 }
 
@@ -224,12 +204,16 @@ void PVPBlock::PVPSet::write(const PVPBlock& pvpBlock, const Pvp& p, const sys::
     if (pvpBlock.hasTxAntenna())
     {
         txAntenna.reset(new PvpAntenna());
-        ::setData(input + value(p.txAntenna).getOffset() * 8, *txAntenna);
+        ::setData(input + value(p.txAntenna).txACX.value().param.getByteOffset(), txAntenna->acx);
+        ::setData(input + value(p.txAntenna).txACY.value().param.getByteOffset(), txAntenna->acy);
+        ::setData(input + value(p.txAntenna).txEB.value().param.getByteOffset(), txAntenna->eb);
     }
     if (pvpBlock.hasRcvAntenna())
     {
         rcvAntenna.reset(new PvpAntenna());
-        ::setData(input + value(p.rcvAntenna).getOffset() * 8, *rcvAntenna);
+        ::setData(input + value(p.rcvAntenna).rcvACX.value().param.getByteOffset(), rcvAntenna->acx);
+        ::setData(input + value(p.rcvAntenna).rcvACY.value().param.getByteOffset(), rcvAntenna->acy);
+        ::setData(input + value(p.rcvAntenna).rcvEB.value().param.getByteOffset(), rcvAntenna->eb);
     }
     for (auto it = p.addedPVP.begin(); it != p.addedPVP.end(); ++it)
     {
@@ -417,11 +401,15 @@ void PVPBlock::PVPSet::read(const Pvp& p, sys::ubyte* dest_) const
     }
     if (txAntenna.get())
     {
-        ::getData(dest + value(p.txAntenna).getOffset() * 8, *txAntenna);
+        ::getData(dest + value(p.txAntenna).txACX.value().param.getByteOffset(), txAntenna->acx);
+        ::getData(dest + value(p.txAntenna).txACY.value().param.getByteOffset(), txAntenna->acy);
+        ::getData(dest + value(p.txAntenna).txEB.value().param.getByteOffset(), txAntenna->eb);
     }
     if (rcvAntenna.get())
     {
-        ::getData(dest + value(p.rcvAntenna).getOffset() * 8, *rcvAntenna);
+        ::getData(dest + value(p.rcvAntenna).rcvACX.value().param.getByteOffset(), rcvAntenna->acx);
+        ::getData(dest + value(p.rcvAntenna).rcvACY.value().param.getByteOffset(), rcvAntenna->acy);
+        ::getData(dest + value(p.rcvAntenna).rcvEB.value().param.getByteOffset(), rcvAntenna->eb);
     }
     if (addedPVP.size() != p.addedPVP.size())
     {

--- a/six/modules/c++/cphd/source/TestDataGenerator.cpp
+++ b/six/modules/c++/cphd/source/TestDataGenerator.cpp
@@ -44,6 +44,14 @@ double getRandom()
     return -1000.0  + r * 2000.0;
 }
 
+Vector2 getRandomVector2()
+{
+    Vector2 ret;
+    ret[0] = getRandom();
+    ret[1] = getRandom();
+    return ret;
+}
+
 Vector3 getRandomVector3()
 {
     Vector3 ret;

--- a/six/modules/c++/cphd/unittests/test_pvp.cpp
+++ b/six/modules/c++/cphd/unittests/test_pvp.cpp
@@ -49,6 +49,8 @@ TEST_CASE(testAppend)
     pvp.append(pvp.ampSF);
     pvp.appendCustomParameter(8, "S8", "AddedParam1");
     pvp.append(pvp.signal);
+    pvp.appendTxAnt();
+    pvp.appendRcvAnt();
 
     TEST_ASSERT_TRUE(pvp.txTime.getOffset() == 0);
     TEST_ASSERT_TRUE(pvp.txPos.getOffset() == 1);
@@ -56,6 +58,8 @@ TEST_CASE(testAppend)
     TEST_ASSERT_TRUE(pvp.ampSF.getOffset() == 7);
     TEST_ASSERT_TRUE(pvp.addedPVP["AddedParam1"].getOffset() == 8);
     TEST_ASSERT_TRUE(pvp.signal.getOffset() == 16);
+    TEST_ASSERT_TRUE(value(pvp.txAntenna).getOffset() == 17);
+    TEST_ASSERT_TRUE(value(pvp.rcvAntenna).getOffset() == 25);
 }
 
 TEST_CASE(testAddedParamsEqualityOperatorTrue)
@@ -101,10 +105,26 @@ TEST_CASE(testAddedParamsEqualityOperatorFalse)
     TEST_ASSERT_TRUE((pvp1 != pvp3));
 }
 
+TEST_CASE(testTxAntennaFailure)
+{
+    cphd::Pvp pvp;
+    pvp.appendTxAnt();
+    TEST_EXCEPTION(pvp.appendTxAnt());
+}
+
+TEST_CASE(testRcvAntennaFailure)
+{
+    cphd::Pvp pvp;
+    pvp.appendRcvAnt();
+    TEST_EXCEPTION(pvp.appendRcvAnt());
+}
+
 TEST_MAIN(
         TEST_CHECK(testSimpleEqualityOperatorTrue);
         TEST_CHECK(testAppend);
         TEST_CHECK(testAddedParamsEqualityOperatorTrue);
         TEST_CHECK(testSimpleEqualityOperatorFalse);
         TEST_CHECK(testAddedParamsEqualityOperatorFalse);
+        TEST_CHECK(testTxAntennaFailure);
+        TEST_CHECK(testRcvAntennaFailure);
         )

--- a/six/modules/c++/cphd/unittests/test_pvp.cpp
+++ b/six/modules/c++/cphd/unittests/test_pvp.cpp
@@ -105,17 +105,12 @@ TEST_CASE(testAddedParamsEqualityOperatorFalse)
     TEST_ASSERT_TRUE((pvp1 != pvp3));
 }
 
-TEST_CASE(testTxAntennaFailure)
+TEST_CASE(testAntennaFailure)
 {
     cphd::Pvp pvp;
     pvp.appendTxAnt();
-    TEST_EXCEPTION(pvp.appendTxAnt());
-}
-
-TEST_CASE(testRcvAntennaFailure)
-{
-    cphd::Pvp pvp;
     pvp.appendRcvAnt();
+    TEST_EXCEPTION(pvp.appendTxAnt());
     TEST_EXCEPTION(pvp.appendRcvAnt());
 }
 
@@ -125,6 +120,5 @@ TEST_MAIN(
         TEST_CHECK(testAddedParamsEqualityOperatorTrue);
         TEST_CHECK(testSimpleEqualityOperatorFalse);
         TEST_CHECK(testAddedParamsEqualityOperatorFalse);
-        TEST_CHECK(testTxAntennaFailure);
-        TEST_CHECK(testRcvAntennaFailure);
+        TEST_CHECK(testAntennaFailure);
         )

--- a/six/modules/c++/cphd/unittests/test_pvp_block.cpp
+++ b/six/modules/c++/cphd/unittests/test_pvp_block.cpp
@@ -143,6 +143,8 @@ TEST_CASE(testPvpOptional)
     pvp.setCustomParameter(1, 30, "F8", "Param1");
     pvp.setCustomParameter(1, 31, "S10", "Param2");
     pvp.setCustomParameter(1, 32, "CI16", "Param3");
+    pvp.appendTxAnt();
+    pvp.appendRcvAnt();
     cphd::PVPBlock pvpBlock(NUM_CHANNELS,
                             std::vector<size_t>(NUM_CHANNELS, NUM_VECTORS),
                             pvp);

--- a/six/modules/c++/cphd/unittests/test_pvp_block.cpp
+++ b/six/modules/c++/cphd/unittests/test_pvp_block.cpp
@@ -159,6 +159,19 @@ TEST_CASE(testPvpOptional)
             pvpBlock.setFxN1(fxN1, channel, vector);
             const double fxN2 = cphd::getRandom();
             pvpBlock.setFxN2(fxN2, channel, vector);
+            
+            const cphd::PvpAntenna txAnt(
+                cphd::getRandomVector3(),
+                cphd::getRandomVector3(),
+                cphd::getRandomVector2());
+            pvpBlock.setTxAntenna(txAnt, channel, vector);
+                 
+            const cphd::PvpAntenna rcvAnt(
+                cphd::getRandomVector3(),
+                cphd::getRandomVector3(),
+                cphd::getRandomVector2()); 
+            pvpBlock.setRcvAntenna(rcvAnt, channel, vector);
+
             const double addedParam1 = cphd::getRandom();
             pvpBlock.setAddedPVP(addedParam1, channel, vector, "Param1");
             const std::string addedParam2 = "Parameter2";
@@ -169,6 +182,8 @@ TEST_CASE(testPvpOptional)
             TEST_ASSERT_EQ(ampSF, pvpBlock.getAmpSF(channel, vector));
             TEST_ASSERT_EQ(fxN1, pvpBlock.getFxN1(channel, vector));
             TEST_ASSERT_EQ(fxN2, pvpBlock.getFxN2(channel, vector));
+            TEST_ASSERT_EQ(txAnt, pvpBlock.getTxAntenna(channel, vector));
+            TEST_ASSERT_EQ(rcvAnt, pvpBlock.getRcvAntenna(channel, vector));
             TEST_ASSERT_EQ(addedParam1, pvpBlock.getAddedPVP<double>(channel, vector, "Param1"));
             TEST_ASSERT_EQ(addedParam2, pvpBlock.getAddedPVP<std::string>(channel, vector, "Param2"));
             TEST_ASSERT_EQ(addedParam3, pvpBlock.getAddedPVP<cphd::zint32_t >(channel, vector, "Param3"));

--- a/six/modules/c++/cphd/unittests/test_pvp_block_round.cpp
+++ b/six/modules/c++/cphd/unittests/test_pvp_block_round.cpp
@@ -189,7 +189,7 @@ bool runTest(bool /*scale*/,
 
 TEST_CASE(testPVPBlockSimple)
 {
-    const types::RowCol<size_t> dims(128, 256);
+    const types::RowCol<size_t> dims(1, 2);
     const auto writeData = generateComplexData<cphd::zint16_t>(dims.area());
     const bool scale = false;
     auto meta = cphd::setUpData(dims, writeData);
@@ -218,11 +218,11 @@ TEST_CASE(testPVPBlockOptional)
     const bool scale = false;
     auto meta = cphd::setUpData(dims, writeData);
     cphd::setPVPXML(meta.pvp);
-    meta.pvp.setOffset(27, meta.pvp.fxN1);
-    meta.pvp.setOffset(28, meta.pvp.fxN2);
+    meta.pvp.setOffset(meta.pvp.getReqSetSize(), meta.pvp.fxN1);
+    meta.pvp.setOffset(meta.pvp.getReqSetSize(), meta.pvp.fxN2);
     meta.pvp.appendTxAnt();
     meta.pvp.appendRcvAnt();
-    meta.data.numBytesPVP += 2 * 8;
+    meta.data.numBytesPVP = meta.pvp.getReqSetSize() * 8;
     cphd::PVPBlock pvpBlock(meta.pvp, meta.data);
     std::vector<std::string> addedParams;
     setPVPBlock(dims,
@@ -270,7 +270,7 @@ TEST_CASE(testPVPBlockAdditional)
 }
 
 TEST_MAIN(
-        TEST_CHECK(testPVPBlockSimple);
+        // TEST_CHECK(testPVPBlockSimple);
         TEST_CHECK(testPVPBlockOptional);
-        TEST_CHECK(testPVPBlockAdditional);
+        // TEST_CHECK(testPVPBlockAdditional);
         )

--- a/six/modules/c++/cphd/unittests/test_pvp_block_round.cpp
+++ b/six/modules/c++/cphd/unittests/test_pvp_block_round.cpp
@@ -270,7 +270,7 @@ TEST_CASE(testPVPBlockAdditional)
 }
 
 TEST_MAIN(
-        // TEST_CHECK(testPVPBlockSimple);
+        TEST_CHECK(testPVPBlockSimple);
         TEST_CHECK(testPVPBlockOptional);
-        // TEST_CHECK(testPVPBlockAdditional);
+        TEST_CHECK(testPVPBlockAdditional);
         )

--- a/six/modules/c++/cphd/unittests/test_pvp_block_round.cpp
+++ b/six/modules/c++/cphd/unittests/test_pvp_block_round.cpp
@@ -189,7 +189,7 @@ bool runTest(bool /*scale*/,
 
 TEST_CASE(testPVPBlockSimple)
 {
-    const types::RowCol<size_t> dims(1, 2);
+    const types::RowCol<size_t> dims(128, 256);
     const auto writeData = generateComplexData<cphd::zint16_t>(dims.area());
     const bool scale = false;
     auto meta = cphd::setUpData(dims, writeData);

--- a/six/modules/c++/cphd/unittests/test_pvp_block_round.cpp
+++ b/six/modules/c++/cphd/unittests/test_pvp_block_round.cpp
@@ -65,6 +65,8 @@ void setPVPBlock(const types::RowCol<size_t> dims,
                  bool isTOAE1,
                  bool isTOAE2,
                  bool isSignal,
+                 bool isTxAnt,
+                 bool isRcvAnt,
                  const std::vector<std::string>& addedParams)
 {
     const size_t numChannels = 1;
@@ -105,6 +107,22 @@ void setPVPBlock(const types::RowCol<size_t> dims,
             {
                 const double signal = cphd::getRandom();
                 pvpBlock.setTOAE2(signal, ii, jj);
+            }
+            if (isTxAnt)
+            {
+                const cphd::PvpAntenna antenna(
+                    cphd::getRandomVector3(),
+                    cphd::getRandomVector3(),
+                    cphd::getRandomVector2());
+                pvpBlock.setTxAntenna(antenna, ii, jj);
+            }
+            if (isRcvAnt)
+            {
+                const cphd::PvpAntenna antenna(
+                    cphd::getRandomVector3(),
+                    cphd::getRandomVector3(),
+                    cphd::getRandomVector2());
+                pvpBlock.setRcvAntenna(antenna, ii, jj);
             }
 
             for (size_t idx = 0; idx < addedParams.size(); ++idx)
@@ -186,6 +204,8 @@ TEST_CASE(testPVPBlockSimple)
                 false,
                 false,
                 false,
+                false,
+                false,
                 addedParams);
 
     TEST_ASSERT_TRUE(runTest(scale, writeData, meta, pvpBlock, dims));
@@ -200,6 +220,8 @@ TEST_CASE(testPVPBlockOptional)
     cphd::setPVPXML(meta.pvp);
     meta.pvp.setOffset(27, meta.pvp.fxN1);
     meta.pvp.setOffset(28, meta.pvp.fxN2);
+    meta.pvp.appendTxAnt();
+    meta.pvp.appendRcvAnt();
     meta.data.numBytesPVP += 2 * 8;
     cphd::PVPBlock pvpBlock(meta.pvp, meta.data);
     std::vector<std::string> addedParams;
@@ -211,6 +233,8 @@ TEST_CASE(testPVPBlockOptional)
                 false,
                 false,
                 false,
+                true,
+                true,
                 addedParams);
 
     TEST_ASSERT_TRUE(runTest(scale, writeData, meta, pvpBlock, dims));
@@ -232,6 +256,8 @@ TEST_CASE(testPVPBlockAdditional)
     addedParams.push_back("param2");
     setPVPBlock(dims,
                 pvpBlock,
+                false,
+                false,
                 false,
                 false,
                 false,


### PR DESCRIPTION
Currently the 'parent' `TxAntenna` and `RcvAntenna` elements are passed to the pvp `parse` call, as opposed to the elements being populated (`TxACX`, `TxACY`, etc.). This causes the PVP parsing to throw an exception.

This makes it so the `TxAntenna` and `RcvAntenna` PVP elements are populated while parsing.