### PR TITLE
Minor change to six/Init.h to allow our software to build using c++17

### DIFF
--- a/six/modules/c++/six/include/six/Init.h
+++ b/six/modules/c++/six/include/six/Init.h
@@ -149,7 +149,11 @@ namespace details
 {
     inline void throw_undefined_value()
     {
+    #if CODA_OSS_cpp17
+        throw std::bad_optional_access();
+    #else
         coda_oss::details::throw_bad_optional_access();
+    #endif
     }
 }
 


### PR DESCRIPTION
I was able to compile the code successfully with this minor change under RH8 using this configure

`
./waf configure --prefix=install --disable-swig --disable-matlab --disable-python
`
