### PR TITLE
Adds check for cpp 17 in six/include/six/Init.h

### DIFF
--- a/six/modules/c++/six/include/six/Init.h
+++ b/six/modules/c++/six/include/six/Init.h
@@ -144,7 +144,11 @@ namespace details
 {
     inline void throw_undefined_value()
     {
+    #if CODA_OSS_cpp17
+        throw std::bad_optional_access();
+    #else
         coda_oss::details::throw_bad_optional_access();
+    #endif
     }
 }
 


### PR DESCRIPTION
This minor change is needed to allow us to build our software using c++17. My first inclination was to make it possible to build this whole library with c++17 but there were errors I didn't have time to figure out so hence the one change. I've confirmed the package builds with the current compiler as expected.