### PR TITLE
Allow other C++ std and latest from coda-oss

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 project(six-library)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CXX_STANDARD_REQUIRED true)
-
 if (${CMAKE_PROJECT_NAME} STREQUAL six-library)
     # we are the top-level project and are responsible for configuration
+    set(CMAKE_CXX_STANDARD 14)
+    set(CXX_STANDARD_REQUIRED true)
 
     # Always turn on "warnings as errors" to avoid lots of (meaningless?) build output;
     # we'll dial-back warnings as necessary.

--- a/externals/coda-oss/.github/workflows/build_unittest.yml
+++ b/externals/coda-oss/.github/workflows/build_unittest.yml
@@ -153,17 +153,17 @@ jobs:
     - name: configure
       run: |
         mkdir out && cd out
-        cmake .. -DENABLE_PYTHON=OFF -DENABLE_${{ matrix.avx }}=ON
+        cmake .. -DENABLE_PYTHON=OFF -DENABLE_${{ matrix.avx }}=ON -DCMAKE_INSTALL_PREFIX=${{ matrix.configuration }}
     - name: build
       run: |
         cd out
         # "-j" spawns too many processes causing GCC to crash
-        cmake --build . --config ${{ matrix.configuration }} -j 12
+        cmake --build . -j 12
     - name: test
     # should run w/o install
       run: |
         cd out
-        ctest -C ${{ matrix.configuration }} --output-on-failure
+        ctest --output-on-failure
 
   build-waf:
     strategy:

--- a/externals/coda-oss/CMakeLists.txt
+++ b/externals/coda-oss/CMakeLists.txt
@@ -5,9 +5,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(coda-oss)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CXX_STANDARD_REQUIRED true)
-
 if (EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
     # build and package with conan
     include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
@@ -18,6 +15,10 @@ endif()
 
 if (${CMAKE_PROJECT_NAME} STREQUAL coda-oss)
     # this is the top level project
+
+    # Allow other project to set different standard. 
+    set(CMAKE_CXX_STANDARD 14)
+    set(CXX_STANDARD_REQUIRED true)
 
     # Always turn on "warnings as errors" to avoid lots of (meaningless?) build output;
     # we'll dial-back warnings as necessary.

--- a/externals/coda-oss/modules/c++/coda_oss.json/include/coda_oss/json/Math.h
+++ b/externals/coda-oss/modules/c++/coda_oss.json/include/coda_oss/json/Math.h
@@ -108,7 +108,7 @@ namespace math
             std::vector<std::vector<T>> coeffs(poly.orderX() + 1);
             for (size_t ix = 0; ix <= poly.orderX(); ix++)
             {
-                coeffs[ix] = poly.coeffs()[ix].coeffs();
+                coeffs[ix] = poly[ix].coeffs();
             }
             j = coeffs;
         }
@@ -120,6 +120,33 @@ namespace math
                 poly = TwoD<T>();
                 return;
             }
+            poly = TwoD<T>(j.template get<std::vector<OneD<T>>>());
+        }
+
+        template<typename BasicJsonType, size_t O, typename T>
+        void to_json(BasicJsonType& j, const Fixed1D<O, T>& poly)
+        {
+            j = poly.coeffs();
+        }
+        template<typename BasicJsonType, size_t O, typename T>
+        void from_json(const BasicJsonType& j, Fixed1D<O, T>& poly)
+        {
+            poly.coeffs() = j.template get<std::array<T, O + 1>>();
+        }
+
+        template<typename BasicJsonType, size_t OX, size_t OY, typename T>
+        void to_json(BasicJsonType& j, const Fixed2D<OX, OY, T>& poly)
+        {
+            std::array<std::array<T, OY + 1>, OX + 1> coeffs;
+            for (size_t ix = 0; ix <= poly.orderX(); ix++)
+            {
+                coeffs[ix] = poly[ix].coeffs();
+            }
+            j = coeffs;
+        }
+        template<typename BasicJsonType, size_t OX, size_t OY, typename T>
+        void from_json(const BasicJsonType& j, Fixed2D<OX, OY, T>& poly)
+        {
             poly = TwoD<T>(j.template get<std::vector<OneD<T>>>());
         }
     } // namespace poly

--- a/externals/coda-oss/modules/c++/coda_oss.json/unittests/test_json_math.cpp
+++ b/externals/coda-oss/modules/c++/coda_oss.json/unittests/test_json_math.cpp
@@ -115,6 +115,32 @@ TEST_CASE(TestPolyXYZ)
     TEST_ASSERT(serialized == expected);
     TEST_ASSERT(startVal == deserialized);
 }
+TEST_CASE(TestPolyFixed1D)
+{
+    using Fixed1D = math::poly::Fixed1D<3, int>;
+    std::vector<int> coeffs{0, 1, 2, 3};
+    Fixed1D startVal(coeffs);
+    json serialized = startVal;
+    json expected = coeffs;
+    Fixed1D deserialized = serialized.template get<Fixed1D>();
+    TEST_ASSERT(serialized == expected);
+    TEST_ASSERT(startVal == deserialized);
+}
+TEST_CASE(TestPolyFixed2D)
+{
+    using Fixed1D = math::poly::Fixed1D<2, double>;
+    using Fixed2D = math::poly::Fixed2D<1, 2, double>;
+    std::vector<double> c0 = {0.1, 0.2, 0.3};
+    std::vector<double> c1 = {-0.3, -0.2, -0.1};
+    Fixed1D p0(c0);
+    Fixed1D p1(c1);
+    Fixed2D startVal({p0, p1});
+    json serialized = startVal;
+    json expected = std::vector<std::vector<double>>{c0, c1};
+    auto deserialized = serialized.template get<Fixed2D>();
+    TEST_ASSERT(serialized == expected);
+    TEST_ASSERT(startVal == deserialized);
+}
 
 
 TEST_MAIN(

--- a/externals/coda-oss/modules/c++/math.poly/include/math/poly/Fixed1D.h
+++ b/externals/coda-oss/modules/c++/math.poly/include/math/poly/Fixed1D.h
@@ -404,6 +404,16 @@ public:
         return copy;
     }
 
+    bool operator == (const Fixed1D<_Order, _T>& other) const 
+    {
+        return (mCoef == other.coeffs());
+    }
+
+    bool operator != (const Fixed1D<_Order, _T>& other) const 
+    {
+        return !(*this == other);
+    }
+
     /*!
      * Returns a scaled polynomial such that
      * P'(x) = P(x * scale)

--- a/externals/coda-oss/modules/c++/math.poly/include/math/poly/Fixed2D.h
+++ b/externals/coda-oss/modules/c++/math.poly/include/math/poly/Fixed2D.h
@@ -56,8 +56,6 @@ public:
         }
     }
 
-
-
     Fixed2D(const TwoD<_T>& coeff)
     {
 
@@ -68,10 +66,15 @@ public:
         }
     }
 
+    Fixed2D(const std::array<Fixed1D<_OrderY, _T>, _OrderX + 1>& coeff)
+    {
+        mCoef = coeff;
+    }
+
     Fixed2D<_OrderX, _OrderY, _T>& operator=(const TwoD<_T>& coeff)
     {
 
-        size_t sizeC = std::min<unsigned int>(coeff.orderX(), _OrderX);
+        size_t sizeC = std::min<size_t>(coeff.orderX(), _OrderX);
         for (size_t i = 0; i <= sizeC; i++)
         {
             mCoef[i] = coeff[i];
@@ -313,6 +316,16 @@ public:
             copy[i] /= cv;
         }
         return copy;
+    }
+
+    bool operator == (const Fixed2D<_OrderX, _OrderY, _T>& other) const 
+    {
+        return (mCoef == other.coeffs());
+    }
+
+    bool operator != (const Fixed2D<_OrderX, _OrderY, _T>& other) const 
+    {
+        return !(*this == other);
     }
 
     /*!

--- a/externals/coda-oss/modules/c++/types/include/types/RowCol.h
+++ b/externals/coda-oss/modules/c++/types/include/types/RowCol.h
@@ -61,7 +61,7 @@ public:
     T col{};
 
     // Try to protect us from the unfortunate and probably
-    // unintended case where row gets set and col doesn't, especially
+    // unintendet case where row gets set and col doesnt, especially
     // when doing scalar operations that might otherwise create
     // ambiguities
     RowCol() {}  // = default; // error w/ICC and "const" member data

--- a/externals/nitro/CMakeLists.txt
+++ b/externals/nitro/CMakeLists.txt
@@ -1,11 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 project(nitro)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CXX_STANDARD_REQUIRED true)
-
 if (${CMAKE_PROJECT_NAME} STREQUAL nitro)
     # we are the top-level project and are responsible for configuration
+    set(CMAKE_CXX_STANDARD 14)
+    set(CXX_STANDARD_REQUIRED true)
 
     # Always turn on "warnings as errors" to avoid lots of (meaningless?) build output;
     # we'll dial-back warnings as necessary.


### PR DESCRIPTION
This code should be able to be compiled with c++ 14-20 (maybe higher?), but the way the `CMakeLists.txt` is setup it hard-codes the standard to 14. This allows a dependent project to set the standard to a different version.