### PR TITLE
Reduce scope of build to exclude externals tests

### DIFF
--- a/.github/workflows/frequent_check.yml
+++ b/.github/workflows/frequent_check.yml
@@ -37,7 +37,7 @@ jobs:
         cmake --build . --config ${{ matrix.configuration }} --target install
     - name: test
       run: |
-        cd out
+        cd out/six
         ctest -C ${{ matrix.configuration }} --output-on-failure
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1 # https://github.com/marketplace/actions/setup-msbuild
@@ -116,5 +116,5 @@ jobs:
         cmake --build . --target install
     - name: test
       run: |
-        cd target
+        cd target/six
         ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if (${CMAKE_PROJECT_NAME} STREQUAL six-library)
              "${CMAKE_CURRENT_SOURCE_DIR}/externals/${CODA_OSS_DIR}/cmake")
         include(CodaBuild)
         coda_initialize_build()
-        add_subdirectory("externals")
+        add_subdirectory("externals" EXCLUDE_FROM_ALL)
     endif()
 endif()
 


### PR DESCRIPTION
With this change, tests and unittests within the externals directories are no longer built, and these unittests are no longer run.  Building and testing of the six directory is unaffected.